### PR TITLE
deep copy at extract_field_values, in order to allow the same input m…

### DIFF
--- a/prepare/cards/sst2.py
+++ b/prepare/cards/sst2.py
@@ -1,6 +1,6 @@
 from src.unitxt.blocks import LoadHF, MapInstanceValues, TaskCard
 from src.unitxt.catalog import add_to_catalog
-from src.unitxt.operators import AddFields, ExtractFieldValues, RenameFields
+from src.unitxt.operators import AddFields, ExtractMostCommonFieldValues, RenameFields
 from src.unitxt.test_utils.card import test_card
 
 card = TaskCard(
@@ -15,7 +15,9 @@ card = TaskCard(
                 "type_of_class": "sentiment",
             }
         ),
-        ExtractFieldValues(field="label", to_field="classes", stream_name="train"),
+        ExtractMostCommonFieldValues(
+            field="label", to_field="classes", stream_name="train"
+        ),
     ],
     task="tasks.classification.multi_class",
     templates="templates.classification.multi_class.all",

--- a/prepare/cards/sst2.py
+++ b/prepare/cards/sst2.py
@@ -1,6 +1,6 @@
 from src.unitxt.blocks import LoadHF, MapInstanceValues, TaskCard
 from src.unitxt.catalog import add_to_catalog
-from src.unitxt.operators import AddFields, ExtractMostCommonFieldValues, RenameFields
+from src.unitxt.operators import AddFields, ExtractFieldValues, RenameFields
 from src.unitxt.test_utils.card import test_card
 
 card = TaskCard(
@@ -15,9 +15,7 @@ card = TaskCard(
                 "type_of_class": "sentiment",
             }
         ),
-        ExtractMostCommonFieldValues(
-            field="label", to_field="classes", stream_name="train"
-        ),
+        ExtractFieldValues(field="label", to_field="classes", stream_name="train"),
     ],
     task="tasks.classification.multi_class",
     templates="templates.classification.multi_class.all",

--- a/prepare/cards/sst2.py
+++ b/prepare/cards/sst2.py
@@ -1,6 +1,6 @@
 from src.unitxt.blocks import LoadHF, MapInstanceValues, TaskCard
 from src.unitxt.catalog import add_to_catalog
-from src.unitxt.operators import AddFields, RenameFields
+from src.unitxt.operators import AddFields, ExtractFieldValues, RenameFields
 from src.unitxt.test_utils.card import test_card
 
 card = TaskCard(
@@ -11,11 +11,11 @@ card = TaskCard(
         RenameFields(field="sentence", to_field="text"),
         AddFields(
             fields={
-                "classes": ["negative", "positive"],
                 "text_type": "sentence",
                 "type_of_class": "sentiment",
             }
         ),
+        ExtractFieldValues(field="label", to_field="classes", stream_name="train"),
     ],
     task="tasks.classification.multi_class",
     templates="templates.classification.multi_class.all",

--- a/src/unitxt/catalog/cards/sst2.json
+++ b/src/unitxt/catalog/cards/sst2.json
@@ -24,13 +24,15 @@
         {
             "type": "add_fields",
             "fields": {
-                "classes": [
-                    "negative",
-                    "positive"
-                ],
                 "text_type": "sentence",
                 "type_of_class": "sentiment"
             }
+        },
+        {
+            "type": "extract_field_values",
+            "field": "label",
+            "to_field": "classes",
+            "stream_name": "train"
         }
     ],
     "task": "tasks.classification.multi_class",

--- a/src/unitxt/catalog/cards/sst2.json
+++ b/src/unitxt/catalog/cards/sst2.json
@@ -29,7 +29,7 @@
             }
         },
         {
-            "type": "extract_most_common_field_values",
+            "type": "extract_field_values",
             "field": "label",
             "to_field": "classes",
             "stream_name": "train"

--- a/src/unitxt/catalog/cards/sst2.json
+++ b/src/unitxt/catalog/cards/sst2.json
@@ -29,7 +29,7 @@
             }
         },
         {
-            "type": "extract_field_values",
+            "type": "extract_most_common_field_values",
             "field": "label",
             "to_field": "classes",
             "stream_name": "train"

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -971,21 +971,6 @@ class FilterByValues(SingleStreamOperator):
                 yield instance
 
 
-class AddFieldValues(SingleStreamOperator):
-    """Adds fields and their values to all instances of a stream.
-
-    Args: fields_values : the fields and their respective vaulues to add to each instance in the stream
-    """
-
-    fields_values: Dict[str, Any]
-
-    def process(self, stream: Stream, stream_name: Optional[str] = None):
-        for instance in stream:
-            for f, v in self.fields_values.items():
-                instance[f] = v
-            yield instance
-
-
 class ExtractMostCommonFieldValues(MultiStreamOperator):
     field: str
     stream_name: str
@@ -1083,7 +1068,7 @@ class ExtractMostCommonFieldValues(MultiStreamOperator):
             for ele in values_and_counts
         ]
 
-        addmostcommons = AddFieldValues(fields_values={self.to_field: values_to_keep})
+        addmostcommons = AddFields(fields={self.to_field: values_to_keep})
         return addmostcommons(multi_stream)
 
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1087,6 +1087,15 @@ class ExtractMostCommonFieldValues(MultiStreamOperator):
         return addmostcommons(multi_stream)
 
 
+class ExtractFieldValues(ExtractMostCommonFieldValues):
+    def verify(self):
+        super().verify()
+
+    def prepare(self):
+        self.overall_top_frequency_percent = 100
+        self.min_frequency_percent = 0
+
+
 class FilterByListsOfValues(SingleStreamOperator):
     """Filters a stream, yielding only instances that  whose field values are included in the specified value lists.
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1048,13 +1048,13 @@ class ExtractFieldValues(MultiStreamOperator):
             [*ele[0]] if isinstance(ele[0], tuple) else ele[0]
             for ele in values_and_counts
         ]
-        multi_stream_to_return = {}
+        add_field_operator = AddFields(
+            fields={self.to_field: values_to_keep}, use_query=False, use_deepcopy=True
+        )
         for name in multi_stream:
-            multi_stream_to_return[name] = []
             for instance in multi_stream[name]:
-                instance[self.to_field] = values_to_keep
-                multi_stream_to_return[name].append(deepcopy(instance))
-        return multi_stream_to_return
+                add_field_operator.process(instance)
+        return multi_stream
 
 
 class FilterByListsOfValues(SingleStreamOperator):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1029,10 +1029,13 @@ class ExtractFieldValues(MultiStreamOperator):
             [*ele[0]] if isinstance(ele[0], tuple) else ele[0]
             for ele in values_and_counts
         ]
+        multi_stream_to_return = {}
         for name in multi_stream:
+            multi_stream_to_return[name] = []
             for instance in multi_stream[name]:
                 instance[self.to_field] = values_to_keep
-        return multi_stream
+                multi_stream_to_return[name].append(deepcopy(instance))
+        return multi_stream_to_return
 
 
 class FilterByListsOfValues(SingleStreamOperator):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1083,17 +1083,8 @@ class ExtractFieldValues(MultiStreamOperator):
             for ele in values_and_counts
         ]
 
-        multi_stream_to_return = {}
-        addmostcommon_stream_operator = AddFieldValues(
-            fields_values={self.to_field: values_to_keep}
-        )
-        for stream_name, stream in multi_stream.items():
-            updated_stream = addmostcommon_stream_operator._process_single_stream(
-                stream
-            )
-            multi_stream_to_return[stream_name] = updated_stream
-
-        return MultiStream(multi_stream_to_return)
+        addmostcommons = AddFieldValues(fields_values={self.to_field: values_to_keep})
+        return addmostcommons(multi_stream)
 
 
 class FilterByListsOfValues(SingleStreamOperator):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1007,21 +1007,21 @@ class ExtractMostCommonFieldValues(MultiStreamOperator):
 
     Examples:
 
-    ExtractFieldValues(stream_name="train", field="label", to_field="classes") - extracts all the unique values of
+    ExtractMostCommonFieldValues(stream_name="train", field="label", to_field="classes") - extracts all the unique values of
     field 'label', sorts them by decreasing frequency, and stores the resulting list in field 'classes' of each and
     every instance in all streams.
 
-    ExtractFieldValues(stream_name="train", field="labels", to_field="classes", process_every_value=True) -
+    ExtractMostCommonFieldValues(stream_name="train", field="labels", to_field="classes", process_every_value=True) -
     in case that field 'labels' contains a list of values (and not a single value) - track the occurrences of all the possible
     value members in these lists, and report the most frequent values.
     if process_every_value=False, track the most frequent whole lists, and report those (as a list of lists) in field
     'to_field' of each instance of all streams.
 
-    ExtractFieldValues(stream_name="train", field="label", to_field="classes",overall_top_frequency_percent=80) -
+    ExtractMostCommonFieldValues(stream_name="train", field="label", to_field="classes",overall_top_frequency_percent=80) -
     extracts the most frequent possible values of field 'label' that together cover at least 80% of the instances of stream_name,
     and stores them in field 'classes' of each instance of all streams.
 
-    ExtractFieldValues(stream_name="train", field="label", to_field="classes",min_frequency_percent=5) -
+    ExtractMostCommonFieldValues(stream_name="train", field="label", to_field="classes",min_frequency_percent=5) -
     extracts all possible values of field 'label' that cover, each, at least 5% of the instances.
     Stores these values, sorted by decreasing order of frequency, in field 'classes' of each instance in all streams.
     """

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -952,6 +952,21 @@ class FilterByValues(SingleStreamOperator):
                 yield instance
 
 
+class AddFieldValues(SingleStreamOperator):
+    """Adds fields and their values to all instances of a stream.
+
+    Args: fields_values : the fields and their respective vaulues to add to each instance in the stream
+    """
+
+    fields_values: Dict[str, Any]
+
+    def process(self, stream: Stream, stream_name: Optional[str] = None):
+        for instance in stream:
+            for f, v in self.fields_values.items():
+                instance[f] = v
+            yield instance
+
+
 class ExtractFieldValues(MultiStreamOperator):
     field: str
     stream_name: str
@@ -1048,13 +1063,18 @@ class ExtractFieldValues(MultiStreamOperator):
             [*ele[0]] if isinstance(ele[0], tuple) else ele[0]
             for ele in values_and_counts
         ]
-        add_field_operator = AddFields(
-            fields={self.to_field: values_to_keep}, use_query=False, use_deepcopy=True
+
+        multi_stream_to_return = {}
+        addmostcommon_stream_operator = AddFieldValues(
+            fields_values={self.to_field: values_to_keep}
         )
-        for name in multi_stream:
-            for instance in multi_stream[name]:
-                add_field_operator.process(instance)
-        return multi_stream
+        for stream_name, stream in multi_stream.items():
+            updated_stream = addmostcommon_stream_operator._process_single_stream(
+                stream
+            )
+            multi_stream_to_return[stream_name] = updated_stream
+
+        return MultiStream(multi_stream_to_return)
 
 
 class FilterByListsOfValues(SingleStreamOperator):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -986,7 +986,7 @@ class AddFieldValues(SingleStreamOperator):
             yield instance
 
 
-class ExtractFieldValues(MultiStreamOperator):
+class ExtractMostCommonFieldValues(MultiStreamOperator):
     field: str
     stream_name: str
     overall_top_frequency_percent: Optional[int] = 100

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -684,27 +684,27 @@ class TestOperators(unittest.TestCase):
         output_multi_stream1 = ExtractFieldValues(
             stream_name="train",
             field="animal",
-            to_field="most_common_animals",
+            to_field="most_common_animals1",
             overall_top_frequency_percent=80,
         ).process(input_multi_stream1)
         expected_output1 = {
             "test": [
-                {"animal": "shark", "most_common_animals": ["dog", "cat", "fish"]}
+                {"animal": "shark", "most_common_animals1": ["dog", "cat", "fish"]}
             ],
             "validation": [
-                {"animal": "cat", "most_common_animals": ["dog", "cat", "fish"]}
+                {"animal": "cat", "most_common_animals1": ["dog", "cat", "fish"]}
             ],
             "train": [
-                {"animal": "fish", "most_common_animals": ["dog", "cat", "fish"]},
-                {"animal": "dog", "most_common_animals": ["dog", "cat", "fish"]},
-                {"animal": "dog", "most_common_animals": ["dog", "cat", "fish"]},
-                {"animal": "cat", "most_common_animals": ["dog", "cat", "fish"]},
-                {"animal": "dog", "most_common_animals": ["dog", "cat", "fish"]},
-                {"animal": "cat", "most_common_animals": ["dog", "cat", "fish"]},
-                {"animal": "sheep", "most_common_animals": ["dog", "cat", "fish"]},
-                {"animal": "cat", "most_common_animals": ["dog", "cat", "fish"]},
-                {"animal": "fish", "most_common_animals": ["dog", "cat", "fish"]},
-                {"animal": "shark", "most_common_animals": ["dog", "cat", "fish"]},
+                {"animal": "fish", "most_common_animals1": ["dog", "cat", "fish"]},
+                {"animal": "dog", "most_common_animals1": ["dog", "cat", "fish"]},
+                {"animal": "dog", "most_common_animals1": ["dog", "cat", "fish"]},
+                {"animal": "cat", "most_common_animals1": ["dog", "cat", "fish"]},
+                {"animal": "dog", "most_common_animals1": ["dog", "cat", "fish"]},
+                {"animal": "cat", "most_common_animals1": ["dog", "cat", "fish"]},
+                {"animal": "sheep", "most_common_animals1": ["dog", "cat", "fish"]},
+                {"animal": "cat", "most_common_animals1": ["dog", "cat", "fish"]},
+                {"animal": "fish", "most_common_animals1": ["dog", "cat", "fish"]},
+                {"animal": "shark", "most_common_animals1": ["dog", "cat", "fish"]},
             ],
         }
         self.assertDictEqual(
@@ -719,23 +719,75 @@ class TestOperators(unittest.TestCase):
         output_multi_stream2 = ExtractFieldValues(
             stream_name="train",
             field="animal",
-            to_field="most_common_animals",
+            to_field="most_common_animals2",
             min_frequency_percent=25,
         ).process(input_multi_stream1)
         expected_output2 = {
-            "test": [{"animal": "shark", "most_common_animals": ["dog", "cat"]}],
-            "validation": [{"animal": "cat", "most_common_animals": ["dog", "cat"]}],
+            "test": [
+                {
+                    "animal": "shark",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                }
+            ],
+            "validation": [
+                {
+                    "animal": "cat",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                }
+            ],
             "train": [
-                {"animal": "fish", "most_common_animals": ["dog", "cat"]},
-                {"animal": "dog", "most_common_animals": ["dog", "cat"]},
-                {"animal": "dog", "most_common_animals": ["dog", "cat"]},
-                {"animal": "cat", "most_common_animals": ["dog", "cat"]},
-                {"animal": "dog", "most_common_animals": ["dog", "cat"]},
-                {"animal": "cat", "most_common_animals": ["dog", "cat"]},
-                {"animal": "sheep", "most_common_animals": ["dog", "cat"]},
-                {"animal": "cat", "most_common_animals": ["dog", "cat"]},
-                {"animal": "fish", "most_common_animals": ["dog", "cat"]},
-                {"animal": "shark", "most_common_animals": ["dog", "cat"]},
+                {
+                    "animal": "fish",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
+                {
+                    "animal": "dog",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
+                {
+                    "animal": "dog",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
+                {
+                    "animal": "cat",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
+                {
+                    "animal": "dog",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
+                {
+                    "animal": "cat",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
+                {
+                    "animal": "sheep",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
+                {
+                    "animal": "cat",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
+                {
+                    "animal": "fish",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
+                {
+                    "animal": "shark",
+                    "most_common_animals1": ["dog", "cat", "fish"],
+                    "most_common_animals2": ["dog", "cat"],
+                },
             ],
         }
         self.assertDictEqual(
@@ -745,15 +797,6 @@ class TestOperators(unittest.TestCase):
             + json.dumps(expected_output2)
             + "\n but instead, received: \n"
             + json.dumps(output_multi_stream2),
-        )
-        ## is output_multi_stream1 stable or on ice?
-        self.assertDictEqual(
-            output_multi_stream1,
-            expected_output1,
-            "expected to see: \n"
-            + json.dumps(expected_output1)
-            + "\n but instead, received: \n"
-            + json.dumps(output_multi_stream1),
         )
         # with list values
         input_multi_stream2 = MultiStream(
@@ -797,10 +840,10 @@ class TestOperators(unittest.TestCase):
             }
         )
         # with lists, treated as single elements
-        output_multi_stream = ExtractFieldValues(
+        output_multi_stream3 = ExtractFieldValues(
             stream_name="train",
             field="field",
-            to_field="most_common_lists",
+            to_field="most_common_lists3",
             overall_top_frequency_percent=90,
             process_every_value=False,
         ).process(input_multi_stream2)
@@ -809,7 +852,7 @@ class TestOperators(unittest.TestCase):
             "test": [
                 {
                     "field": ["a", "b", "c"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -820,7 +863,7 @@ class TestOperators(unittest.TestCase):
             "validation": [
                 {
                     "field": ["d", "e", "f"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -831,7 +874,7 @@ class TestOperators(unittest.TestCase):
             "train": [
                 {
                     "field": ["t", "u", "v"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -840,7 +883,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["h", "i", "j"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -849,7 +892,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["k", "h", "m"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -858,7 +901,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["m", "o", "p"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -867,7 +910,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["m", "o", "p"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -876,7 +919,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["h", "i", "j"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -885,7 +928,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["q", "r", "s"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -894,7 +937,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["k", "h", "m"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -903,7 +946,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["h", "i", "j"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -912,7 +955,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["q", "r", "s"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -921,7 +964,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["k", "h", "m"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -930,7 +973,7 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["m", "o", "p"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
@@ -941,19 +984,19 @@ class TestOperators(unittest.TestCase):
         }
 
         self.assertDictEqual(
-            output_multi_stream,
+            output_multi_stream3,
             expected_output3,
             "expected to see: \n"
             + json.dumps(expected_output3)
             + "\n but instead, received: \n"
-            + json.dumps(output_multi_stream),
+            + json.dumps(output_multi_stream3),
         )
 
         # finally, with lists and with process_every_value=True
-        output_multi_stream = ExtractFieldValues(
+        output_multi_stream4 = ExtractFieldValues(
             stream_name="train",
             field="field",
-            to_field="most_common_individuals",
+            to_field="most_common_individuals4",
             overall_top_frequency_percent=90,
             process_every_value=True,
         ).process(input_multi_stream2)
@@ -962,13 +1005,13 @@ class TestOperators(unittest.TestCase):
             "test": [
                 {
                     "field": ["a", "b", "c"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -985,13 +1028,13 @@ class TestOperators(unittest.TestCase):
             "validation": [
                 {
                     "field": ["d", "e", "f"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1008,13 +1051,13 @@ class TestOperators(unittest.TestCase):
             "train": [
                 {
                     "field": ["t", "u", "v"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1029,13 +1072,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["h", "i", "j"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1050,13 +1093,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["k", "h", "m"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1071,13 +1114,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["m", "o", "p"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1092,13 +1135,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["m", "o", "p"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1113,13 +1156,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["h", "i", "j"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1134,13 +1177,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["q", "r", "s"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1155,13 +1198,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["k", "h", "m"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1176,13 +1219,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["h", "i", "j"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1197,13 +1240,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["q", "r", "s"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1218,13 +1261,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["k", "h", "m"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1239,13 +1282,13 @@ class TestOperators(unittest.TestCase):
                 },
                 {
                     "field": ["m", "o", "p"],
-                    "most_common_lists": [
+                    "most_common_lists3": [
                         ["h", "i", "j"],
                         ["k", "h", "m"],
                         ["m", "o", "p"],
                         ["q", "r", "s"],
                     ],
-                    "most_common_individuals": [
+                    "most_common_individuals4": [
                         "h",
                         "m",
                         "i",
@@ -1261,16 +1304,16 @@ class TestOperators(unittest.TestCase):
             ],
         }
         self.assertDictEqual(
-            output_multi_stream,
+            output_multi_stream4,
             expected_output4,
             "expected to see: \n"
             + json.dumps(expected_output4)
             + "\n but instead, received: \n"
-            + json.dumps(output_multi_stream),
+            + json.dumps(output_multi_stream4),
         )
-
+        # test error cases
         with self.assertRaises(ValueError):
-            output_multi_stream = ExtractFieldValues(
+            ExtractFieldValues(
                 stream_name="train",
                 field="animal",
                 to_field="most_common_individuals",
@@ -1279,7 +1322,7 @@ class TestOperators(unittest.TestCase):
             ).process(input_multi_stream1)
 
         with self.assertRaises(AssertionError):
-            output_multi_stream = ExtractFieldValues(
+            ExtractFieldValues(
                 stream_name="train",
                 field="animal",
                 to_field="most_common_individuals",
@@ -1287,14 +1330,14 @@ class TestOperators(unittest.TestCase):
                 min_frequency_percent=25,
             ).process(input_multi_stream1)
         with self.assertRaises(AssertionError):
-            output_multi_stream = ExtractFieldValues(
+            ExtractFieldValues(
                 stream_name="train",
                 field="animal",
                 to_field="most_common_individuals",
                 overall_top_frequency_percent=120,
             ).process(input_multi_stream1)
         with self.assertRaises(AssertionError):
-            output_multi_stream = ExtractFieldValues(
+            ExtractFieldValues(
                 stream_name="train",
                 field="animal",
                 to_field="most_common_individuals",

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -16,6 +16,7 @@ from src.unitxt.operators import (
     CopyFields,
     DeterministicBalancer,
     EncodeLabels,
+    ExtractFieldValues,
     ExtractMostCommonFieldValues,
     FieldOperator,
     FilterByListsOfValues,
@@ -663,6 +664,88 @@ class TestOperators(unittest.TestCase):
         self.compare_streams(merged, expected_merged)
 
     def test_extract_values(self):
+        input_multi_stream1 = MultiStream(
+            {
+                "test": [{"animal": "shark"}],
+                "validation": [{"animal": "cat"}],
+                "train": [
+                    {"animal": "fish"},
+                    {"animal": "dog"},
+                    {"animal": "cat"},
+                    {"animal": "dog"},
+                    {"animal": "cat"},
+                    {"animal": "sheep"},
+                    {"animal": "fish"},
+                    {"animal": "shark"},
+                ],
+            }
+        )
+        output_multi_stream1 = ExtractFieldValues(
+            stream_name="train",
+            field="animal",
+            to_field="all_animals1",
+        ).process(input_multi_stream1)
+        output_for_comparison1 = {}
+        for k, v in output_multi_stream1.items():
+            output_for_comparison1[k] = list(v)
+        expected_output1 = {
+            "test": [
+                {
+                    "animal": "shark",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                }
+            ],
+            "validation": [
+                {
+                    "animal": "cat",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                }
+            ],
+            "train": [
+                {
+                    "animal": "fish",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                },
+                {
+                    "animal": "dog",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                },
+                {
+                    "animal": "cat",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                },
+                {
+                    "animal": "dog",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                },
+                {
+                    "animal": "cat",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                },
+                {
+                    "animal": "sheep",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                },
+                {
+                    "animal": "fish",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                },
+                {
+                    "animal": "shark",
+                    "all_animals1": ["fish", "dog", "cat", "sheep", "shark"],
+                },
+            ],
+        }
+        self.assertDictEqual(
+            output_for_comparison1,
+            expected_output1,
+            "expected to see: \n"
+            + json.dumps(expected_output1)
+            + "\n but instead, received: \n"
+            + json.dumps(output_for_comparison1),
+        )
+
+    def test_extract_most_common_values(self):
         input_multi_stream1 = MultiStream(
             {
                 "test": [{"animal": "shark"}],

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -681,7 +681,7 @@ class TestOperators(unittest.TestCase):
                 ],
             }
         )
-        output_multi_stream = ExtractFieldValues(
+        output_multi_stream1 = ExtractFieldValues(
             stream_name="train",
             field="animal",
             to_field="most_common_animals",
@@ -708,15 +708,15 @@ class TestOperators(unittest.TestCase):
             ],
         }
         self.assertDictEqual(
-            output_multi_stream,
+            output_multi_stream1,
             expected_output1,
             "expected to see: \n"
             + json.dumps(expected_output1)
             + "\n but instead, received: \n"
-            + json.dumps(output_multi_stream),
+            + json.dumps(output_multi_stream1),
         )
         # with minimum frequency limit
-        output_multi_stream = ExtractFieldValues(
+        output_multi_stream2 = ExtractFieldValues(
             stream_name="train",
             field="animal",
             to_field="most_common_animals",
@@ -739,12 +739,21 @@ class TestOperators(unittest.TestCase):
             ],
         }
         self.assertDictEqual(
-            output_multi_stream,
+            output_multi_stream2,
             expected_output2,
             "expected to see: \n"
             + json.dumps(expected_output2)
             + "\n but instead, received: \n"
-            + json.dumps(output_multi_stream),
+            + json.dumps(output_multi_stream2),
+        )
+        ## is output_multi_stream1 stable or on ice?
+        self.assertDictEqual(
+            output_multi_stream1,
+            expected_output1,
+            "expected to see: \n"
+            + json.dumps(expected_output1)
+            + "\n but instead, received: \n"
+            + json.dumps(output_multi_stream1),
         )
         # with list values
         input_multi_stream2 = MultiStream(

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -16,7 +16,7 @@ from src.unitxt.operators import (
     CopyFields,
     DeterministicBalancer,
     EncodeLabels,
-    ExtractFieldValues,
+    ExtractMostCommonFieldValues,
     FieldOperator,
     FilterByListsOfValues,
     FilterByValues,
@@ -681,7 +681,7 @@ class TestOperators(unittest.TestCase):
                 ],
             }
         )
-        output_multi_stream1 = ExtractFieldValues(
+        output_multi_stream1 = ExtractMostCommonFieldValues(
             stream_name="train",
             field="animal",
             to_field="most_common_animals1",
@@ -719,7 +719,7 @@ class TestOperators(unittest.TestCase):
             + json.dumps(output_for_comparison1),
         )
         # with minimum frequency limit
-        output_multi_stream2 = ExtractFieldValues(
+        output_multi_stream2 = ExtractMostCommonFieldValues(
             stream_name="train",
             field="animal",
             to_field="most_common_animals2",
@@ -846,7 +846,7 @@ class TestOperators(unittest.TestCase):
             }
         )
         # with lists, treated as single elements
-        output_multi_stream3 = ExtractFieldValues(
+        output_multi_stream3 = ExtractMostCommonFieldValues(
             stream_name="train",
             field="field",
             to_field="most_common_lists3",
@@ -1001,7 +1001,7 @@ class TestOperators(unittest.TestCase):
         )
 
         # finally, with lists and with process_every_value=True
-        output_multi_stream4 = ExtractFieldValues(
+        output_multi_stream4 = ExtractMostCommonFieldValues(
             stream_name="train",
             field="field",
             to_field="most_common_individuals4",
@@ -1323,7 +1323,7 @@ class TestOperators(unittest.TestCase):
         )
         # test error cases
         with self.assertRaises(ValueError):
-            ExtractFieldValues(
+            ExtractMostCommonFieldValues(
                 stream_name="train",
                 field="animal",
                 to_field="most_common_individuals",
@@ -1332,7 +1332,7 @@ class TestOperators(unittest.TestCase):
             ).process(input_multi_stream1)
 
         with self.assertRaises(AssertionError):
-            ExtractFieldValues(
+            ExtractMostCommonFieldValues(
                 stream_name="train",
                 field="animal",
                 to_field="most_common_individuals",
@@ -1340,14 +1340,14 @@ class TestOperators(unittest.TestCase):
                 min_frequency_percent=25,
             ).process(input_multi_stream1)
         with self.assertRaises(AssertionError):
-            ExtractFieldValues(
+            ExtractMostCommonFieldValues(
                 stream_name="train",
                 field="animal",
                 to_field="most_common_individuals",
                 overall_top_frequency_percent=120,
             ).process(input_multi_stream1)
         with self.assertRaises(AssertionError):
-            ExtractFieldValues(
+            ExtractMostCommonFieldValues(
                 stream_name="train",
                 field="animal",
                 to_field="most_common_individuals",

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -687,6 +687,9 @@ class TestOperators(unittest.TestCase):
             to_field="most_common_animals1",
             overall_top_frequency_percent=80,
         ).process(input_multi_stream1)
+        output_for_comparison1 = {}
+        for k, v in output_multi_stream1.items():
+            output_for_comparison1[k] = list(v)
         expected_output1 = {
             "test": [
                 {"animal": "shark", "most_common_animals1": ["dog", "cat", "fish"]}
@@ -708,12 +711,12 @@ class TestOperators(unittest.TestCase):
             ],
         }
         self.assertDictEqual(
-            output_multi_stream1,
+            output_for_comparison1,
             expected_output1,
             "expected to see: \n"
             + json.dumps(expected_output1)
             + "\n but instead, received: \n"
-            + json.dumps(output_multi_stream1),
+            + json.dumps(output_for_comparison1),
         )
         # with minimum frequency limit
         output_multi_stream2 = ExtractFieldValues(
@@ -722,6 +725,9 @@ class TestOperators(unittest.TestCase):
             to_field="most_common_animals2",
             min_frequency_percent=25,
         ).process(input_multi_stream1)
+        output_for_comparison2 = {}
+        for k, v in output_multi_stream2.items():
+            output_for_comparison2[k] = list(v)
         expected_output2 = {
             "test": [
                 {
@@ -791,12 +797,12 @@ class TestOperators(unittest.TestCase):
             ],
         }
         self.assertDictEqual(
-            output_multi_stream2,
+            output_for_comparison2,
             expected_output2,
             "expected to see: \n"
             + json.dumps(expected_output2)
             + "\n but instead, received: \n"
-            + json.dumps(output_multi_stream2),
+            + json.dumps(output_for_comparison2),
         )
         # with list values
         input_multi_stream2 = MultiStream(
@@ -847,7 +853,9 @@ class TestOperators(unittest.TestCase):
             overall_top_frequency_percent=90,
             process_every_value=False,
         ).process(input_multi_stream2)
-
+        output_for_comparison3 = {}
+        for k, v in output_multi_stream3.items():
+            output_for_comparison3[k] = list(v)
         expected_output3 = {
             "test": [
                 {
@@ -984,12 +992,12 @@ class TestOperators(unittest.TestCase):
         }
 
         self.assertDictEqual(
-            output_multi_stream3,
+            output_for_comparison3,
             expected_output3,
             "expected to see: \n"
             + json.dumps(expected_output3)
             + "\n but instead, received: \n"
-            + json.dumps(output_multi_stream3),
+            + json.dumps(output_for_comparison3),
         )
 
         # finally, with lists and with process_every_value=True
@@ -1000,7 +1008,9 @@ class TestOperators(unittest.TestCase):
             overall_top_frequency_percent=90,
             process_every_value=True,
         ).process(input_multi_stream2)
-
+        output_for_comparison4 = {}
+        for k, v in output_multi_stream4.items():
+            output_for_comparison4[k] = list(v)
         expected_output4 = {
             "test": [
                 {
@@ -1304,12 +1314,12 @@ class TestOperators(unittest.TestCase):
             ],
         }
         self.assertDictEqual(
-            output_multi_stream4,
+            output_for_comparison4,
             expected_output4,
             "expected to see: \n"
             + json.dumps(expected_output4)
             + "\n but instead, received: \n"
-            + json.dumps(output_multi_stream4),
+            + json.dumps(output_for_comparison4),
         )
         # test error cases
         with self.assertRaises(ValueError):

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -264,10 +264,10 @@ class TestRecipes(unittest.TestCase):
         stream = recipe()
         sample = list(stream["test"])[1]
         source = sample["source"]
-        pattern = "Classify the sentiment of following sentence to one of these options: negative, positive. Text: (.*)"
+        pattern = "Classify the sentiment of following sentence to one of these options: ((negative, positive)|(positive, negative)). Text: (.*)"
         result = re.match(pattern, sample["source"], re.DOTALL)
         assert result, f"Unable to find '{pattern}' in '{source}'"
-        result = result.group(1)
+        result = result.group(4)
         original_text = "unflinchingly bleak and desperate "
         assert (
             result != original_text


### PR DESCRIPTION
…s to feed different runs of operator extract_field_values, while maintaining all the different outpus.  For [issue 378](https://github.com/IBM/unitxt/issues/378)