### PR TITLE
BugFix: avoid processing the same instance twice

### DIFF
--- a/src/unitxt/dataset.py
+++ b/src/unitxt/dataset.py
@@ -1,4 +1,5 @@
 import datasets
+import os
 
 from .artifact import Artifact, UnitxtArtifactNotFoundError
 from .artifact import __file__ as _
@@ -87,7 +88,7 @@ def get_dataset_artifact(dataset_str):
     if recipe is None:
         args = parse(dataset_str)
         if "type" not in args:
-            args["type"] = __default_recipe__
+            args["type"] = os.environ.get("UNITXT_DEFAULT_RECIPE", __default_recipe__)
         recipe = Artifact.from_dict(args)
     return recipe
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -136,6 +136,22 @@ class AddFields(StreamInstanceOperator):
         return instance
 
 
+class RemoveFields(StreamInstanceOperator):
+    """
+    Adds specified fields to each instance in a stream.
+
+    Args:
+        fields (Dict[str, object]): The fields to add to each instance.
+    """
+
+    fields: List[str]
+
+    def process(self, instance: Dict[str, Any], stream_name: str = None) -> Dict[str, Any]:
+        for field in self.fields:
+            del instance[field]
+        return instance
+
+
 class FieldOperator(StreamInstanceOperator):
     """
     A general stream that processes the values of a field (or multiple ones

--- a/src/unitxt/renderers.py
+++ b/src/unitxt/renderers.py
@@ -24,7 +24,7 @@ class RenderTemplate(Renderer, StreamInstanceOperator):
     def process(self, instance: Dict[str, Any], stream_name: str = None) -> Dict[str, Any]:
         if self.skip_rendered_instance:
             if (
-                "inpust" not in instance
+                "inputs" not in instance
                 and "outputs" not in instance
                 and "source" in instance
                 and "target" in instance

--- a/src/unitxt/renderers.py
+++ b/src/unitxt/renderers.py
@@ -19,8 +19,19 @@ class Renderer(ABC):
 class RenderTemplate(Renderer, StreamInstanceOperator):
     template: Template
     random_reference: bool = False
+    skip_rendered_instance: bool = True
 
     def process(self, instance: Dict[str, Any], stream_name: str = None) -> Dict[str, Any]:
+        if self.skip_rendered_instance:
+            if (
+                "inpust" not in instance
+                and "outputs" not in instance
+                and "source" in instance
+                and "target" in instance
+                and "references" in instance
+            ):
+                return instance
+
         inputs = instance.pop("inputs")
         outputs = instance.pop("outputs")
 
@@ -58,8 +69,7 @@ class RenderDemonstrations(RenderTemplate):
 
         processed_demos = []
         for demo_instance in demos:
-            if "inputs" in demo_instance and "outputs" in demo_instance:
-                demo_instance = super().process(demo_instance)
+            demo_instance = super().process(demo_instance)
             processed_demos.append(demo_instance)
 
         instance[self.demos_field] = processed_demos

--- a/src/unitxt/renderers.py
+++ b/src/unitxt/renderers.py
@@ -58,7 +58,7 @@ class RenderDemonstrations(RenderTemplate):
 
         processed_demos = []
         for demo_instance in demos:
-            if 'inputs' in demo_instance and 'outputs' in demo_instance:
+            if "inputs" in demo_instance and "outputs" in demo_instance:
                 demo_instance = super().process(demo_instance)
             processed_demos.append(demo_instance)
 

--- a/src/unitxt/renderers.py
+++ b/src/unitxt/renderers.py
@@ -58,8 +58,9 @@ class RenderDemonstrations(RenderTemplate):
 
         processed_demos = []
         for demo_instance in demos:
-            processed_demo = super().process(demo_instance)
-            processed_demos.append(processed_demo)
+            if 'inputs' in demo_instance and 'outputs' in demo_instance:
+                demo_instance = super().process(demo_instance)
+            processed_demos.append(demo_instance)
 
         instance[self.demos_field] = processed_demos
 

--- a/src/unitxt/schema.py
+++ b/src/unitxt/schema.py
@@ -34,9 +34,14 @@ class ToUnitxtGroup(StreamInstanceOperatorValidator):
 
     def process(self, instance: Dict[str, Any], stream_name: str = None) -> Dict[str, Any]:
         if self.remove_unnecessary_fields:
+            keys_to_delete = []
+
             for key in instance.keys():
                 if key not in UNITXT_DATASET_SCHEMA:
-                    del instance[key]
+                    keys_to_delete.append(key)
+
+            for key in keys_to_delete:
+                del instance[key]
 
         instance["group"] = self.group
         if self.metrics is not None:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -10,6 +10,7 @@ from src.unitxt.operators import (
     FlattenInstances,
     JoinStr,
     MapInstanceValues,
+    RemoveFields,
     RenameFields,
     Shuffle,
     SplitByValue,
@@ -94,6 +95,19 @@ class TestOperators(unittest.TestCase):
         ]
 
         test_operator(operator=AddFields(fields={"c": 3}), inputs=inputs, targets=targets, tester=self)
+
+    def test_remove_fields(self):
+        inputs = [
+            {"a": 1, "b": 2},
+            {"a": 2, "b": 3},
+        ]
+
+        targets = [
+            {"a": 1},
+            {"a": 2},
+        ]
+
+        test_operator(operator=RemoveFields(fields=["b"]), inputs=inputs, targets=targets, tester=self)
 
     def test_unique_on_single_field(self):
         inputs = [

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -92,12 +92,15 @@ class TestRecipes(unittest.TestCase):
             print_dict(instance)
             break
 
-    def test_recipe_with_hf(self):
+    def test_recipe_with_hf_with_twice_the_same_instance_demos(self):
         from datasets import load_dataset
 
         d = load_dataset(
             dataset_file,
             "type=standard_recipe_with_indexes,card=cards.wnli,template_card_index=0,demos_pool_size=5,num_demos=5,instruction=instructions.models.llama",
+            streaming=True,
         )
 
-        print_dict(d["train"][0])
+        iterator = iter(d["train"])
+        next(iterator)
+        print_dict(next(iterator))

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,5 +1,6 @@
 import unittest
 
+from src.unitxt import dataset_file
 from src.unitxt.formats import ICLFormat
 from src.unitxt.instructions import TextualInstruction
 from src.unitxt.standard import StandardRecipe, StandardRecipeWithIndexes
@@ -90,3 +91,13 @@ class TestRecipes(unittest.TestCase):
         for instance in stream["train"]:
             print_dict(instance)
             break
+
+    def test_recipe_with_hf(self):
+        from datasets import load_dataset
+
+        d = load_dataset(
+            dataset_file,
+            "type=standard_recipe_with_indexes,card=cards.wnli,template_card_index=0,demos_pool_size=100,num_demos=5,instruction=instructions.models.llama",
+        )
+
+        print_dict(d["train"][0])

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -97,7 +97,7 @@ class TestRecipes(unittest.TestCase):
 
         d = load_dataset(
             dataset_file,
-            "type=standard_recipe_with_indexes,card=cards.wnli,template_card_index=0,demos_pool_size=100,num_demos=5,instruction=instructions.models.llama",
+            "type=standard_recipe_with_indexes,card=cards.wnli,template_card_index=0,demos_pool_size=5,num_demos=5,instruction=instructions.models.llama",
         )
 
         print_dict(d["train"][0])


### PR DESCRIPTION
The new renderer sometimes tried to process the same instance twice which caused an error