### PR TITLE
Fixed F1 in multi label

### DIFF
--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -337,7 +337,7 @@ class F1MultiLabel(GlobalMetric):
             labels_param = [1]
         else:
             labels_param = None
-            
+
         result = self._metric.compute(
             predictions=formatted_predictions,
             references=formatted_references,


### PR DESCRIPTION
When no classes were in references, threw an exception instead. Now returns Nan.

When only one class was in references, scikitlearn f1 incorrectly iterpreted the input as two classes.  Added a flag to avoid this behavior.

Added unit text to fix it.