### PR TITLE
peek at the first instance

### DIFF
--- a/src/unitxt/metric.py
+++ b/src/unitxt/metric.py
@@ -64,7 +64,7 @@ class MultiStreamScoreMean(MultiStreamOperator):
     def aggegate_results(self, multi_stream: MultiStream):
         scores = []
         for stream in multi_stream.values():
-            instance = stream.peak()
+            instance = stream.peek()
             scores.append(instance["score"]["global"]["score"])
 
         from statistics import mean

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1322,7 +1322,7 @@ class ApplyStreamOperatorsField(SingleStreamOperator, ArtifactFetcherMixin):
     reversed: bool = False
 
     def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
-        first_instance = stream.peak()
+        first_instance = stream.peek()
 
         operators = first_instance.get(self.field, [])
         if isinstance(operators, str):
@@ -1356,7 +1356,7 @@ class ApplyMetric(SingleStreamOperator, ArtifactFetcherMixin):
     def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
         from .metrics import Metric, MetricPipeline, MetricWithConfidenceInterval
 
-        first_instance = stream.peak()
+        first_instance = stream.peek()
 
         metric_names = first_instance.get(self.metric_field, [])
         if not metric_names:

--- a/src/unitxt/stream.py
+++ b/src/unitxt/stream.py
@@ -48,7 +48,7 @@ class Stream(Dataclass):
     def __iter__(self):
         return iter(self._get_stream())
 
-    def peak(self):
+    def peek(self):
         return next(iter(self))
 
     def take(self, n):


### PR DESCRIPTION
In case this is worth the trouble, and/or backward compatible,
the correct verb here is `peek`, rather than `peak`:
https://www.merriam-webster.com/dictionary/peek