### PR TITLE
Add debug card capabilities

### DIFF
--- a/prepare/cards/belebele.py
+++ b/prepare/cards/belebele.py
@@ -182,5 +182,5 @@ for lang in language_codes:
         templates=CONTEXT_MMLU_TEMPLATES_NO_INTRO,
     )
     if lang == "acm_Arab":
-        test_card(card, tested_split="test")
+        test_card(card, demos_taken_from="test", debug=True)
     add_to_catalog(card, f"cards.belebele.{lang}", overwrite=True)

--- a/prepare/cards/boolq.py
+++ b/prepare/cards/boolq.py
@@ -126,5 +126,5 @@ card = TaskCard(
     templates=CONTEXT_QA_TEMPLATES,
 )
 
-test_card(card, tested_split="test")
+test_card(card, demos_taken_from="test")
 add_to_catalog(card, "cards.boolq", overwrite=True)

--- a/prepare/cards/ethos.py
+++ b/prepare/cards/ethos.py
@@ -49,5 +49,5 @@ card = TaskCard(
     ),
 )
 
-test_card(card, demos_pools_size=20, loader_limit=1000)
+test_card(card, demos_pool_size=20, loader_limit=1000)
 add_to_catalog(card, "cards.ethos_binary", overwrite=True)

--- a/prepare/cards/ethos.py
+++ b/prepare/cards/ethos.py
@@ -49,5 +49,5 @@ card = TaskCard(
     ),
 )
 
-test_card(card, tested_split="test")
+test_card(card, demos_pools_size=20, loader_limit=1000)
 add_to_catalog(card, "cards.ethos_binary", overwrite=True)

--- a/prepare/cards/mmlu.py
+++ b/prepare/cards/mmlu.py
@@ -211,7 +211,8 @@ def main():
             ),
             templates=MMLU_TEMPLATES,
         )
-        test_card(card)
+        if subtask == subtasks[0]:
+            test_card(card)
         add_to_catalog(card, f"cards.mmlu.{subtask}", overwrite=True)
 
 

--- a/prepare/cards/sst2.py
+++ b/prepare/cards/sst2.py
@@ -49,5 +49,5 @@ card = TaskCard(
     templates="templates.one_sent_classification",
 )
 
-test_card(card, debug=False)
+test_card(card, debug=True)
 add_to_catalog(card, "cards.sst2", overwrite=True)

--- a/prepare/cards/sst2.py
+++ b/prepare/cards/sst2.py
@@ -49,5 +49,5 @@ card = TaskCard(
     templates="templates.one_sent_classification",
 )
 
-test_card(card)
+test_card(card, debug=False)
 add_to_catalog(card, "cards.sst2", overwrite=True)

--- a/prepare/cards/winogrande.py
+++ b/prepare/cards/winogrande.py
@@ -54,5 +54,5 @@ for subtask in subtasks:
         ),
         templates=MMLU_TEMPLATES,
     )
-    test_card(card, tested_split="test")
+    test_card(card, demos_taken_from="test")
     add_to_catalog(card, f"cards.winogrande.{subtask.replace('-', '_')}", overwrite=True)

--- a/prepare/cards/winogrande.py
+++ b/prepare/cards/winogrande.py
@@ -54,5 +54,6 @@ for subtask in subtasks:
         ),
         templates=MMLU_TEMPLATES,
     )
-    test_card(card, demos_taken_from="test")
+    if subtask == subtask[0]:
+        test_card(card, demos_taken_from="test")
     add_to_catalog(card, f"cards.winogrande.{subtask.replace('-', '_')}", overwrite=True)

--- a/prepare/cards/xnli.py
+++ b/prepare/cards/xnli.py
@@ -15,7 +15,7 @@ from src.unitxt.catalog import add_to_catalog
 from src.unitxt.splitters import RenameSplits
 from src.unitxt.test_utils.card import test_card
 
-for lang in [
+langs = [
     "fr",
     "vi",
     "zh",
@@ -32,7 +32,9 @@ for lang in [
     "th",
     "tr",
     "ur",
-]:
+]
+
+for lang in langs:
     card = TaskCard(
         loader=LoadHF(path="xnli", name=lang),
         preprocess_steps=[
@@ -48,6 +50,6 @@ for lang in [
         task="tasks.nli",
         templates="templates.classification.nli.all",
     )
-
-    test_card(card)
+    if lang == lang[0]:
+        test_card(card)
     add_to_catalog(card, f"cards.xnli.{lang}", overwrite=True)

--- a/prepare/cards/xwinogrande.py
+++ b/prepare/cards/xwinogrande.py
@@ -57,5 +57,5 @@ for lang in langs:
         ),
         templates=MMLU_TEMPLATES,
     )
-    test_card(card, tested_split="test")
+    test_card(card, demos_taken_from="test")
     add_to_catalog(card, f"cards.xwinogrande.{lang}", overwrite=True)

--- a/prepare/cards/xwinogrande.py
+++ b/prepare/cards/xwinogrande.py
@@ -57,5 +57,6 @@ for lang in langs:
         ),
         templates=MMLU_TEMPLATES,
     )
-    test_card(card, demos_taken_from="test")
+    if lang == langs[0]:
+        test_card(card, demos_taken_from="test")
     add_to_catalog(card, f"cards.xwinogrande.{lang}", overwrite=True)

--- a/src/unitxt/metric.py
+++ b/src/unitxt/metric.py
@@ -25,8 +25,8 @@ from .metrics import __file__ as _
 from .normalizers import __file__ as _
 from .operator import (
     MultiStreamOperator,
-    SequntialOperator,
-    SequntialOperatorInitilizer,
+    SequentialOperator,
+    SequentialOperatorInitilizer,
     StreamInitializerOperator,
 )
 from .operator import __file__ as _
@@ -99,7 +99,7 @@ class FromPredictionsAndOriginalData(StreamInitializerOperator):
 from .schema import UNITXT_DATASET_SCHEMA
 
 
-class MetricRecipe(SequntialOperatorInitilizer):
+class MetricRecipe(SequentialOperatorInitilizer):
     def prepare(self):
         register_all_artifacts()
         self.steps = [

--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -396,7 +396,7 @@ class SourceSequentialOperator(SequentialOperator):
         return super().__call__()
 
     def process(self, multi_stream: Optional[MultiStream] = None) -> MultiStream:
-        assert (self.num_steps() > 0, "Calling process on a SourceSequentialOperator without any steps")
+        assert self.num_steps() > 0, "Calling process on a SourceSequentialOperator without any steps"
         multi_stream = self.steps[0]()
         for operator in self.steps[1 : self._get_max_steps()]:
             multi_stream = operator(multi_stream)
@@ -415,7 +415,7 @@ class SequentialOperatorInitilizer(SequentialOperator):
             return self.process(*args, **kwargs)
 
     def process(self, *args, **kwargs) -> MultiStream:
-        assert (self.num_steps() > 0, "Calling process on a SequentialOperatorInitilizer without any steps")
+        assert self.num_steps() > 0, "Calling process on a SequentialOperatorInitilizer without any steps"
 
         assert isinstance(
             self.steps[0], StreamInitializerOperator

--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -1,3 +1,4 @@
+import re
 from abc import abstractmethod
 from dataclasses import field
 from typing import Any, Dict, Generator, List, Optional, Union
@@ -156,7 +157,7 @@ class SingleStreamOperator(MultiStreamOperator):
     """
 
     apply_to_streams: List[str] = NonPositionalField(default=None)  # None apply to all streams
-    dont_apply_to_streams: List[str] = NonPositionalField(default_factory=list)
+    dont_apply_to_streams: List[str] = NonPositionalField(default_factory=None)
 
     def _process_multi_stream(self, multi_stream: MultiStream) -> MultiStream:
         result = {}
@@ -173,6 +174,7 @@ class SingleStreamOperator(MultiStreamOperator):
     def is_should_be_processed(self, stream_name):
         if (
             self.apply_to_streams is not None
+            and self.dont_apply_to_streams is not None
             and stream_name in self.apply_to_streams
             and stream_name in self.dont_apply_to_streams
         ):
@@ -180,9 +182,9 @@ class SingleStreamOperator(MultiStreamOperator):
                 f"Stream '{stream_name}' can be in either apply_to_streams or dont_apply_to_streams not both."
             )
 
-        return (
-            self.apply_to_streams is None or stream_name in self.apply_to_streams
-        ) and stream_name not in self.dont_apply_to_streams
+        return (self.apply_to_streams is None or stream_name in self.apply_to_streams) and (
+            self.dont_apply_to_streams is None or stream_name not in self.dont_apply_to_streams
+        )
 
     def _process_stream(self, stream: Stream, stream_name: str = None) -> Generator:
         if self.is_should_be_processed(stream_name):
@@ -374,7 +376,8 @@ class SequentialOperator(MultiStreamOperator):
 
     def get_last_step_description(self):
         last_step = self.max_steps - 1 if not self.max_steps is None else len(self.steps) - 1
-        return self.steps[last_step].to_dict()
+        description = str(self.steps[last_step])
+        return re.sub(r"\w+=None, ", "", description)
 
     def _get_max_steps(self):
         return self.max_steps if not self.max_steps is None else len(self.steps)

--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -364,21 +364,23 @@ class SequentialOperator(MultiStreamOperator):
 
     def num_steps(self) -> int:
         return len(self.steps)
-    
-    def set_max_steps(self,max_steps):
-        assert max_steps <= self.num_steps(), f"Max steps requested ({max_steps}) is larger than defined steps {self.num_steps()}"
-        assert max_steps >= 1 , f"Max steps requested ({max_steps}) is less than 1"       
+
+    def set_max_steps(self, max_steps):
+        assert (
+            max_steps <= self.num_steps()
+        ), f"Max steps requested ({max_steps}) is larger than defined steps {self.num_steps()}"
+        assert max_steps >= 1, f"Max steps requested ({max_steps}) is less than 1"
         self.max_steps = max_steps
 
     def get_last_step_description(self):
-        last_step = self.max_steps-1 if not self.max_steps is None else len(self.steps)-1
+        last_step = self.max_steps - 1 if not self.max_steps is None else len(self.steps) - 1
         return self.steps[last_step].to_dict()
-    
+
     def _get_max_steps(self):
         return self.max_steps if not self.max_steps is None else len(self.steps)
 
     def process(self, multi_stream: Optional[MultiStream] = None) -> MultiStream:
-        for operator in self.steps[0:self._get_max_steps()]:
+        for operator in self.steps[0 : self._get_max_steps()]:
             multi_stream = operator(multi_stream)
         return multi_stream
 
@@ -394,9 +396,9 @@ class SourceSequentialOperator(SequentialOperator):
         return super().__call__()
 
     def process(self, multi_stream: Optional[MultiStream] = None) -> MultiStream:
-        assert(self.num_steps() > 0, "Calling process on a SourceSequentialOperator without any steps")
+        assert (self.num_steps() > 0, "Calling process on a SourceSequentialOperator without any steps")
         multi_stream = self.steps[0]()
-        for operator in self.steps[1:self._get_max_steps()]:
+        for operator in self.steps[1 : self._get_max_steps()]:
             multi_stream = operator(multi_stream)
         return multi_stream
 
@@ -413,12 +415,12 @@ class SequentialOperatorInitilizer(SequentialOperator):
             return self.process(*args, **kwargs)
 
     def process(self, *args, **kwargs) -> MultiStream:
-        assert(self.num_steps() > 0, "Calling process on a SequentialOperatorInitilizer without any steps")
-  
+        assert (self.num_steps() > 0, "Calling process on a SequentialOperatorInitilizer without any steps")
+
         assert isinstance(
             self.steps[0], StreamInitializerOperator
         ), "The first step in a SequentialOperatorInitilizer must be a StreamInitializerOperator"
         multi_stream = self.steps[0](*args, **kwargs)
-        for operator in self.steps[1:self._get_max_steps()]:
+        for operator in self.steps[1 : self._get_max_steps()]:
             multi_stream = operator(multi_stream)
         return multi_stream

--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -375,7 +375,7 @@ class SequentialOperator(MultiStreamOperator):
         self.max_steps = max_steps
 
     def get_last_step_description(self):
-        last_step = self.max_steps - 1 if not self.max_steps is None else len(self.steps) - 1
+        last_step = self.max_steps - 1 if self.max_steps is not None else len(self.steps) - 1
         description = str(self.steps[last_step])
         return re.sub(r"\w+=None, ", "", description)
 

--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -372,7 +372,7 @@ class SequentialOperator(MultiStreamOperator):
 
     def get_last_step_description(self):
         last_step = self.max_steps-1 if not self.max_steps is None else len(self.steps)-1
-        return self.steps[last_step].__class__.__name__
+        return self.steps[last_step].to_dict()
     
     def _get_max_steps(self):
         return self.max_steps if not self.max_steps is None else len(self.steps)

--- a/src/unitxt/recipe.py
+++ b/src/unitxt/recipe.py
@@ -1,9 +1,9 @@
-from .operator import SourceSequntialOperator
+from .operator import SourceSequentialOperator
 
 
 class Recipe:
     pass
 
 
-class SequentialRecipe(Recipe, SourceSequntialOperator):
+class SequentialRecipe(Recipe, SourceSequentialOperator):
     pass

--- a/src/unitxt/renderers.py
+++ b/src/unitxt/renderers.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 from .dataclass import InternalField
 from .formats import Format, ICLFormat
 from .instructions import Instruction
-from .operator import Operator, SequntialOperator, StreamInstanceOperator
+from .operator import Operator, SequentialOperator, StreamInstanceOperator
 from .random_utils import random
 from .templates import Template
 
@@ -101,7 +101,7 @@ class RenderFormat(Renderer, StreamInstanceOperator):
         return instance
 
 
-class StandardRenderer(Renderer, SequntialOperator):
+class StandardRenderer(Renderer, SequentialOperator):
     template: Template
     instruction: Instruction = None
     demos_field: str = None

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -183,6 +183,10 @@ class SpreadSplit(InstanceOperatorWithGlobalAccess):
             raise Exception(f"Unable to fetch instances from '{self.source_stream}' to '{self.target_field}'")
 
 
+class CreateDemoSplit(SpreadSplit):
+    pass
+
+
 if __name__ == "__main__":
     # some tests
     import random

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -183,10 +183,6 @@ class SpreadSplit(InstanceOperatorWithGlobalAccess):
             raise Exception(f"Unable to fetch instances from '{self.source_stream}' to '{self.target_field}'")
 
 
-class CreateDemoSplit(SpreadSplit):
-    pass
-
-
 if __name__ == "__main__":
     # some tests
     import random

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -81,7 +81,6 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
                 )
 
     def prepare(self):
-
         self.steps = [
             self.card.loader,
         ]

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -81,6 +81,8 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
                 )
 
     def prepare(self):
+
+        self.card.loader.caching = True
         self.steps = [
             self.card.loader,
         ]

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -82,7 +82,6 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
 
     def prepare(self):
 
-        self.card.loader.caching = True
         self.steps = [
             self.card.loader,
         ]

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -9,7 +9,7 @@ from .operators import Augmentor, NullAugmentor, StreamRefiner
 from .recipe import Recipe
 from .renderers import StandardRenderer
 from .schema import ToUnitxtGroup
-from .splitters import Sampler, SeparateSplit, SpreadSplit
+from .splitters import CreateDemoSplit, Sampler, SeparateSplit
 from .templates import Template, TemplatesDict
 
 
@@ -108,7 +108,7 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
             sampler.set_size(self.num_demos)
 
             self.steps.append(
-                SpreadSplit(
+                CreateDemoSplit(
                     source_stream=self.demos_pool_name,
                     target_field=self.demos_field,
                     sampler=sampler,

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -9,8 +9,17 @@ from .operators import Augmentor, NullAugmentor, StreamRefiner
 from .recipe import Recipe
 from .renderers import StandardRenderer
 from .schema import ToUnitxtGroup
-from .splitters import CreateDemoSplit, Sampler, SeparateSplit
+from .splitters import Sampler, SeparateSplit, SpreadSplit
 from .templates import Template, TemplatesDict
+
+
+# Used to give meaningful name to recipe steps
+class CreateDemosPool(SeparateSplit):
+    pass
+
+
+class AddDemosField(SpreadSplit):
+    pass
 
 
 class BaseRecipe(Recipe, SourceSequentialOperator):
@@ -92,7 +101,7 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
 
         if self.demos_pool_size is not None:
             self.steps.append(
-                SeparateSplit(
+                CreateDemosPool(
                     from_split=self.demos_taken_from,
                     to_split_names=[self.demos_pool_name, self.demos_taken_from],
                     to_split_sizes=[int(self.demos_pool_size)],
@@ -108,7 +117,7 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
             sampler.set_size(self.num_demos)
 
             self.steps.append(
-                CreateDemoSplit(
+                AddDemosField(
                     source_stream=self.demos_pool_name,
                     target_field=self.demos_field,
                     sampler=sampler,

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -4,7 +4,7 @@ from .card import TaskCard
 from .dataclass import InternalField, OptionalField
 from .formats import ICLFormat
 from .instructions import Instruction
-from .operator import SourceSequntialOperator, StreamingOperator
+from .operator import SourceSequentialOperator, StreamingOperator
 from .operators import Augmentor, NullAugmentor, StreamRefiner
 from .recipe import Recipe
 from .renderers import StandardRenderer
@@ -13,7 +13,7 @@ from .splitters import Sampler, SeparateSplit, SpreadSplit
 from .templates import Template, TemplatesDict
 
 
-class BaseRecipe(Recipe, SourceSequntialOperator):
+class BaseRecipe(Recipe, SourceSequentialOperator):
     card: TaskCard
     template: Template = None
     instruction: Instruction = None

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -53,11 +53,13 @@ def load_examples_from_standard_recipe(card, template_card_index, debug, **kwarg
         for max_steps in range(1, recipe.num_steps() + 1):
             examples = print_recipe_output(recipe, max_steps=max_steps, num_examples=1, print_header=True)
     else:
-        examples = print_recipe_output(recipe, max_steps=recipe.num_steps(), num_examples=3, print_header=False)
+        examples = print_recipe_output(
+            recipe, max_steps=recipe.num_steps(), num_examples=3, print_header=False, streams=["test"]
+        )
     return examples
 
 
-def print_recipe_output(recipe, max_steps, num_examples, print_header):
+def print_recipe_output(recipe, max_steps, num_examples, print_header, streams=None):
     recipe.set_max_steps(max_steps)
     if print_header:
         last_step_description_dict = recipe.get_last_step_description()
@@ -72,13 +74,14 @@ def print_recipe_output(recipe, max_steps, num_examples, print_header):
         print(f"stream named '{stream_name}' has {num_instances} instances")
     print("")
     for stream_name in multi_stream.keys():
-        stream = multi_stream[stream_name]
-        examples = list(stream.take(num_examples))
-        print("-" * 10)
-        print(f"Showing {len(examples)} examples from stream '{stream_name}':\n")
-        for example in examples:
-            print_dict(example)
-            print("\n")
+        if streams is None or stream_name in streams:
+            stream = multi_stream[stream_name]
+            examples = list(stream.take(num_examples))
+            print("-" * 10)
+            print(f"Showing {len(examples)} example(s) from stream '{stream_name}':\n")
+            for example in examples:
+                print_dict(example)
+                print("\n")
     return examples
 
 

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -65,6 +65,31 @@ def load_examples_from_standard_recipe(card, tested_split, template_card_index):
 
     return examples
 
+def debug_card(card,**kwargs):  
+    recipe = StandardRecipe(card=card,**kwargs)
+  
+    for max_steps in range(1,recipe.num_steps()+1):
+        recipe.set_max_steps(max_steps)
+        print("=" * 80)
+        print("=" * 8)
+        print("=" * 8 , f"{max_steps} - after {recipe.get_last_step_description()}")
+        print("=" * 8)
+  
+        multi_stream = recipe()
+        for stream_name in multi_stream.keys():
+            stream = multi_stream[stream_name]
+            num_instances = len(list(stream.take(1000000)))
+            print(f"stream name '{stream_name}' has {num_instances} instances")
+        print("")          
+        for stream_name in multi_stream.keys():
+            stream = multi_stream[stream_name]
+            examples = list(stream.take(1))
+            print("-" * 10)
+            print(f"{len(examples)} Example from '{stream_name}'")
+            for example in examples:
+                print_dict(example)
+                print("\n")
+
 
 def test_with_eval(card, tested_split, strict=True, exact_match_score=1.0, full_mismatch_score=0.0):
     if type(card.templates) is TemplatesDict:

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -70,11 +70,12 @@ def debug_card(card,**kwargs):
   
     for max_steps in range(1,recipe.num_steps()+1):
         recipe.set_max_steps(max_steps)
+        last_step_description_dict = recipe.get_last_step_description()
         print("=" * 80)
         print("=" * 8)
-        print("=" * 8 , f"{max_steps} - after {recipe.get_last_step_description()}")
+        print("=" * 8 , f"{max_steps} - after {last_step_description_dict['type']}")
         print("=" * 8)
-  
+        print(json.dumps(last_step_description_dict, indent=4))
         multi_stream = recipe()
         for stream_name in multi_stream.keys():
             stream = multi_stream[stream_name]

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -51,9 +51,10 @@ def load_examples_from_standard_recipe(card, template_card_index, debug, **kwarg
     recipe = StandardRecipe(card=card, template_card_index=template_card_index, **kwargs)
     if debug:
         for max_steps in range(1, recipe.num_steps() + 1):
-            print_recipe_output(recipe, max_steps=max_steps, num_examples=1, print_header=True)
+            examples = print_recipe_output(recipe, max_steps=max_steps, num_examples=1, print_header=True)
     else:
-        print_recipe_output(recipe, max_steps=recipe.num_steps(), num_examples=3, print_header=False)
+        examples = print_recipe_output(recipe, max_steps=recipe.num_steps(), num_examples=3, print_header=False)
+    return examples
 
 
 def print_recipe_output(recipe, max_steps, num_examples, print_header):
@@ -69,16 +70,17 @@ def print_recipe_output(recipe, max_steps, num_examples, print_header):
     for stream_name in multi_stream.keys():
         stream = multi_stream[stream_name]
         num_instances = len(list(iter(stream)))
-        print(f"stream name '{stream_name}' has {num_instances} instances")
+        print(f"stream named '{stream_name}' has {num_instances} instances")
     print("")
     for stream_name in multi_stream.keys():
         stream = multi_stream[stream_name]
         examples = list(stream.take(num_examples))
         print("-" * 10)
-        print(f"Showing {len(examples)} examples from '{stream_name}'")
+        print(f"Showing {len(examples)} examples from stream '{stream_name}:'\n")
         for example in examples:
             print_dict(example)
             print("\n")
+    return examples
 
 
 def test_with_eval(card, debug=False, strict=True, exact_match_score=1.0, full_mismatch_score=0.0, **kwargs):

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -75,7 +75,7 @@ def print_recipe_output(recipe, max_steps, num_examples, print_header):
         stream = multi_stream[stream_name]
         examples = list(stream.take(num_examples))
         print("-" * 10)
-        print(f"Showing {len(examples)} examples from stream '{stream_name}:'\n")
+        print(f"Showing {len(examples)} examples from stream '{stream_name}':\n")
         for example in examples:
             print_dict(example)
             print("\n")

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -63,9 +63,8 @@ def print_recipe_output(recipe, max_steps, num_examples, print_header):
         last_step_description_dict = recipe.get_last_step_description()
         print("=" * 80)
         print("=" * 8)
-        print("=" * 8, f"{max_steps} - after {last_step_description_dict['type']}")
+        print("=" * 8, recipe.get_last_step_description())
         print("=" * 8)
-        print(json.dumps(last_step_description_dict, indent=4))
     multi_stream = recipe()
     for stream_name in multi_stream.keys():
         stream = multi_stream[stream_name]

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -65,15 +65,16 @@ def load_examples_from_standard_recipe(card, tested_split, template_card_index):
 
     return examples
 
-def debug_card(card,**kwargs):  
-    recipe = StandardRecipe(card=card,**kwargs)
-  
-    for max_steps in range(1,recipe.num_steps()+1):
+
+def debug_card(card, **kwargs):
+    recipe = StandardRecipe(card=card, **kwargs)
+
+    for max_steps in range(1, recipe.num_steps() + 1):
         recipe.set_max_steps(max_steps)
         last_step_description_dict = recipe.get_last_step_description()
         print("=" * 80)
         print("=" * 8)
-        print("=" * 8 , f"{max_steps} - after {last_step_description_dict['type']}")
+        print("=" * 8, f"{max_steps} - after {last_step_description_dict['type']}")
         print("=" * 8)
         print(json.dumps(last_step_description_dict, indent=4))
         multi_stream = recipe()
@@ -81,7 +82,7 @@ def debug_card(card,**kwargs):
             stream = multi_stream[stream_name]
             num_instances = len(list(stream.take(1000000)))
             print(f"stream name '{stream_name}' has {num_instances} instances")
-        print("")          
+        print("")
         for stream_name in multi_stream.keys():
             stream = multi_stream[stream_name]
             examples = list(stream.take(1))

--- a/tests/test_function_operators.py
+++ b/tests/test_function_operators.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from src.unitxt.operator import SequntialOperator
+from src.unitxt.operator import SequentialOperator
 from src.unitxt.operators import AddFields, Apply, CopyFields
 from src.unitxt.test_utils.operators import test_operator
 
@@ -23,7 +23,7 @@ class TestFunctionOperators(unittest.TestCase):
         test_operator(operator=operator, inputs=inputs, targets=targets, tester=self)
 
     def test_apply_function_operator_for_library_function(self):
-        operator = SequntialOperator(
+        operator = SequentialOperator(
             [
                 Apply(function=dict, to_field="t"),
                 CopyFields(field_to_field={"a": "t/a", "b": "t/b"}, use_query=True),


### PR DESCRIPTION
     Added debug_card utility to help debug cards
    
    At the core, added an ability to run a sequence operator
    only for a given number of steps.
    
    The debug_card utility iterates over all steps in a card and
    prints the for each step all the streams (splits) in the output
    and the first example in each stream.
    
    test_card(card,debug=True  )
    
    
## Example output:
