### PR TITLE
A new format that does not have an input output seperator

### DIFF
--- a/prepare/formats/empty_input_output_separators.py
+++ b/prepare/formats/empty_input_output_separators.py
@@ -1,0 +1,6 @@
+from src.unitxt.catalog import add_to_catalog
+from src.unitxt.formats import ICLFormat
+
+format = ICLFormat(input_output_separator="")
+
+add_to_catalog(format, f"formats.empty_input_output_separator", overwrite=True)

--- a/src/unitxt/catalog/formats/empty_input_output_separator.json
+++ b/src/unitxt/catalog/formats/empty_input_output_separator.json
@@ -1,0 +1,4 @@
+{
+    "type": "icl_format",
+    "input_output_separator": ""
+}


### PR DESCRIPTION
This is required for inference in 0-shot mode, when it is expected that the model completes the input, and does not answer in a new line.