### PR TITLE
Fix for empty_instruction case

### DIFF
--- a/src/unitxt/formats.py
+++ b/src/unitxt/formats.py
@@ -29,7 +29,9 @@ class ICLFormat(SizeLimitingFormat):
 
         if "instruction" in instance:
             instruction = instance.pop("instruction")
-            source += self.instruction_prefix + instruction + self.demo_separator
+            assert "instruction" != None, f"instruction field can not be none : {instance}"
+            if instruction != "":
+                source += self.instruction_prefix + instruction + self.demo_separator
 
         for demo_instance in demos_instances:
             demo_str = (

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -44,3 +44,13 @@ Agent:"""
         target = """User:1+1
 Agent:"""
         self.assertEqual(result, target)
+
+    def test_icl_format_without_demonstrations_and_empty_instruction(self):
+        format = ICLFormat(input_prefix="User:", output_prefix="Agent:", instruction_prefix="Instruction:")
+
+        instance = {"source": "1+1", "target": "2", "instruction": ""}
+
+        result = format.format(instance)
+        target = """User:1+1
+Agent:"""
+        self.assertEqual(result, target)


### PR DESCRIPTION
Which added "\n\n" when instruction is empty

Added unit text