### PR TITLE
Fix demos selection using DiverseLabelsSampler

### DIFF
--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -162,6 +162,7 @@ class SpreadSplit(InstanceOperatorWithGlobalAccess):
         self.accessible_streams = [self.source_stream]
         self.cache_accessible_streams = True
         self.local_cache = None
+        self.sampler.prepare()
 
     def verify(self):
         assert self.source_stream is not None, "Source stream must be specified"


### PR DESCRIPTION
When using `DiverseLabelsSampler` the demos were selected using the first template.
For templates following the first template, this caused a mismatch between the templates used for the question and the demo.

The root cause was:

The DiverseLabelsSampler has a cache within self.labels, initialized [here](https://github.com/IBM/unitxt/blob/main/src/unitxt/splitters.py#L130). The cache is reset in [DiverseLabelsSampler.prepare()](https://github.com/IBM/unitxt/blob/main/src/unitxt/splitters.py#L110).

The issue is that Sampler.prepare() is not called for the [sampler](https://github.com/IBM/unitxt/blob/main/src/unitxt/splitters.py#L159) member within a SpreadSplit. It should be called from [SpreadSplit.prepare](https://github.com/IBM/unitxt/blob/main/src/unitxt/splitters.py#L161).

