### PR TITLE
DiverseLabelsSampler fix

### DIFF
--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -7,18 +7,42 @@ class TestDiverseLabelsSampler(unittest.TestCase):
     """Tests for the DiverseLabelsSampler object."""
 
     @staticmethod
-    def new_examplar(input_choices=None, output_choices=None):
+    def new_examplar(choices=None, labels=None, text=""):
         """Return an examplar in a correct format."""
-        if output_choices is None:
-            output_choices = ["class_a"]
-        if input_choices is None:
-            input_choices = ["class_a", "class_b"]
+        if labels is None:
+            labels = ["class_a"]
+        if choices is None:
+            choices = ["class_a", "class_b"]
         return {
-            "inputs": {"choices": input_choices},
+            "inputs": {"choices": choices, "text": text},
             "outputs": {
-                "choices": output_choices,
+                "labels": labels,
             },
         }
+
+    def test_sample(self):
+        for i in range(3):
+            num_samples = 3
+            sampler = DiverseLabelsSampler(num_samples)
+            choices = ["dog", "cat"]
+            instances = [
+                self.new_examplar(choices, ["dog"], "Bark1"),
+                self.new_examplar(choices, ["dog"], "Bark2"),
+                self.new_examplar(choices, ["cat"], "Cat1"),
+                self.new_examplar(choices, ["dog"], "Bark3"),
+                self.new_examplar(choices, ["cow"], "Moo1"),
+                self.new_examplar(choices, ["duck"], "Quack"),
+            ]
+            result = sampler.sample(instances)
+
+            from collections import Counter
+
+            counts = Counter()
+            for i in range(0, num_samples):
+                counts[result[i]["outputs"]["labels"][0]] += 1
+            self.assertEqual(counts["dog"], 1)
+            self.assertEqual(counts["cat"], 1)
+            self.assertEqual(len(counts.keys()), 3)
 
     def test_examplar_repr(self):
         sampler = DiverseLabelsSampler()
@@ -29,7 +53,7 @@ class TestDiverseLabelsSampler(unittest.TestCase):
     def test_examplar_repr_with_string_for_input_choices(self):
         sampler = DiverseLabelsSampler()
         examplar_input_choices = "a string which is a wrong value"
-        wrong_examplar = self.new_examplar(input_choices=examplar_input_choices)
+        wrong_examplar = self.new_examplar(choices=examplar_input_choices)
         with self.assertRaises(ValueError) as cm:
             sampler.examplar_repr(examplar=wrong_examplar)
         self.assertEqual(


### PR DESCRIPTION
The class assumed there is only one output field which needs to be balanced, and took the first one.
This was not true for NER.  Added an explicit customizable field to select which output field should be used.

Also improved the tests.