### PR TITLE
Improve test card error messages and allow disabling by env variable

### DIFF
--- a/prepare/cards/stsb.py
+++ b/prepare/cards/stsb.py
@@ -34,5 +34,5 @@ card = TaskCard(
     ),
 )
 
-test_card(card)
+test_card(card, strict=False)
 add_to_catalog(card, "cards.stsb", overwrite=True)

--- a/prepare/cards/xlsum.py
+++ b/prepare/cards/xlsum.py
@@ -39,5 +39,5 @@ for lang in langs:
         ),
     )
     if lang == langs[0]:
-        test_card(card, debug=False)
+        test_card(card, debug=False, strict=False)
     add_to_catalog(card, f"cards.xlsum.{lang}", overwrite=True)

--- a/prepare/cards/xlsum.py
+++ b/prepare/cards/xlsum.py
@@ -39,5 +39,5 @@ for lang in langs:
         ),
     )
     if lang == langs[0]:
-        test_card(card, debug=False, strict=False)
+        test_card(card, debug=False)
     add_to_catalog(card, f"cards.xlsum.{lang}", overwrite=True)

--- a/src/unitxt/catalog/cards/cola.json
+++ b/src/unitxt/catalog/cards/cola.json
@@ -17,20 +17,30 @@
             }
         },
         {
+            "type": "rename_fields",
+            "field_to_field": {
+                "sentence": "text"
+            }
+        },
+        {
             "type": "add_fields",
             "fields": {
-                "choices": [
+                "classes": [
                     "unacceptable",
                     "acceptable"
-                ]
+                ],
+                "text_type": "text",
+                "type_of_class": "grammatical acceptability"
             }
         }
     ],
     "task": {
         "type": "form_task",
         "inputs": [
-            "choices",
-            "sentence"
+            "text",
+            "text_type",
+            "classes",
+            "type_of_class"
         ],
         "outputs": [
             "label"
@@ -39,14 +49,5 @@
             "metrics.matthews_correlation"
         ]
     },
-    "templates": {
-        "type": "templates_list",
-        "items": [
-            {
-                "type": "input_output_template",
-                "input_format": "Given this sentence: {sentence}, classify if it is {choices}.",
-                "output_format": "{label}"
-            }
-        ]
-    }
+    "templates": "templates.classification.multi_class.all"
 }

--- a/src/unitxt/catalog/cards/dbpedia_14.json
+++ b/src/unitxt/catalog/cards/dbpedia_14.json
@@ -18,19 +18,19 @@
             "mappers": {
                 "label": {
                     "0": "Company",
-                    "1": "EducationalInstitution",
+                    "1": "Educational Institution",
                     "2": "Artist",
                     "3": "Athlete",
-                    "4": "OfficeHolder",
-                    "5": "MeanOfTransportation",
+                    "4": "Office Holder",
+                    "5": "Mean Of Transportation",
                     "6": "Building",
-                    "7": "NaturalPlace",
+                    "7": "Natural Place",
                     "8": "Village",
                     "9": "Animal",
                     "10": "Plant",
                     "11": "Album",
                     "12": "Film",
-                    "13": "WrittenWork"
+                    "13": "Written Work"
                 }
             }
         },
@@ -45,21 +45,21 @@
             "fields": {
                 "classes": [
                     "Company",
-                    "EducationalInstitution",
+                    "Educational Institution",
                     "Artist",
                     "Athlete",
-                    "OfficeHolder",
-                    "MeanOfTransportation",
+                    "Office Holder",
+                    "Mean Of Transportation",
                     "Building",
-                    "NaturalPlace",
+                    "Natural Place",
                     "Village",
                     "Animal",
                     "Plant",
                     "Album",
                     "Film",
-                    "WrittenWork"
+                    "Written Work"
                 ],
-                "text_type": "text",
+                "text_type": "paragraph",
                 "type_of_class": "topic"
             }
         }

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -177,7 +177,7 @@ def test_with_eval(
         )
         warning_message = (
             f"{message}"
-            f"This is flagged as only as a warning because strict=False was set in the call to test_card()."
+            f"This is flagged as only as a warning because strict=False was set in the call to test_card().\n"
             f"The predictions passed to the metrics were:\n {correct_predictions}\n"
         )
         if strict:
@@ -207,7 +207,7 @@ def test_with_eval(
         )
         warning_message = (
             f"{message}"
-            f"This is flagged as only as a warning because strict=False was set in the call to test_card()."
+            f"This is flagged as only as a warning because strict=False was set in the call to test_card().\n"
             f"The predictions passed to the metrics were:\n {wrong_predictions}\n"
         )
         if strict:

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -201,7 +201,7 @@ def test_with_eval(
         error_message = (
             f"{message}"
             f"This can indicates an error in the metric or post processors, but can be also an acceptable edge case.\n"
-            f"For example, in a metric that checks character level edit distance, a low none zero score is expected on random data"
+            f"For example, in a metric that checks character level edit distance, a low none zero score is expected on random data.\n"
             f"In anycase, this requires a review.  If this is acceptable, set strict=False in the call to test_card().\n"
             f"The predictions passed to the metrics were:\n {wrong_predictions}\n"
         )

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -196,7 +196,7 @@ def test_with_eval(
         message = (
             f"The results of running the main metric in used in the card ({score_name}) "
             f"over random predictions returns a different score than expected.\n"
-            f"Usually, one would expect a low score of {exact_match_score} in this case, but returned metric score was {score}.\n"
+            f"Usually, one would expect a low score of {full_mismatch_score} in this case, but returned metric score was {score}.\n"
         )
         error_message = (
             f"{message}"

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -194,7 +194,7 @@ def test_with_eval(
 
     if full_mismatch_score is not None and score != full_mismatch_score:
         message = (
-            f"The results of running the main metric in used in the card ({score_name}) "
+            f"The results of running the main metric used in the card ({score_name}) "
             f"over random predictions returns a different score than expected.\n"
             f"Usually, one would expect a low score of {full_mismatch_score} in this case, but returned metric score was {score}.\n"
         )

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -153,13 +153,13 @@ def test_with_eval(
                 card, template_card_index=template_card_index, debug=debug, **kwargs
             )
     # metric = evaluate.load('unitxt/metric')
-    predictions = []
+    correct_predictions = []
     for example in examples:
-        predictions.append(
+        correct_predictions.append(
             example["references"][0] if len(example["references"]) > 0 else []
         )
 
-    results = _compute(predictions=predictions, references=examples)
+    results = _compute(predictions=correct_predictions, references=examples)
     score_name = results[0]["score"]["global"]["score_name"]
     score = results[0]["score"]["global"]["score"]
 
@@ -173,12 +173,12 @@ def test_with_eval(
             f"{message}"
             f"This usually indicates an error in the metric or post processors, but can be also an acceptable edge case.\n"
             f"In anycase, this requires a review.  If this is acceptable, set strict=False in the call to test_card().\n"
-            f"The predictions passed to the metrics were:\n {predictions}\n"
+            f"The predictions passed to the metrics were:\n {correct_predictions}\n"
         )
         warning_message = (
             f"{message}"
             f"This is flagged as only as a warning because strict=False was set in the call to test_card()."
-            f"The predictions passed to the metrics were:\n {predictions}\n"
+            f"The predictions passed to the metrics were:\n {correct_predictions}\n"
         )
         if strict:
             raise AssertionError(error_message)
@@ -186,8 +186,8 @@ def test_with_eval(
         logger.info(warning_message)
         logger.info("*" * 80)
 
-    predictions = ["a1s", "bfsdf", "dgdfgs", "gfjgfh", "ghfjgh"]
-    results = _compute(predictions=predictions, references=examples)
+    wrong_predictions = ["a1s", "bfsdf", "dgdfgs", "gfjgfh", "ghfjgh"]
+    results = _compute(predictions=wrong_predictions, references=examples)
 
     score_name = results[0]["score"]["global"]["score_name"]
     score = results[0]["score"]["global"]["score"]
@@ -203,12 +203,12 @@ def test_with_eval(
             f"This can indicates an error in the metric or post processors, but can be also an acceptable edge case.\n"
             f"For example, in a metric that checks character level edit distance, a low none zero score is expected on random data"
             f"In anycase, this requires a review.  If this is acceptable, set strict=False in the call to test_card().\n"
-            f"The predictions passed to the metrics were:\n {predictions}\n"
+            f"The predictions passed to the metrics were:\n {wrong_predictions}\n"
         )
         warning_message = (
             f"{message}"
             f"This is flagged as only as a warning because strict=False was set in the call to test_card()."
-            f"The predictions passed to the metrics were:\n {predictions}\n"
+            f"The predictions passed to the metrics were:\n {wrong_predictions}\n"
         )
         if strict:
             raise AssertionError(error_message)

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -226,6 +226,12 @@ def test_card(
     full_mismatch_score=0.0,
     **kwargs,
 ):
+    disable = os.getenv("UNITXT_TEST_CARD_DISABLE", None)
+    if disable is not None:
+        logger.info(
+            "test_card() functionality is disable because UNITXT_TEST_CARD_DISABLE environment variable is set"
+        )
+        return
     test_adding_to_catalog(card)
     test_metrics_exist(card)
     test_loading_from_catalog(card)

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -229,7 +229,7 @@ def test_card(
     disable = os.getenv("UNITXT_TEST_CARD_DISABLE", None)
     if disable is not None:
         logger.info(
-            "test_card() functionality is disable because UNITXT_TEST_CARD_DISABLE environment variable is set"
+            "test_card() functionality is disabled because UNITXT_TEST_CARD_DISABLE environment variable is set"
         )
         return
     test_adding_to_catalog(card)

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -165,7 +165,7 @@ def test_with_eval(
 
     if exact_match_score is not None and not math.isclose(score, exact_match_score):
         message = (
-            f"The results of running the main metric in used in the card ({score_name}) "
+            f"The results of running the main metric used in the card ({score_name}) "
             f"over simulated predictions that are equal to the references returns a different score than expected.\n"
             f"One would expect a perfect score of {exact_match_score} in this case, but returned metric score was {score}.\n"
         )


### PR DESCRIPTION
    Improved error messages of metrics checks in test_card

    Added option to disable test_card by setting an environment variable  UNITXT_TEST_CARD_DISABLE
    
    Updated json of dbpedia and cola - after running prepare
 
    
