### PR TITLE
Updates to YesNoTemplate

### DIFF
--- a/src/unitxt/templates.py
+++ b/src/unitxt/templates.py
@@ -225,7 +225,16 @@ class YesNoTemplate(Template):
                 raise RuntimeError(
                     f"Unexpected value for gold_class_names: '{gold_class_names}'. Expected a non-empty list."
                 )
-            queried_class_name = outputs[self.class_field]
+            queried_class_names = outputs[self.class_field]
+            if (
+                not queried_class_names
+                or not isinstance(queried_class_names, list)
+                or not len(queried_class_names) == 1
+            ):
+                raise RuntimeError(
+                    f"Unexpected value for queried_class_names: '{queried_class_names}'. Expected a list with one item."
+                )
+            queried_class_name = queried_class_names[0]
             if queried_class_name in gold_class_names:
                 return self.yes_answer
             else:

--- a/src/unitxt/templates.py
+++ b/src/unitxt/templates.py
@@ -221,29 +221,29 @@ class YesNoTemplate(Template):
     def process_outputs(self, outputs: Dict[str, object]) -> str:
         try:
             gold_class_names = outputs[self.label_field]
-            if not isinstance(gold_class_names, list) or not gold_class_names:
-                raise RuntimeError(
-                    f"Unexpected value for gold_class_names: '{gold_class_names}'. Expected a non-empty list."
-                )
-            queried_class_names = outputs[self.class_field]
-            if (
-                not queried_class_names
-                or not isinstance(queried_class_names, list)
-                or not len(queried_class_names) == 1
-            ):
-                raise RuntimeError(
-                    f"Unexpected value for queried_class_names: '{queried_class_names}'. Expected a list with one item."
-                )
-            queried_class_name = queried_class_names[0]
-            if queried_class_name in gold_class_names:
-                return self.yes_answer
-            else:
-                return self.no_answer
         except KeyError as e:
-            raise KeyError(
-                f"Available outputs are {outputs.keys()}, but required label field is: '{self.label_field}', "
-                f"and required class field is '{self.class_field}'. One or both are missing."
+            raise RuntimeError(
+                f"Available outputs are {list(outputs.keys())}, missing required label field: '{self.label_field}'."
             ) from e
+        if not isinstance(gold_class_names, list) or not gold_class_names:
+            raise RuntimeError(
+                f"Unexpected value for gold_class_names: '{gold_class_names}'. Expected a non-empty list."
+            )
+        try:
+            queried_class_names = outputs[self.class_field]
+        except KeyError as e:
+            raise RuntimeError(
+                f"Available outputs are {list(outputs.keys())}, missing required class field: '{self.class_field}'."
+            ) from e
+        if not queried_class_names or not isinstance(queried_class_names, list) or not len(queried_class_names) == 1:
+            raise RuntimeError(
+                f"Unexpected value for queried_class_names: '{queried_class_names}'. Expected a list with one item."
+            )
+        queried_class_name = queried_class_names[0]
+        if queried_class_name in gold_class_names:
+            return self.yes_answer
+        else:
+            return self.no_answer
 
     def get_postprocessors(self) -> List[str]:
         return self.postprocessors

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -96,8 +96,8 @@ class TestTemplates(unittest.TestCase):
         template = YesNoTemplate(input_format="Is {text} of {class}?", class_field="class", label_field="labels")
 
         proccessed_input_to_inputs = {
-            "Is text_a of news?": {"text": "text_a", "class": "news"},
-            "Is text_b of news?": {"text": "text_b", "class": "news"},
+            "Is text_a of news?": {"text": "text_a", "class": ["news"]},
+            "Is text_b of news?": {"text": "text_b", "class": ["news"]},
         }
         for expected_processed_input, inputs in proccessed_input_to_inputs.items():
             processed = template.process_inputs(inputs)
@@ -112,7 +112,7 @@ class TestTemplates(unittest.TestCase):
         template = YesNoTemplate(input_format=input_format, class_field="class", label_field="")
         with self.assertRaises(KeyError) as cm:
             wrong_field_name = "wrong_field_name"
-            template.process_inputs(inputs={wrong_field_name: "news"})
+            template.process_inputs(inputs={wrong_field_name: ["news"]})
             self.assertEquals(
                 f"Available inputs are {wrong_field_name} but input format requires a different one: {input_format}",
                 str(cm.exception),
@@ -188,7 +188,7 @@ class TestTemplates(unittest.TestCase):
             )
 
         _test_with_wrong_labels_value(wrong_labels_value=[])  # list of labels values should not be empty
-        _test_with_wrong_labels_value(wrong_labels_value="non list value")
+        _test_with_wrong_labels_value(wrong_labels_value="non list value is an error")
 
     def test_yes_no_template_process_output_wrong_value_in_class_field(self):
         """
@@ -213,8 +213,8 @@ class TestTemplates(unittest.TestCase):
             )
 
         _test_with_wrong_class_value(wrong_class_value=[])  # list of class values should not be empty
-        _test_with_wrong_class_value(wrong_class_value="non list value")
-        _test_with_wrong_class_value(wrong_class_value=["list with", "two items"])
+        _test_with_wrong_class_value(wrong_class_value="non list value is an error")
+        _test_with_wrong_class_value(wrong_class_value=["list with", "two or more items is an error"])
 
     def test_span_labeling_template_one_entity_escaping(self):
         parser, _ = fetch_artifact("processors.to_span_label_pairs_surface_only")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -90,76 +90,105 @@ class TestTemplates(unittest.TestCase):
             self.assertEqual(parsed, parsed_target)
 
     def test_yes_no_template_process_input(self):
-        template = YesNoTemplate(input_format="Is {text} of {class_name}?", class_name="news", label_field="labels")
+        """
+        Test the processing of the input of a YesNoTemplate.
+        """
+        template = YesNoTemplate(input_format="Is {text} of {class}?", class_field="class", label_field="labels")
 
         proccessed_input_to_inputs = {
-            "Is text_a of news?": {"text": "text_a"},
-            "Is text_b of news?": {"text": "text_b"},
+            "Is text_a of news?": {"text": "text_a", "class": "news"},
+            "Is text_b of news?": {"text": "text_b", "class": "news"},
         }
         for expected_processed_input, inputs in proccessed_input_to_inputs.items():
             processed = template.process_inputs(inputs)
             self.assertEqual(expected_processed_input, processed)
 
     def test_yes_no_template_process_input_missing_input_field(self):
-        input_format = "Expecting field {text} in input."
-        template = YesNoTemplate(input_format=input_format, class_name="", label_field="")
+        """
+        Test the processing of the input of a YesNoTemplate when one of the fields required in the
+        input is missing. Expect that an exception is thrown.
+        """
+        input_format = "Expecting field {class} in input."
+        template = YesNoTemplate(input_format=input_format, class_field="class", label_field="")
         with self.assertRaises(KeyError) as cm:
             wrong_field_name = "wrong_field_name"
-            template.process_inputs(inputs={wrong_field_name: "text_a"})
+            template.process_inputs(inputs={wrong_field_name: "news"})
             self.assertEquals(
                 f"Available inputs are {wrong_field_name} but input format requires a different one: {input_format}",
                 str(cm.exception),
             )
 
     def test_yes_no_template_process_output(self):
+        """
+        Test the processing of the output of a YesNoTemplate.
+        """
         label_field = "labels"
-        class_name = "news"
+        class_field = "class"
         yes_answer = "y"
         no_answer = "n"
         template = YesNoTemplate(
             input_format="",
-            class_name=class_name,
+            class_field=class_field,
             label_field=label_field,
             yes_answer=yes_answer,
             no_answer=no_answer,
         )
 
         processed_output_to_outputs = {
-            no_answer: {label_field: ["sports"]},
-            yes_answer: {label_field: [class_name]},
-            yes_answer: {label_field: [class_name, "sports"]},
+            no_answer: {label_field: ["sports"], class_field: "news"},
+            yes_answer: {label_field: ["news"], class_field: "news"},
+            yes_answer: {label_field: ["news", "sports"], class_field: "news"},
         }
         for expected_processed_output, outputs in processed_output_to_outputs.items():
             processed = template.process_outputs(outputs)
             self.assertEqual(expected_processed_output, processed)
 
-    def test_yes_no_template_process_output_missing_label_field(self):
+    def test_yes_no_template_process_output_missing_fields(self):
+        """
+        Test the processing of the output of a YesNoTemplate, when the label_field or the
+        class_field values are missing from the output.
+        """
         label_field = "labels"
-        template = YesNoTemplate(input_format="", class_name="", label_field=label_field)
-        with self.assertRaises(KeyError) as cm:
-            outputs = {}
-            template.process_outputs(outputs=outputs)
-            self.assertEquals(
-                f"Available outputs are {outputs.keys()}, but required label field is: '{label_field}'.",
-                str(cm.exception),
-            )
+        class_field = "class"
+        template = YesNoTemplate(input_format="", class_field=class_field, label_field=label_field)
+
+        correct_outputs = {
+            class_field: "news",
+            label_field: ["news", "sports"],
+        }
+
+        def _test_with_missing_output(missing_output_key):
+            # check for missing label_field
+            with self.assertRaises(KeyError) as cm:
+                outputs = correct_outputs.copy()
+                del outputs[missing_output_key]
+                template.process_outputs(outputs=outputs)
+                self.assertEquals(
+                    f"Available outputs are {outputs.keys()}, but required label field is: '{self.label_field}', "
+                    f"and required class field is '{self.class_field}'. One or both are missing.",
+                    str(cm.exception),
+                )
+
+        _test_with_missing_output(missing_output_key=label_field)
+        _test_with_missing_output(missing_output_key=class_field)
 
     def test_yes_no_template_process_output_wrong_value_in_label_field(self):
-        template = YesNoTemplate(input_format="", class_name="", label_field="labels")
-        with self.assertRaises(RuntimeError) as cm:
-            gold_class_names = []
-            template.process_outputs(outputs={"labels": gold_class_names})
-            self.assertEquals(
-                f"Unexpected value for gold_class_names: '{gold_class_names}'. Expected a non-empty list.",
-                str(cm.exception),
-            )
-        with self.assertRaises(RuntimeError) as cm:
-            gold_class_names = "non list value"
-            template.process_outputs(outputs={"labels": gold_class_names})
-            self.assertEquals(
-                f"Unexpected value for gold_class_names: '{gold_class_names}'. Expected a non-empty list.",
-                str(cm.exception),
-            )
+        """
+        Test the processing of the output of a YesNoTemplate, when the label_field or the
+        contains incorrect values.
+        """
+
+        def _test_with_wrong_labels_value(wrong_labels_value):
+            template = YesNoTemplate(input_format="", class_field="", label_field="labels")
+            with self.assertRaises(RuntimeError) as cm:
+                template.process_outputs(outputs={"labels": wrong_labels_value})
+                self.assertEquals(
+                    f"Unexpected value for gold_class_names: '{wrong_labels_value}'. Expected a non-empty list.",
+                    str(cm.exception),
+                )
+
+        _test_with_wrong_labels_value(wrong_labels_value=[])  # list of labels values should not be empty
+        _test_with_wrong_labels_value(wrong_labels_value="non list value")
 
     def test_span_labeling_template_one_entity_escaping(self):
         parser, _ = fetch_artifact("processors.to_span_label_pairs_surface_only")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -152,25 +152,21 @@ class TestTemplates(unittest.TestCase):
         class_field = "class"
         template = YesNoTemplate(input_format="", class_field=class_field, label_field=label_field)
 
-        correct_outputs = {
-            class_field: ["news"],
-            label_field: ["news", "sports"],
-        }
+        with self.assertRaises(RuntimeError) as cm:
+            outputs = {class_field: ["news"]}
+            template.process_outputs(outputs=outputs)
+        self.assertEquals(
+            f"Available outputs are {list(outputs.keys())}, missing required label field: '{label_field}'.",
+            str(cm.exception),
+        )
 
-        def _test_with_missing_output(missing_output_key):
-            # check for missing label_field
-            with self.assertRaises(KeyError) as cm:
-                outputs = correct_outputs.copy()
-                del outputs[missing_output_key]
-                template.process_outputs(outputs=outputs)
-                self.assertEquals(
-                    f"Available outputs are {outputs.keys()}, but required label field is: '{self.label_field}', "
-                    f"and required class field is '{self.class_field}'. One or both are missing.",
-                    str(cm.exception),
-                )
-
-        _test_with_missing_output(missing_output_key=label_field)
-        _test_with_missing_output(missing_output_key=class_field)
+        with self.assertRaises(RuntimeError) as cm:
+            outputs = {label_field: ["news", "sports"]}
+            template.process_outputs(outputs=outputs)
+        self.assertEquals(
+            f"Available outputs are {list(outputs.keys())}, missing required class field: '{class_field}'.",
+            str(cm.exception),
+        )
 
     def test_yes_no_template_process_output_wrong_value_in_label_field(self):
         """


### PR DESCRIPTION
Change `YesNoTemplate` to accept a `class_field`, which contains the name of the field with the queried class_name. It is now expected in both the inputs and the outputs to the template.

This replaces the `class_name` parameter, that directly included the queried class name.