### PR TITLE
Add support for mapping full list in MapInstanceValues

### DIFF
--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -134,31 +134,29 @@ class MapInstanceValues(StreamInstanceOperator):
                     )
                 if isinstance(value, list) and self.process_every_value:
                     for i, val in enumerate(value):
-                        val = str(val)  # make sure the value is a string
-                        if self.strict and (val not in mapper):
-                            raise KeyError(
-                                f"value '{val}' in instance '{instance}' is not found in mapper '{mapper}', associated with field '{key}'."
-                            )
-                        if val in mapper:
-                            # replace just that member of value (value is a list)
-                            value[i] = mapper[val]
-                            dict_set(instance, key, value, use_dpath=self.use_query)
+                        value[i] = self.get_mapped_value(instance, key, mapper, val)
+                    dict_set(instance, key, value, use_dpath=self.use_query)
                 else:
-                    value = str(value)  # make sure the value is a string
-                    if self.strict and (value not in mapper):
-                        raise KeyError(
-                            f"value '{value}' in instance '{instance}' is not found in mapper '{mapper}', associated with field '{key}'."
-                        )
-                    if value in mapper:
-                        # By default deep copy the value in mapper to avoid shared modifications
-                        dict_set(
-                            instance,
-                            key,
-                            deepcopy(mapper[value]),
-                            use_dpath=self.use_query,
-                        )
+                    value = self.get_mapped_value(instance, key, mapper, value)
+                    dict_set(
+                        instance,
+                        key,
+                        value,
+                        use_dpath=self.use_query,
+                    )
 
         return instance
+
+    def get_mapped_value(self, instance, key, mapper, val):
+        val_as_str = str(val)  # make sure the value is a string
+        if self.strict and (val_as_str not in mapper):
+            raise KeyError(
+                f"value '{val}' in instance '{instance}' is not found in mapper '{mapper}', associated with field '{key}'."
+            )
+        # By default deep copy the value in mapper to avoid shared modifications
+        if val_as_str in mapper:
+            return deepcopy(mapper[val_as_str])
+        return val
 
 
 class FlattenInstances(StreamInstanceOperator):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -135,15 +135,14 @@ class MapInstanceValues(StreamInstanceOperator):
                 if isinstance(value, list) and self.process_every_value:
                     for i, val in enumerate(value):
                         value[i] = self.get_mapped_value(instance, key, mapper, val)
-                    dict_set(instance, key, value, use_dpath=self.use_query)
                 else:
                     value = self.get_mapped_value(instance, key, mapper, value)
-                    dict_set(
-                        instance,
-                        key,
-                        value,
-                        use_dpath=self.use_query,
-                    )
+                dict_set(
+                    instance,
+                    key,
+                    value,
+                    use_dpath=self.use_query,
+                )
 
         return instance
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -87,6 +87,11 @@ class MapInstanceValues(StreamInstanceOperator):
         To ensure that all values of field 'a' are mapped in every instance, use strict=True.
         Input instance {"a":"3", "b": 2} will raise an exception per the above call,
         because "3" is not a key in the mapper of "a".
+
+        MapInstanceValues(mappers={"a": {str([1,2,3,4]): 'All', str([]): 'None'}}, strict=True)
+        replaces a list [1,2,3,4] with the string 'All' and an empty list by string 'None'.
+        Note that mapped values are defined by their string representation, so mapped values
+        must be converted to strings.
     """
 
     mappers: Dict[str, Dict[str, str]]
@@ -115,31 +120,31 @@ class MapInstanceValues(StreamInstanceOperator):
                     raise ValueError(
                         f"'process_every_field' == True is allowed only when all fields which have mappers, i.e., {list(self.mappers.keys())} are lists. Instace = {instance}"
                     )
-                if isinstance(value, list):
-                    if self.process_every_value:
-                        for i, val in enumerate(value):
-                            val = str(val)  # make sure the value is a string
-                            if self.strict and (val not in mapper):
-                                raise KeyError(
-                                    f"value '{val}' in instance '{instance}' is not found in mapper '{mapper}', associated with field '{key}'."
-                                )
-                            if val in mapper:
-                                # replace just that member of value (value is a list)
-                                value[i] = mapper[val]
-                                dict_set(instance, key, value, use_dpath=self.use_query)
-                    else:  # field is a list, and process_every_value == False
-                        if self.strict:  # whole lists can not be mapped by a string-to-something mapper
+                if isinstance(value, list) and self.process_every_value:
+                    for i, val in enumerate(value):
+                        val = str(val)  # make sure the value is a string
+                        if self.strict and (val not in mapper):
                             raise KeyError(
-                                f"A whole list ({value}) in the instance can not be mapped by a field mapper."
+                                f"value '{val}' in instance '{instance}' is not found in mapper '{mapper}', associated with field '{key}'."
                             )
-                else:  # value is not a list, implying process_every_value == False
+                        if val in mapper:
+                            # replace just that member of value (value is a list)
+                            value[i] = mapper[val]
+                            dict_set(instance, key, value, use_dpath=self.use_query)
+                else:
                     value = str(value)  # make sure the value is a string
                     if self.strict and (value not in mapper):
                         raise KeyError(
                             f"value '{value}' in instance '{instance}' is not found in mapper '{mapper}', associated with field '{key}'."
                         )
                     if value in mapper:
-                        dict_set(instance, key, mapper[value], use_dpath=self.use_query)
+                        # By default deep copy the value in mapper to avoid shared modifications
+                        dict_set(
+                            instance,
+                            key,
+                            deepcopy(mapper[value]),
+                            use_dpath=self.use_query,
+                        )
 
         return instance
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -111,31 +111,21 @@ class TestOperators(unittest.TestCase):
             exception_text="Error processing instance '0' from stream 'test' in MapInstanceValues due to: \"value '3' in instance '{'a': ['hi', 'bye', 3, 4], 'b': 2}' is not found in mapper '{'1': 'hi', '2': 'bye'}', associated with field 'a'.\"",
             tester=self,
         )
-
-        # input list can not be ignored with strict=True, and process_every_value=False
-        check_operator_exception(
-            operator=MapInstanceValues(
-                mappers=mappers, strict=True, process_every_value=False
-            ),
-            inputs=[{"a": [1, 2, 3, 4], "b": 2}],
-            exception_text="Error processing instance '0' from stream 'test' in MapInstanceValues due to: 'A whole list ([1, 2, 3, 4]) in the instance can not be mapped by a field mapper.'",
-            tester=self,
-        )
-
+        # Test mapping of lists to lists
         inputs_not_process_every_value = [
             {"a": [1, 2, 3, 4], "b": 2},
-            {"a": 2, "b": 3},
+            {"a": [], "b": 3},
         ]
 
         targets_not_process_every_value = [
-            {"a": [1, 2, 3, 4], "b": 2},
-            {"a": "bye", "b": 3},
+            {"a": ["All"], "b": 2},
+            {"a": ["None"], "b": 3},
         ]
 
-        # with strict=False, and process_every_value=False, lists are ignored
+        list_mappers = {"a": {str([1, 2, 3, 4]): ["All"], "[]": ["None"]}}
         check_operator(
             operator=MapInstanceValues(
-                mappers=mappers, process_every_value=False, strict=False
+                mappers=list_mappers, process_every_value=False, strict=False
             ),
             inputs=inputs_not_process_every_value,
             targets=targets_not_process_every_value,


### PR DESCRIPTION
In recent change, mapping of list was not supported .  This prevented valid uses cases such as mapping [] to ['None']/

This is a fix for this.

Also ensured that mapper values are deep copied to prevent overwritten .