### PR TITLE
Add load limit

### DIFF
--- a/prepare/templates/classification/choices/templates.py
+++ b/prepare/templates/classification/choices/templates.py
@@ -9,7 +9,7 @@ add_to_catalog(
 
 add_to_catalog(
     InputOutputTemplate(
-        input_format="Given this sentence: {sentence}, classify if it is {choices}.",
+        input_format="Given this sentence: {text}, classify if it is {choices}.",
         output_format="{label}",
     ),
     "templates.classification.choices.simple2",

--- a/requirements/tests.rqr
+++ b/requirements/tests.rqr
@@ -1,3 +1,4 @@
 bert_score
 transformers
 sentence_transformers
+ibm-cos-sdk

--- a/src/unitxt/catalog.py
+++ b/src/unitxt/catalog.py
@@ -100,7 +100,7 @@ class GithubCatalog(LocalCatalog):
 def verify_legal_catalog_name(name):
     assert re.match(
         r"^[\w" + COLLECTION_SEPARATOR + "]+$", name
-    ), f'Catalog name should be alphanumeric, ":" should specify dirs (instead of "/"). Name: {name}'
+    ), f'Artifict name ("{name}") should be alphanumeric. Use "." for nesting (e.g. myfolder.my_artifact)'
 
 
 def add_to_catalog(

--- a/src/unitxt/catalog.py
+++ b/src/unitxt/catalog.py
@@ -56,7 +56,9 @@ class LocalCatalog(Catalog):
             return False
         return os.path.exists(path) and os.path.isfile(path)
 
-    def save_artifact(self, artifact: Artifact, artifact_identifier: str, overwrite: bool = False):
+    def save_artifact(
+        self, artifact: Artifact, artifact_identifier: str, overwrite: bool = False, verbose: bool = True
+    ):
         assert isinstance(artifact, Artifact), f"Input artifact must be an instance of Artifact, got {type(artifact)}"
         if not overwrite:
             assert (
@@ -65,7 +67,8 @@ class LocalCatalog(Catalog):
         path = self.path(artifact_identifier)
         os.makedirs(Path(path).parent.absolute(), exist_ok=True)
         artifact.save(path)
-        print(f"Artifact {artifact_identifier} saved to {path}")
+        if verbose:
+            print(f"Artifact {artifact_identifier} saved to {path}")
 
 
 class EnvironmentLocalCatalog(LocalCatalog):
@@ -101,12 +104,19 @@ def verify_legal_catalog_name(name):
 
 
 def add_to_catalog(
-    artifact: Artifact, name: str, catalog: Catalog = None, overwrite: bool = False, catalog_path: str = None
+    artifact: Artifact,
+    name: str,
+    catalog: Catalog = None,
+    overwrite: bool = False,
+    catalog_path: str = None,
+    verbose=True,
 ):
     if catalog is None:
         if catalog_path is None:
             catalog_path = default_catalog_path
         catalog = LocalCatalog(location=catalog_path)
     verify_legal_catalog_name(name)
-    catalog.save_artifact(artifact, name, overwrite=overwrite)  # remove collection (its actually the dir).
+    catalog.save_artifact(
+        artifact, name, overwrite=overwrite, verbose=verbose
+    )  # remove collection (its actually the dir).
     # verify name

--- a/src/unitxt/catalog.py
+++ b/src/unitxt/catalog.py
@@ -100,7 +100,7 @@ class GithubCatalog(LocalCatalog):
 def verify_legal_catalog_name(name):
     assert re.match(
         r"^[\w" + COLLECTION_SEPARATOR + "]+$", name
-    ), 'Catalog name should be alphanumeric, ":" should specify dirs (instead of "/").'
+    ), f'Catalog name should be alphanumeric, ":" should specify dirs (instead of "/"). Name: {name}'
 
 
 def add_to_catalog(

--- a/src/unitxt/catalog/templates/classification/choices/simple2.json
+++ b/src/unitxt/catalog/templates/classification/choices/simple2.json
@@ -1,5 +1,5 @@
 {
     "type": "input_output_template",
-    "input_format": "Given this sentence: {sentence}, classify if it is {choices}.",
+    "input_format": "Given this sentence: {text}, classify if it is {choices}.",
     "output_format": "{label}"
 }

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -858,6 +858,9 @@ class DeterministicBalancer(StreamRefiner):
         for instance in stream:
             counter[self.signature(instance)] += 1
 
+        if len(counter) == 0:
+            return
+
         lowest_count = counter.most_common()[-1][-1]
 
         max_total_instances_per_sign = lowest_count

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -170,7 +170,7 @@ class StandardRecipeWithIndexes(BaseRecipe):
                 else:
                     options = list(range(0, len(self.card.templates)))
                 raise ValueError(
-                    f"card_template_index {self.template_card_index} is not in card. Available options: {options}"
+                    f"card_template_index '{self.template_card_index}' is not in card. Available options: {options}"
                 )
         assert (
             self.instruction_card_index is None or self.instruction is None

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -50,25 +50,25 @@ class BaseRecipe(Recipe, SourceSequntialOperator):
                 )
             if self.demos_pool_size < self.num_demos:
                 raise ValueError(
-                    f"demos_pool_size must be bigger than num_demos={self.num_demos}, Got demos_pool_size={self.demos_pool_size}"
+                    f"demos_pool_size must be bigger than num_demos ({self.num_demos}), Got demos_pool_size={self.demos_pool_size}"
                 )
             if self.loader_limit and self.demos_pool_size > self.loader_limit:
                 raise ValueError(
-                    f"demos_pool_size must be bigger than loader_limit{self.loader_limit}, Got demos_pool_size={self.demos_pool_size}"
+                    f"demos_pool_size must be bigger than loader_limit ({self.loader_limit}), Got demos_pool_size={self.demos_pool_size}"
                 )
 
         if self.loader_limit:
             if self.max_test_instances and self.max_test_instances > self.loader_limit:
                 raise ValueError(
-                    f"max_test_instances must be bigger than loader_limit{self.loader_limit}, Got max_test_instances={self.max_test_instances}"
+                    f"max_test_instances must be bigger than loader_limit ({self.loader_limit}), Got max_test_instances={self.max_test_instances}"
                 )
             if self.max_validation_instances and self.max_validation_instances > self.loader_limit:
                 raise ValueError(
-                    f"max_validation_instances must be bigger than loader_limit{self.loader_limit}, Got max_validation_instances={self.max_validation_instances}"
+                    f"max_validation_instances must be bigger than loader_limit ({self.loader_limit}), Got max_validation_instances={self.max_validation_instances}"
                 )
             if self.max_train_instances and self.max_train_instances > self.loader_limit:
                 raise ValueError(
-                    f"max_train_instances must be bigger than loader_limit{self.loader_limit}, Got max_train_instances={self.max_train_instances}"
+                    f"max_train_instances must be bigger than loader_limit ({self.loader_limit}), Got max_train_instances={self.max_train_instances}"
                 )
 
     def prepare(self):

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -56,18 +56,17 @@ class BaseRecipe(Recipe, SourceSequntialOperator):
                 raise ValueError(
                     f"demos_pool_size must be bigger than loader_limit{self.loader_limit}, Got demos_pool_size={self.demos_pool_size}"
                 )
-        if self.max_test_instances and self.loader_limit:
-            if self.max_test_instances > self.loader_limit:
+
+        if self.loader_limit:
+            if self.max_test_instances and self.max_test_instances > self.loader_limit:
                 raise ValueError(
                     f"max_test_instances must be bigger than loader_limit{self.loader_limit}, Got max_test_instances={self.max_test_instances}"
                 )
-        if self.max_validation_instances and self.loader_limit:
-            if self.max_validation_instances > self.loader_limit:
+            if self.max_validation_instances and self.max_validation_instances > self.loader_limit:
                 raise ValueError(
                     f"max_validation_instances must be bigger than loader_limit{self.loader_limit}, Got max_validation_instances={self.max_validation_instances}"
                 )
-        if self.max_train_instances and self.loader_limit:
-            if self.max_train_instances > self.loader_limit:
+            if self.max_train_instances and self.max_train_instances > self.loader_limit:
                 raise ValueError(
                     f"max_train_instances must be bigger than loader_limit{self.loader_limit}, Got max_train_instances={self.max_train_instances}"
                 )
@@ -159,8 +158,8 @@ class StandardRecipeWithIndexes(BaseRecipe):
         assert (
             self.template_card_index is None or self.template is None
         ), f"Specify either template ({self.template}) or template_card_index ({self.template_card_index}) but not both"
-        assert (
-            not self.template_card_index is None or not self.template is None
+        assert not (
+            self.template_card_index is None and self.template is None
         ), "Specify either template or template_card_index in card"
         if self.template_card_index is not None:
             try:

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -10,7 +10,7 @@ from .recipe import Recipe
 from .renderers import StandardRenderer
 from .schema import ToUnitxtGroup
 from .splitters import Sampler, SeparateSplit, SpreadSplit
-from .templates import Template
+from .templates import Template, TemplatesDict
 
 
 class BaseRecipe(Recipe, SourceSequntialOperator):
@@ -158,10 +158,21 @@ class StandardRecipeWithIndexes(BaseRecipe):
     def prepare(self):
         assert (
             self.template_card_index is None or self.template is None
-        ), "Specify either template or template_card_index"
+        ), f"Specify either template ({self.template}) or template_card_index ({self.template_card_index}) but not both"
+        assert (
+            not self.template_card_index is None or not self.template is None
+        ), "Specify either template or template_card_index in card"
         if self.template_card_index is not None:
-            self.template = self.card.templates[int(self.template_card_index)]
-
+            try:
+                self.template = self.card.templates[self.template_card_index]
+            except:
+                if type(self.card.templates) is TemplatesDict:
+                    options = self.card.templates.keys()
+                else:
+                    options = list(range(0, len(self.card.templates)))
+                raise ValueError(
+                    f"card_template_index {self.template_card_index} is not in card. Available options: {options}"
+                )
         assert (
             self.instruction_card_index is None or self.instruction is None
         ), "Specify either instruction or instruction_card_index"

--- a/src/unitxt/test_utils/artifact.py
+++ b/src/unitxt/test_utils/artifact.py
@@ -10,7 +10,7 @@ TEMP_NAME = "tmp_name"
 
 def test_artfifact_saving_and_loading(artifact, tester=None):
     with tempfile.TemporaryDirectory() as tmp_dir:
-        add_to_catalog(artifact, TEMP_NAME, overwrite=True, catalog_path=tmp_dir)
+        add_to_catalog(artifact, TEMP_NAME, overwrite=True, catalog_path=tmp_dir, verbose=False)
         register_local_catalog(tmp_dir)
         loaded_artifact, _ = fetch_artifact(TEMP_NAME)
         if tester is not None:

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -8,6 +8,7 @@ from .. import add_to_catalog, register_local_catalog
 from ..artifact import fetch_artifact
 from ..metric import _compute
 from ..standard import StandardRecipe
+from ..templates import TemplatesDict
 from ..text_utils import print_dict
 
 TEMP_NAME = "tmp_name"
@@ -34,13 +35,9 @@ def test_loading_from_catalog(card):
         ), "Card loaded is not equal to card stored"
 
 
-def load_examples_from_standard_recipe(card, tested_split, template_card_index=None):
-    if template_card_index == None:
-        if card.templates:
-            try:  # named templates (dict)
-                template_item = next(iter(card.templates.keys()))
-            except AttributeError:  # template list
-                template_item = 0
+def load_examples_from_standard_recipe(card, tested_split, template_card_index):
+    print("=" * 80)
+    print(f"Using template card index: {template_card_index}")
 
     num_instructions = len(card.instructions) if card.instructions else 0
     recipe = StandardRecipe(
@@ -70,9 +67,14 @@ def load_examples_from_standard_recipe(card, tested_split, template_card_index=N
 
 
 def test_with_eval(card, tested_split, strict=True, exact_match_score=1.0, full_mismatch_score=0.0):
-    num_templates = len(card.templates)
-    for template_item in range(0, num_templates):
-        examples = load_examples_from_standard_recipe(card, tested_split, template_item)
+    if type(card.templates) is TemplatesDict:
+        for template_item in card.templates.keys():
+            examples = load_examples_from_standard_recipe(card, tested_split, template_item)
+    else:
+        num_templates = len(card.templates)
+        for template_item in range(0, num_templates):
+            examples = load_examples_from_standard_recipe(card, tested_split, template_item)
+
     # metric = evaluate.load('unitxt/metric')
     predictions = []
     for example in examples:

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -15,7 +15,7 @@ TEMP_NAME = "tmp_name"
 
 def test_adding_to_catalog(card):
     with tempfile.TemporaryDirectory() as tmp_dir:
-        add_to_catalog(card, TEMP_NAME, overwrite=True, catalog_path=tmp_dir)
+        add_to_catalog(card, TEMP_NAME, overwrite=True, catalog_path=tmp_dir, verbose=False)
         assert os.path.exists(os.path.join(tmp_dir, TEMP_NAME + ".json")), "Card was not added to catalog"
 
 
@@ -26,7 +26,7 @@ def test_metrics_exist(card):
 
 def test_loading_from_catalog(card):
     with tempfile.TemporaryDirectory() as tmp_dir:
-        add_to_catalog(card, TEMP_NAME, overwrite=True, catalog_path=tmp_dir)
+        add_to_catalog(card, TEMP_NAME, overwrite=True, catalog_path=tmp_dir, verbose=False)
         register_local_catalog(tmp_dir)
         card_, _ = fetch_artifact(TEMP_NAME)
         assert json.dumps(card_.to_dict(), sort_keys=True) == json.dumps(

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -6,8 +6,8 @@ import tempfile
 
 from .. import add_to_catalog, register_local_catalog
 from ..artifact import fetch_artifact
-from ..common import CommonRecipe
 from ..metric import _compute
+from ..standard import StandardRecipe
 from ..text_utils import print_dict
 
 TEMP_NAME = "tmp_name"
@@ -34,36 +34,34 @@ def test_loading_from_catalog(card):
         ), "Card loaded is not equal to card stored"
 
 
-def load_examples_from_common_recipe(card, tested_split):
-    if card.templates:
-        num_templates = len(card.templates)
+def load_examples_from_standard_recipe(card, tested_split, template_card_index=None):
+    if template_card_index == None:
+        if card.templates:
+            try:  # named templates (dict)
+                template_item = next(iter(card.templates.keys()))
+            except AttributeError:  # template list
+                template_item = 0
 
-        try:  # named templates (dict)
-            template_item = next(iter(card.templates.keys()))
-        except AttributeError:  # template list
-            template_item = 0
-    else:
-        num_templates = 0
-        template_item = None
     num_instructions = len(card.instructions) if card.instructions else 0
-    recipe = CommonRecipe(
+    recipe = StandardRecipe(
         card=card,
         demos_pool_size=100,
         demos_taken_from=tested_split,
         num_demos=3,
-        template_item=template_item,
-        instruction_item=0 if num_instructions else None,
+        template_card_index=template_card_index,
+        instruction_card_index=0 if num_instructions else None,
+        loader_limit=200,
     )
     multi_stream = recipe()
     stream = multi_stream[tested_split]
     try:
-        examples = list(stream.take(5))
+        examples = list(stream.take(3))
     except ValueError as e:
         raise ValueError(
             "Try setting streaming=False in LoadHF in your card. For example: LoadHF(path='glue', name='mrpc', streaming=False). Org error message:",
             e,
         )
-    print("5 Examples: ")
+    print("3 Examples: ")
     for example in examples:
         print_dict(example)
         print("\n")
@@ -72,7 +70,9 @@ def load_examples_from_common_recipe(card, tested_split):
 
 
 def test_with_eval(card, tested_split, strict=True, exact_match_score=1.0, full_mismatch_score=0.0):
-    examples = load_examples_from_common_recipe(card, tested_split)
+    num_templates = len(card.templates)
+    for template_item in range(0, num_templates):
+        examples = load_examples_from_standard_recipe(card, tested_split, template_item)
     # metric = evaluate.load('unitxt/metric')
     predictions = []
     for example in examples:

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -2,9 +2,36 @@ import os
 import tempfile
 import unittest
 from math import isnan
+from unittest.mock import patch
 
+import ibm_boto3
 import pandas as pd
 from src.unitxt.loaders import LoadCSV, LoadFromIBMCloud
+
+
+class DummyBody:
+    pass
+
+
+class DummyObject:
+    def get(self):
+        return {"ContentLength": 1, "Body": DummyBody}
+
+
+class DummyBucket:
+    def download_file(self, item_name, local_file, Callback):
+        with open(local_file, "w") as f:
+            print(local_file)
+            f.write("a,b\n")
+            f.write("1,2\n")
+
+
+class DummyS3:
+    def Object(self, bucket_name, item_name):
+        return DummyObject()
+
+    def Bucket(self, bucket_name):
+        return DummyBucket()
 
 
 class TestLoaders(unittest.TestCase):
@@ -38,5 +65,8 @@ class TestLoaders(unittest.TestCase):
             aws_secret_access_key_env="DUMMY_SECRET_ENV",
             bucket_name="DUMMY_BUCKET",
             data_dir="DUMMY_DATA_DIR",
-            data_files="DUMMY_DATA_FILES",
+            data_files=["train.csv", "test.csv"],
         )
+        with (patch.object(ibm_boto3, "resource", return_value=DummyS3())):
+            ms = loader()
+            self.assertEqual(ms.to_dataset()["test"][0], {"a": 1, "b": 2})

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -4,7 +4,7 @@ import unittest
 from math import isnan
 
 import pandas as pd
-from src.unitxt.loaders import LoadCSV
+from src.unitxt.loaders import LoadCSV, LoadFromIBMCloud
 
 
 class TestLoaders(unittest.TestCase):
@@ -27,3 +27,16 @@ class TestLoaders(unittest.TestCase):
             for file in ["train", "test"]:
                 for saved_instance, loaded_instance in zip(dfs[file].iterrows(), ms[file]):
                     self.assertEqual(saved_instance[1].to_dict(), loaded_instance)
+
+    def test_load_from_ibm_cos(self):
+        os.environ["DUMMY_URL_ENV"] = "DUMMY_URL"
+        os.environ["DUMMY_KEY_ENV"] = "DUMMY_KEY"
+        os.environ["DUMMY_SECRET_ENV"] = "DUMMY_SECRET"
+        loader = LoadFromIBMCloud(
+            endpoint_url_env="DUMMY_URL_ENV",
+            aws_access_key_id_env="DUMMY_KEY_ENV",
+            aws_secret_access_key_env="DUMMY_SECRET_ENV",
+            bucket_name="DUMMY_BUCKET",
+            data_dir="DUMMY_DATA_DIR",
+            data_files="DUMMY_DATA_FILES",
+        )

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -350,6 +350,18 @@ class TestOperators(unittest.TestCase):
         test = list(refined_ms["test"])
         self.assertEqual(len(test), 2)
 
+    def test_deterministic_balancer_empty_stream(self):
+        inputs = []
+
+        targets = []
+
+        test_operator(
+            operator=DeterministicBalancer(fields=["a", "b"]),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
     def test_deterministic_balancer(self):
         inputs = [
             {"a": [1, 3], "b": 0, "id": 0},

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -112,6 +112,21 @@ class TestRecipes(unittest.TestCase):
 
         self.assertEqual(counts["entailment"], counts["not entailment"])
 
+    def test_standard_recipe_with_loader_limit(self):
+        recipe = StandardRecipeWithIndexes(
+            card="cards.wnli",
+            instruction="instructions.models.llama",
+            template="templates.key_val",
+            format="formats.user_agent",
+            demos_pool_size=5,
+            num_demos=1,
+            loader_limit=10,
+        )
+
+        stream = recipe()
+        self.assertEqual(len(list(stream["train"])), 5)
+        self.assertEqual(len(list(stream["test"])), 10)
+
     def test_standard_recipe_with_balancer_and_size_limit(self):
         recipe = StandardRecipeWithIndexes(
             card="cards.wnli",

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -160,6 +160,29 @@ class TestRecipes(unittest.TestCase):
                 loader_limit=9,
             )
 
+    def test_standard_recipe_with_template_errors(self):
+        with self.assertRaises(AssertionError) as cm:
+            recipe = StandardRecipeWithIndexes(card="cards.wnli")
+        self.assertEqual(str(cm.exception), "Specify either template or template_card_index in card")
+
+        with self.assertRaises(AssertionError) as cm:
+            recipe = StandardRecipeWithIndexes(
+                card="cards.wnli", template="templates.key_val", template_card_index=100
+            )
+        self.assertTrue("Specify either template" in str(cm.exception))
+        self.assertTrue("but not both" in str(cm.exception))
+
+        with self.assertRaises(AssertionError) as cm:
+            recipe = StandardRecipeWithIndexes(
+                card="cards.wnli", template="templates.key_val", template_card_index="illegal_template"
+            )
+        self.assertTrue("Specify either template" in str(cm.exception))
+        self.assertTrue("but not both" in str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            recipe = StandardRecipeWithIndexes(card="cards.wnli", template_card_index="illegal_template")
+        self.assertTrue("is not in card" in str(cm.exception))
+
     def test_standard_recipe_with_balancer_and_size_limit(self):
         recipe = StandardRecipeWithIndexes(
             card="cards.wnli",

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -127,6 +127,39 @@ class TestRecipes(unittest.TestCase):
         self.assertEqual(len(list(stream["train"])), 5)
         self.assertEqual(len(list(stream["test"])), 10)
 
+    def test_standard_recipe_with_loader_limit_errors(self):
+        with self.assertRaises(ValueError):
+            recipe = StandardRecipeWithIndexes(
+                card="cards.wnli",
+                template="templates.key_val",
+                max_test_instances=10,
+                loader_limit=9,
+            )
+
+        with self.assertRaises(ValueError):
+            recipe = StandardRecipeWithIndexes(
+                card="cards.wnli",
+                template="templates.key_val",
+                max_train_instances=10,
+                loader_limit=9,
+            )
+        with self.assertRaises(ValueError):
+            recipe = StandardRecipeWithIndexes(
+                template="templates.key_val",
+                card="cards.wnli",
+                max_validation_instances=10,
+                loader_limit=9,
+            )
+
+        with self.assertRaises(ValueError):
+            recipe = StandardRecipeWithIndexes(
+                template="templates.key_val",
+                card="cards.wnli",
+                num_demos=3,
+                demos_pool_size=10,
+                loader_limit=9,
+            )
+
     def test_standard_recipe_with_balancer_and_size_limit(self):
         recipe = StandardRecipeWithIndexes(
             card="cards.wnli",

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -124,7 +124,7 @@ class TestRecipes(unittest.TestCase):
         )
 
         stream = recipe()
-        self.assertEqual(len(list(stream["train"])), 5)
+        self.assertEqual(len(list(stream["train"])), 5)  # 5 elements were moved to demo pool
         self.assertEqual(len(list(stream["test"])), 10)
 
     def test_standard_recipe_with_loader_limit_errors(self):
@@ -161,26 +161,38 @@ class TestRecipes(unittest.TestCase):
             )
 
     def test_standard_recipe_with_template_errors(self):
+        # Check some template was specified
         with self.assertRaises(AssertionError) as cm:
             recipe = StandardRecipeWithIndexes(card="cards.wnli")
         self.assertEqual(str(cm.exception), "Specify either template or template_card_index in card")
 
+        # Check either template or template index was specified , but not both
         with self.assertRaises(AssertionError) as cm:
             recipe = StandardRecipeWithIndexes(
                 card="cards.wnli", template="templates.key_val", template_card_index=100
             )
-        self.assertTrue("Specify either template" in str(cm.exception))
-        self.assertTrue("but not both" in str(cm.exception))
+        self.assertTrue(
+            not re.match("Specify either template (.*) or template_card_index (.*) but not both", str(cm.exception))
+            is None
+        )
 
+        # Also check if string index is used
         with self.assertRaises(AssertionError) as cm:
             recipe = StandardRecipeWithIndexes(
                 card="cards.wnli", template="templates.key_val", template_card_index="illegal_template"
             )
-        self.assertTrue("Specify either template" in str(cm.exception))
-        self.assertTrue("but not both" in str(cm.exception))
+        self.assertTrue(
+            not re.match("Specify either template (.*) or template_card_index (.*) but not both", str(cm.exception))
+            is None
+        )
 
+        # Return an error if index is not found in card
         with self.assertRaises(ValueError) as cm:
             recipe = StandardRecipeWithIndexes(card="cards.wnli", template_card_index="illegal_template")
+        self.assertTrue("is not in card" in str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            recipe = StandardRecipeWithIndexes(card="cards.wnli", template_card_index=100)
         self.assertTrue("is not in card" in str(cm.exception))
 
     def test_standard_recipe_with_balancer_and_size_limit(self):


### PR DESCRIPTION
Added a env new variable called UNITEXT_IBM_COS_LOADER_LINE_LIMIT which is used to limit the number of lines downloaded from COS.  This is used to speedup generating datacards (using the prepare/cards/*.py files) .  

This works only for datsets that are in jsonl format.   

In another change avoid placing random file names in output
(To simplify diffs comparison)
