### PR TITLE
Changed default behavior to strip string

### DIFF
--- a/prepare/processors/to_string.py
+++ b/prepare/processors/to_string.py
@@ -1,6 +1,10 @@
 from src.unitxt import add_to_catalog
-from src.unitxt.blocks import ToString
+from src.unitxt.blocks import ToString, ToStringStripped
 
 operator = ToString()
 
 add_to_catalog(operator, "processors.to_string", overwrite=True)
+
+operator = ToStringStripped()
+
+add_to_catalog(operator, "processors.to_string_stripped", overwrite=True)

--- a/src/unitxt/blocks.py
+++ b/src/unitxt/blocks.py
@@ -20,7 +20,7 @@ from .operators import (
     MapInstanceValues,
     RenameFields,
 )
-from .processors import ToString
+from .processors import ToString, ToStringStripped
 from .recipe import SequentialRecipe
 from .splitters import RandomSampler, SliceSplit, SplitRandomMix, SpreadSplit
 from .stream import MultiStream

--- a/src/unitxt/catalog/processors/to_string_stripped.json
+++ b/src/unitxt/catalog/processors/to_string_stripped.json
@@ -1,0 +1,3 @@
+{
+    "type": "to_string_stripped"
+}

--- a/src/unitxt/metric.py
+++ b/src/unitxt/metric.py
@@ -105,7 +105,7 @@ class MetricRecipe(SequntialOperatorInitilizer):
                 inputs_fields=["prediction", "references"],
                 fields_to_treat_as_list=["references"],
                 operators_field="postprocessors",
-                default_operators=["processors.to_string"],
+                default_operators=["processors.to_string_stripped"],
             ),
             SplitByValue(["group"]),
             ApplyStreamOperatorsField(

--- a/src/unitxt/processors.py
+++ b/src/unitxt/processors.py
@@ -10,6 +10,11 @@ class ToString(BaseFieldOperator):
         return str(instance)
 
 
+class ToStringStripped(BaseFieldOperator):
+    def process(self, instance):
+        return str(instance).strip()
+
+
 class ToListByComma(BaseFieldOperator):
     def process(self, instance):
         output = [x.strip() for x in instance.split(",")]
@@ -61,6 +66,3 @@ class DictOfListsToPairs(BaseFieldOperator):
             return result
         except:
             return []
-
-
-# add_to_catalog(ToString('prediction'), 'processors', 'to_string')

--- a/src/unitxt/schema.py
+++ b/src/unitxt/schema.py
@@ -29,7 +29,7 @@ UNITXT_DATASET_SCHEMA = Features(
 class ToUnitxtGroup(StreamInstanceOperatorValidator):
     group: str
     metrics: List[str] = None
-    postprocessors: List[str] = field(default_factory=lambda: ["to_string"])
+    postprocessors: List[str] = field(default_factory=lambda: ["to_string_stripped"])
     remove_unnecessary_fields: bool = True
 
     def process(self, instance: Dict[str, Any], stream_name: str = None) -> Dict[str, Any]:

--- a/src/unitxt/templates.py
+++ b/src/unitxt/templates.py
@@ -151,7 +151,7 @@ class RenderTemplatedICL(RenderAutoFormatTemplate):
 class InputOutputTemplate(Template):
     input_format: str = None
     output_format: str = None
-    postprocessors: List[str] = field(default_factory=lambda: ["processors.to_string"])
+    postprocessors: List[str] = field(default_factory=lambda: ["processors.to_string_stripped"])
 
     def process_template(self, template: str, data: Dict[str, object]) -> str:
         data = {k: ", ".join(v) if isinstance(v, list) else v for k, v in data.items()}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -66,6 +66,27 @@ class TestTemplates(unittest.TestCase):
             parsed = parser.process(processed)
             self.assertEqual(parsed, parsed_target)
 
+    def test_input_output_template(self):
+        parser, _ = fetch_artifact("processors.to_string_stripped")
+
+        template = InputOutputTemplate(output_format="{labels}")
+
+        inputs = [
+            {"labels": ["cat"]},
+            {"labels": [" man"]},
+            {"labels": ["dog\n"]},
+        ]
+
+        processed_targets = ["cat", " man", "dog\n"]
+
+        parsed_targets = ["cat", "man", "dog"]
+
+        for input, processed_target, parsed_target in zip(inputs, processed_targets, parsed_targets):
+            processed = template.process_outputs(input)
+            self.assertEqual(processed, processed_target)
+            parsed = parser.process(processed)
+            self.assertEqual(parsed, parsed_target)
+
     def test_span_labeling_template_one_entity_escaping(self):
         parser, _ = fetch_artifact("processors.to_span_label_pairs_surface_only")
 


### PR DESCRIPTION
Added a to_string_splitted preprocessor
Changed default uses of of to_string to to_string_splitted Added a test for the standard input output template
Signed-off-by: Yoav Katz <katz@il.ibm.com>