### PR TITLE
Support random generators that are independent of previous randomizations

### DIFF
--- a/src/unitxt/random_utils.py
+++ b/src/unitxt/random_utils.py
@@ -36,6 +36,16 @@ def get_random_string(length):
     return "".join(get_random().choice(letters) for _ in range(length))
 
 
+def get_sub_default_random_generator(sub_seed: str):
+    """Get a generator based on a seed derived from the default seed.
+
+    The purpose is to have a random generator that provides outputs
+    that are independent of previous randomizations.
+    """
+    sub_default_seed = str(__default_seed__) + "/" + sub_seed
+    return python_random.Random(sub_default_seed)
+
+
 @contextlib.contextmanager
 def nested_seed(sub_seed=None):
     old_state = get_random().getstate()

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -108,7 +108,9 @@ class RandomSampler(Sampler):
 
     def prepare(self):
         super().prepare()
-        self.random_generator = get_sub_default_random_generator("lkdjfsa")
+        self.random_generator = get_sub_default_random_generator(
+            sub_seed="random_sample_seed"
+        )
 
     def sample(
         self, instances_pool: List[Dict[str, object]]

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -1,10 +1,11 @@
 import itertools
 from abc import abstractmethod
+from random import Random
 from typing import Dict, List
 
 from .artifact import Artifact
 from .operator import InstanceOperatorWithMultiStreamAccess, MultiStreamOperator
-from .random_utils import get_random
+from .random_utils import get_random, get_sub_default_random_generator
 from .split_utils import (
     parse_random_mix_string,
     parse_slices_string,
@@ -103,11 +104,17 @@ class Sampler(Artifact):
 
 
 class RandomSampler(Sampler):
+    random_generator: Random = None
+
+    def prepare(self):
+        super().prepare()
+        self.random_generator = get_sub_default_random_generator("lkdjfsa")
+
     def sample(
         self, instances_pool: List[Dict[str, object]]
     ) -> List[Dict[str, object]]:
         instances_pool = list(instances_pool)
-        return get_random().sample(instances_pool, self.sample_size)
+        return self.random_generator.sample(instances_pool, self.sample_size)
 
 
 class DiverseLabelsSampler(Sampler):

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -1,11 +1,23 @@
 import random as python_random
 import unittest
 
-from src.unitxt.random_utils import __default_seed__, get_random, nested_seed, set_seed
+from src.unitxt.random_utils import (
+    __default_seed__,
+    get_random,
+    get_sub_default_random_generator,
+    nested_seed,
+    set_seed,
+)
 
 
 def first_randomization():
-    return tuple(get_random().randint(0, 10000000000000000000000) for _ in range(100))
+    return randomize(get_random())
+
+
+def randomize(random_generator):
+    return tuple(
+        random_generator.randint(0, 10000000000000000000000) for _ in range(100)
+    )
 
 
 class TestRandomUtils(unittest.TestCase):
@@ -28,6 +40,21 @@ class TestRandomUtils(unittest.TestCase):
             b = first_randomization()
 
         self.assertNotEqual(a, b)
+
+    def compare_get_sub_default_random_generator_with_same_seed(self, sub_seed: str):
+        rand1 = get_sub_default_random_generator(sub_seed=sub_seed)
+        rand2 = get_sub_default_random_generator(sub_seed=sub_seed)
+        self.assertEqual(randomize(rand1), randomize(rand2))
+
+    def test_get_sub_default_random_generator(self):
+        self.compare_get_sub_default_random_generator_with_same_seed(sub_seed="a")
+        with nested_seed():
+            self.compare_get_sub_default_random_generator_with_same_seed(sub_seed="b")
+        with nested_seed():
+            with nested_seed():
+                self.compare_get_sub_default_random_generator_with_same_seed(
+                    sub_seed="c"
+                )
 
     def test_nested_level_similarity(self):
         with nested_seed():


### PR DESCRIPTION
Added a new option to create random generators that depend only on the default seed and a provided sub seed.

Modify RandomSampler to use such random generators.