### PR TITLE
improve error handling in DiverseLabelsSampler

### DIFF
--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -110,11 +110,20 @@ class DiverseLabelsSampler(Sampler):
         self.labels = None
 
     def examplar_repr(self, examplar):
-        assert (
-            "inputs" in examplar and self.choices in examplar["inputs"]
-        ), f"DiverseLabelsSampler assumes each examplar has {self.choices} field in it input"
+        if "inputs" not in examplar:
+            raise ValueError(f"'inputs' field is missing from '{examplar}'.")
+        inputs = examplar["inputs"]
+        if self.choices not in inputs:
+            raise ValueError(f"{self.choices} field is missing from '{inputs}'.")
+        choices = inputs[self.choices]
+        if not isinstance(choices, list):
+            raise ValueError(f"Unexpected choices value '{choices}'. Expected a list.")
+
+        if "outputs" not in examplar:
+            raise ValueError(f"'outputs' field is missing from '{examplar}'.")
         examplar_outputs = next(iter(examplar["outputs"].values()))
-        return str([choice for choice in examplar["inputs"][self.choices] if choice in examplar_outputs])
+
+        return str([choice for choice in choices if choice in examplar_outputs])
 
     def divide_by_repr(self, examplars_pool):
         labels = dict()

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -122,6 +122,8 @@ class DiverseLabelsSampler(Sampler):
         if "outputs" not in examplar:
             raise ValueError(f"'outputs' field is missing from '{examplar}'.")
         examplar_outputs = next(iter(examplar["outputs"].values()))
+        if not isinstance(examplar_outputs, list):
+            raise ValueError(f"Unexpected examplar_outputs value '{examplar_outputs}'. Expected a list.")
 
         return str([choice for choice in choices if choice in examplar_outputs])
 

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -117,7 +117,7 @@ class DiverseLabelsSampler(Sampler):
             raise ValueError(f"{self.choices} field is missing from '{inputs}'.")
         choices = inputs[self.choices]
         if not isinstance(choices, list):
-            raise ValueError(f"Unexpected choices value '{choices}'. Expected a list.")
+            raise ValueError(f"Unexpected input choices value '{choices}'. Expected a list.")
 
         if "outputs" not in examplar:
             raise ValueError(f"'outputs' field is missing from '{examplar}'.")

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -1,6 +1,6 @@
 import unittest
 
-from unitxt.splitters import DiverseLabelsSampler
+from src.unitxt.splitters import DiverseLabelsSampler
 
 
 class TestDiverseLabelsSampler(unittest.TestCase):

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -26,14 +26,14 @@ class TestDiverseLabelsSampler(unittest.TestCase):
         result = sampler.examplar_repr(examplar=self.new_examplar())
         self.assertEqual(str(expected_results), result)
 
-    def test_examplar_repr_with_string_for_output_choices(self):
+    def test_examplar_repr_with_string_for_input_choices(self):
         sampler = DiverseLabelsSampler()
-        examplar_output_choices = "a string which is a wrong value"
-        wrong_examplar = self.new_examplar(output_choices=examplar_output_choices)
+        examplar_input_choices = "a string which is a wrong value"
+        wrong_examplar = self.new_examplar(input_choices=examplar_input_choices)
         with self.assertRaises(ValueError) as cm:
             sampler.examplar_repr(examplar=wrong_examplar)
         self.assertEquals(
-            f"Unexpected examplar_outputs value '{examplar_output_choices}'. Expected a list.",
+            f"Unexpected input choices value '{examplar_input_choices}'. Expected a list.",
             str(cm.exception),
         )
 

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -1,0 +1,42 @@
+import unittest
+
+from unitxt.splitters import DiverseLabelsSampler
+
+
+class TestDiverseLabelsSampler(unittest.TestCase):
+    """
+    Tests for the DiverseLabelsSampler object.
+    """
+
+    @staticmethod
+    def get_correct_examplar():
+        """
+        return an examplar in a correct format.
+        """
+        return {
+            "inputs": {"choices": ["class_a", "class_b"]},
+            "outputs": {
+                "choices": ["class_a"],
+            },
+        }
+
+    def test_examplar_repr(self):
+        sampler = DiverseLabelsSampler()
+        expected_results = ["class_a"]
+        result = sampler.examplar_repr(examplar=self.get_correct_examplar())
+        self.assertEqual(str(expected_results), result)
+
+    def _test_examplar_repr_missing_field(self, missing_field):
+        examplar = self.get_correct_examplar()
+        del examplar[missing_field]
+        with self.assertRaises(ValueError) as cm:
+            sampler = DiverseLabelsSampler()
+            sampler.examplar_repr(examplar=examplar)
+        self.assertEquals(
+            f"'{missing_field}' field is missing from '{examplar}'.",
+            str(cm.exception),
+        )
+
+    def test_examplar_repr_missing_fields(self):
+        self._test_examplar_repr_missing_field(missing_field="inputs")
+        self._test_examplar_repr_missing_field(missing_field="outputs")

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -9,25 +9,36 @@ class TestDiverseLabelsSampler(unittest.TestCase):
     """
 
     @staticmethod
-    def get_correct_examplar():
+    def new_examplar(input_choices=["class_a", "class_b"], output_choices=["class_a"]):
         """
         return an examplar in a correct format.
         """
         return {
-            "inputs": {"choices": ["class_a", "class_b"]},
+            "inputs": {"choices": input_choices},
             "outputs": {
-                "choices": ["class_a"],
+                "choices": output_choices,
             },
         }
 
     def test_examplar_repr(self):
         sampler = DiverseLabelsSampler()
         expected_results = ["class_a"]
-        result = sampler.examplar_repr(examplar=self.get_correct_examplar())
+        result = sampler.examplar_repr(examplar=self.new_examplar())
         self.assertEqual(str(expected_results), result)
 
+    def test_examplar_repr_with_string_for_output_choices(self):
+        sampler = DiverseLabelsSampler()
+        examplar_output_choices = "a string which is a wrong value"
+        wrong_examplar = self.new_examplar(output_choices=examplar_output_choices)
+        with self.assertRaises(ValueError) as cm:
+            sampler.examplar_repr(examplar=wrong_examplar)
+        self.assertEquals(
+            f"Unexpected examplar_outputs value '{examplar_output_choices}'. Expected a list.",
+            str(cm.exception),
+        )
+
     def _test_examplar_repr_missing_field(self, missing_field):
-        examplar = self.get_correct_examplar()
+        examplar = self.new_examplar()
         del examplar[missing_field]
         with self.assertRaises(ValueError) as cm:
             sampler = DiverseLabelsSampler()


### PR DESCRIPTION
Improve the error handling for the `DiverseLabelsSampler`.
The motivation behind is having set value set in the "choices" field, by mistake, to a string:

```
        AddFields(
            fields={
                "class": "Termination for convenience",  #### The mistake is here, should be ["Termination for convenience"]
                "text_type": "contractual sentence",
            }
        ),
```

Since the code then iterates over the value in this field, the iteration was over the string characters, which is wrong. It was expected that "choices" within the input contains is a list. Added a check for that.

Also added other relevant tests and checks, including one that represents the issue.