### PR TITLE
Fix AutoRelease: Allow setup.py to have a version, and replace it whe…

### DIFF
--- a/.github/workflows/pipy.yml
+++ b/.github/workflows/pipy.yml
@@ -25,7 +25,7 @@ jobs:
       run: echo ::set-output name=TAG_NAME::$(echo $GITHUB_REF | cut -d / -f 3)
     - name: Update version in setup.py
       run: >-
-        sed -i "s/{{VERSION_PLACEHOLDER}}/${{ steps.tag.outputs.TAG_NAME }}/g" setup.py
+        sed -i 's/version=\".*\"/version=\"${{ steps.tag.outputs.TAG_NAME }}"/g' setup.py
     - name: Build a binary wheel
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
…n pushing a tag

We need to in order to create a new pypi release when new tag is pushed. On the other hand we want setup.py to have a real version in ordet to enable install from local clone (e.g. by pip -e).