### PR TITLE
fixing split definition for debater datatests

### DIFF
--- a/prepare/cards/argument_topic.py
+++ b/prepare/cards/argument_topic.py
@@ -1,5 +1,5 @@
 from src.unitxt import add_to_catalog
-from src.unitxt.blocks import AddFields, LoadHF, SplitRandomMix, TaskCard
+from src.unitxt.blocks import AddFields, LoadHF, TaskCard
 from src.unitxt.operators import ListFieldValues
 from src.unitxt.test_utils.card import test_card
 
@@ -82,7 +82,6 @@ class_names = [
 card = TaskCard(
     loader=LoadHF(path="ibm/argument_quality_ranking_30k", name=f"{dataset_name}"),
     preprocess_steps=[
-        SplitRandomMix({"train": "train", "validation": "dev", "test": "test"}),
         ListFieldValues(fields=["label"], to_field="label"),
         AddFields(
             fields={

--- a/prepare/cards/claim_stance_topic.py
+++ b/prepare/cards/claim_stance_topic.py
@@ -1,5 +1,5 @@
 from src.unitxt import add_to_catalog
-from src.unitxt.blocks import AddFields, LoadHF, SplitRandomMix, TaskCard
+from src.unitxt.blocks import AddFields, LoadHF, TaskCard
 from src.unitxt.operators import ListFieldValues
 from src.unitxt.test_utils.card import test_card
 
@@ -67,7 +67,6 @@ class_names = [
 card = TaskCard(
     loader=LoadHF(path="ibm/claim_stance", name=f"{dataset_name}"),
     preprocess_steps=[
-        SplitRandomMix({"train": "train", "validation": "dev", "test": "test"}),
         ListFieldValues(fields=["label"], to_field="label"),
         AddFields(
             fields={


### PR DESCRIPTION
Found out that in Debater datasets there is no need to define random split.