### PR TITLE
Add FilterByQuery and ExecuteQuery as simple operators receiving textual python query

### DIFF
--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1263,6 +1263,65 @@ class FilterByCondition(SingleStreamOperator):
         return True
 
 
+class FilterByLambdaCondition(SingleStreamOperator):
+    """Filters a stream, yielding only instances for which the input specified fields fulfil the conditions assigned to them.
+
+    Raises an error if a field for which a condition is specified is missing from the instance
+
+    Args:
+       lambda_conditions (Dict[str, str]): a mapping of fields to lambda conditions encoded as strings
+       error_on_filtered_all (bool, optional): If True, raises an error if all instances are filtered out. Defaults to True.
+
+    Examples:
+       FilterByCondition(lambda_conditions = {"a": "lambda x: x > 4"}) will yield only instances where "a">4
+       FilterByCondition(lambda_conditions = {"a": "lambda x: x <= 4"}) will yield only instances where "a"<=4
+       FilterByCondition(lambda_conditions = {"a": "lambda x: x in [4, 8]"}) will yield only instances where "a" is 4 or 8
+       FilterByCondition(lambda_conditions = {"a": "lambda x: x not in [4, 8]"}) will yield only instances where "a" is neither 4 nor 8
+
+    """
+
+    lambda_conditions: Dict[str, str]
+    error_on_filtered_all: bool = True
+
+    def prepare(self):
+        self.functs = {}
+        for key, val in self.lambda_conditions.items():
+            self.functs[key] = eval(val)
+
+    def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
+        yielded = False
+        for instance in stream:
+            if self._is_required(instance):
+                yielded = True
+                yield instance
+
+        if not yielded and self.error_on_filtered_all:
+            raise RuntimeError(
+                f"{self.__class__.__name__} filtered out every instance in stream '{stream_name}'. If this is intended set error_on_filtered_all=False"
+            )
+
+    def verify(self):
+        # verify that each lambda condition is decodable to an actual lambda function
+        for key, val in self.lambda_conditions.items():
+            f = eval(val)
+            assert (
+                f(1) in [True, False]
+            ), f"lambda expression, {val}, specified for field {key}, is not decodable from a string to a lambda condition."
+
+        return super().verify()
+
+    def _is_required(self, instance: dict) -> bool:
+        for key in self.functs.keys():
+            if key not in instance:
+                raise ValueError(
+                    f"Required filter field ('{key}') in FilterByCondition is not found in {instance}"
+                )
+            if not self.functs[key](instance[key]):
+                return False
+
+        return True
+
+
 class ExtractMostCommonFieldValues(MultiStreamOperator):
     field: str
     stream_name: str

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1264,19 +1264,19 @@ class FilterByCondition(SingleStreamOperator):
 
 
 class FilterByQuery(SingleStreamOperator):
-    """Filters a stream, yielding only instances which fulfil all the conditions specified as strings to be python's eval-uated.
+    """Filters a stream, yielding only instances which fulfil a condition specified as a string to be python's eval-uated.
 
-    Raises an error if a field for which a condition is specified is missing from the instance
+    Raises an error if a field participating in the specified condition is missing from the instance
 
     Args:
        query (str): a condition over fields of the instance, to be processed by python's eval()
        error_on_filtered_all (bool, optional): If True, raises an error if all instances are filtered out. Defaults to True.
 
     Examples:
-       FilterByQuery(query = {"a > 4"}) will yield only instances where "a">4
-       FilterByQuery(query = {"a <= 4 and b > 5"}) will yield only instances where field 'a' has a value not exceeding 4 and field 'b' has a value greater than 5
-       FilterByQuery(query = {"a in [4, 8]"}) will yield only instances where "a" is 4 or 8
-       FilterByQuery(query = {"a not in [4, 8]"}) will yield only instances where "a" is neither 4 nor 8
+       FilterByQuery(query = "a > 4") will yield only instances where "a">4
+       FilterByQuery(query = "a <= 4 and b > 5") will yield only instances where the value of field "a" is not exceeding 4 and in field "b" -- greater than 5
+       FilterByQuery(query = "a in [4, 8]") will yield only instances where "a" is 4 or 8
+       FilterByQuery(query = "a not in [4, 8]") will yield only instances where "a" is neither 4 nor 8
 
     """
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1630,7 +1630,7 @@ class AddFieldNamePrefix(StreamInstanceOperator):
     """Adds a prefix to each field name in each instance of a stream.
 
     Args:
-        prefix_dict (Dict[str, str]): A dictionary mapping stream names to prefixes.
+        prefix_dict (Dict[str, str]): A dictionary mapping field names to prefixes.
     """
 
     prefix_dict: Dict[str, str]

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1626,27 +1626,6 @@ class ApplyMetric(SingleStreamOperator, ArtifactFetcherMixin):
         yield from stream
 
 
-class AddFieldNamePrefix(StreamInstanceOperator):
-    """Adds a prefix to each field name in each instance of a stream.
-
-    Args:
-        prefix_dict (Dict[str, str]): A dictionary mapping field names to prefixes.
-    """
-
-    prefix_dict: Dict[str, str]
-
-    def prepare(self):
-        return super().prepare()
-
-    def process(
-        self, instance: Dict[str, Any], stream_name: Optional[str] = None
-    ) -> Dict[str, Any]:
-        return {
-            self.prefix_dict[stream_name] + key: value
-            for key, value in instance.items()
-        }
-
-
 class MergeStreams(MultiStreamOperator):
     """Merges multiple streams into a single stream.
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -532,6 +532,12 @@ class TestOperators(unittest.TestCase):
             exception_text=exception_text,
             tester=self,
         )
+        check_operator_exception(
+            operator=FilterByLambdaCondition(lambda_conditions={"c": "lambda x: x==5"}),
+            inputs=inputs,
+            exception_text=exception_text,
+            tester=self,
+        )
 
     def test_filter_by_condition_ne(self):
         inputs = [{"a": 0, "b": 2}, {"a": 2, "b": 3}, {"a": 1, "b": 3}]
@@ -578,6 +584,8 @@ class TestOperators(unittest.TestCase):
     def test_filter_by_condition_bad_condition(self):
         with self.assertRaises(ValueError):
             FilterByCondition(values={"a": 1}, condition="gte")
+        with self.assertRaises(AssertionError):
+            FilterByLambdaCondition(lambda_conditions={"a": "lambda x: 8*x"})
 
     def test_filter_by_condition_not_in(self):
         inputs = [
@@ -634,6 +642,18 @@ class TestOperators(unittest.TestCase):
             ),
             inputs=inputs,
             targets=targets,
+            tester=self,
+        )
+        check_operator_exception(
+            operator=FilterByLambdaCondition(
+                lambda_conditions={
+                    "b": "lambda x: x not in [3, 4]",
+                    "a": "lambda x: x not in [1]",
+                },
+                error_on_filtered_all=True,
+            ),
+            inputs=inputs,
+            exception_text="FilterByLambdaCondition filtered out every instance in stream 'test'. If this is intended set error_on_filtered_all=False",
             tester=self,
         )
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -725,6 +725,17 @@ class TestOperators(unittest.TestCase):
         check_operator(operator=operator, inputs=inputs, targets=targets, tester=self)
         operator = ExecuteQuery(queries_to_fields=[["f'{a} {b}'", "c"]])
         check_operator(operator=operator, inputs=inputs, targets=targets, tester=self)
+        with self.assertRaises(ValueError) as ve:
+            check_operator(
+                operator=operator,
+                inputs=[{"x": 2, "y": 3}],
+                targets=targets,
+                tester=self,
+            )
+        self.assertEqual(
+            "Error processing instance '0' from stream 'test' in ExecuteQuery due to: name 'a' is not defined",
+            str(ve.exception),
+        )
         with self.assertRaises(AssertionError) as ae:
             operator = ExecuteQuery(queries_to_fields=["a", "b"])
         self.assertEqual(

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -23,6 +23,7 @@ from src.unitxt.operators import (
     ExtractMostCommonFieldValues,
     FieldOperator,
     FilterByCondition,
+    FilterByLambdaCondition,
     FlattenInstances,
     FromIterables,
     IndexOf,
@@ -515,6 +516,14 @@ class TestOperators(unittest.TestCase):
             targets=targets,
             tester=self,
         )
+        check_operator(
+            operator=FilterByLambdaCondition(
+                lambda_conditions={"a": "lambda x: x==1", "b": "lambda x: x==3"}
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
 
         exception_text = "Required filter field ('c') in FilterByCondition is not found in {'a': 1, 'b': 2}"
         check_operator_exception(
@@ -537,6 +546,14 @@ class TestOperators(unittest.TestCase):
             targets=targets,
             tester=self,
         )
+        check_operator(
+            operator=FilterByLambdaCondition(
+                lambda_conditions={"a": "lambda x: x!=1", "b": "lambda x: x!=2"}
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
 
     def test_filter_by_condition_gt(self):
         inputs = [{"a": 0, "b": 2}, {"a": 2, "b": 3}, {"a": 1, "b": 3}]
@@ -547,6 +564,12 @@ class TestOperators(unittest.TestCase):
 
         check_operator(
             operator=FilterByCondition(values={"a": 1}, condition="gt"),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+        check_operator(
+            operator=FilterByLambdaCondition(lambda_conditions={"a": "lambda x: x>1"}),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -573,6 +596,14 @@ class TestOperators(unittest.TestCase):
             targets=targets,
             tester=self,
         )
+        check_operator(
+            operator=FilterByLambdaCondition(
+                lambda_conditions={"b": "lambda x: x not in [3, 4]"}
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
 
     def test_filter_by_condition_not_in_multiple(self):
         inputs = [
@@ -587,6 +618,18 @@ class TestOperators(unittest.TestCase):
             operator=FilterByCondition(
                 values={"b": [3, 4], "a": [1]},
                 condition="not in",
+                error_on_filtered_all=False,
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+        check_operator(
+            operator=FilterByLambdaCondition(
+                lambda_conditions={
+                    "b": "lambda x: x not in [3, 4]",
+                    "a": "lambda x: x not in [1]",
+                },
                 error_on_filtered_all=False,
             ),
             inputs=inputs,
@@ -612,7 +655,14 @@ class TestOperators(unittest.TestCase):
             targets=targets,
             tester=self,
         )
-
+        check_operator(
+            operator=FilterByLambdaCondition(
+                lambda_conditions={"b": "lambda x: x in [3, 4]"}
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
         with self.assertRaises(ValueError) as cm:
             check_operator(
                 operator=FilterByCondition(values={"b": "5"}, condition="in"),

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -23,7 +23,7 @@ from src.unitxt.operators import (
     ExtractMostCommonFieldValues,
     FieldOperator,
     FilterByCondition,
-    FilterByLambdaCondition,
+    FilterByQuery,
     FlattenInstances,
     FromIterables,
     IndexOf,
@@ -517,9 +517,7 @@ class TestOperators(unittest.TestCase):
             tester=self,
         )
         check_operator(
-            operator=FilterByLambdaCondition(
-                lambda_conditions={"a": "lambda x: x==1", "b": "lambda x: x==3"}
-            ),
+            operator=FilterByQuery(queries=["a == 1 and b == 3"]),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -533,9 +531,9 @@ class TestOperators(unittest.TestCase):
             tester=self,
         )
         check_operator_exception(
-            operator=FilterByLambdaCondition(lambda_conditions={"c": "lambda x: x==5"}),
+            operator=FilterByQuery(queries=["c == 5"]),
             inputs=inputs,
-            exception_text=exception_text,
+            exception_text="name 'c' is not defined",
             tester=self,
         )
 
@@ -553,9 +551,7 @@ class TestOperators(unittest.TestCase):
             tester=self,
         )
         check_operator(
-            operator=FilterByLambdaCondition(
-                lambda_conditions={"a": "lambda x: x!=1", "b": "lambda x: x!=2"}
-            ),
+            operator=FilterByQuery(queries=["a != 1 and b != 2"]),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -575,7 +571,7 @@ class TestOperators(unittest.TestCase):
             tester=self,
         )
         check_operator(
-            operator=FilterByLambdaCondition(lambda_conditions={"a": "lambda x: x>1"}),
+            operator=FilterByQuery(queries=["a>1"]),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -584,8 +580,6 @@ class TestOperators(unittest.TestCase):
     def test_filter_by_condition_bad_condition(self):
         with self.assertRaises(ValueError):
             FilterByCondition(values={"a": 1}, condition="gte")
-        with self.assertRaises(AssertionError):
-            FilterByLambdaCondition(lambda_conditions={"a": "lambda x: 8*x"})
 
     def test_filter_by_condition_not_in(self):
         inputs = [
@@ -605,9 +599,7 @@ class TestOperators(unittest.TestCase):
             tester=self,
         )
         check_operator(
-            operator=FilterByLambdaCondition(
-                lambda_conditions={"b": "lambda x: x not in [3, 4]"}
-            ),
+            operator=FilterByQuery(queries=["b not in [3, 4]"]),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -633,11 +625,11 @@ class TestOperators(unittest.TestCase):
             tester=self,
         )
         check_operator(
-            operator=FilterByLambdaCondition(
-                lambda_conditions={
-                    "b": "lambda x: x not in [3, 4]",
-                    "a": "lambda x: x not in [1]",
-                },
+            operator=FilterByQuery(
+                queries=[
+                    "b not in [3, 4]",
+                    "a not in [1]",
+                ],
                 error_on_filtered_all=False,
             ),
             inputs=inputs,
@@ -645,15 +637,15 @@ class TestOperators(unittest.TestCase):
             tester=self,
         )
         check_operator_exception(
-            operator=FilterByLambdaCondition(
-                lambda_conditions={
-                    "b": "lambda x: x not in [3, 4]",
-                    "a": "lambda x: x not in [1]",
-                },
+            operator=FilterByQuery(
+                queries=[
+                    "b not in [3, 4]",
+                    "a not in [1]",
+                ],
                 error_on_filtered_all=True,
             ),
             inputs=inputs,
-            exception_text="FilterByLambdaCondition filtered out every instance in stream 'test'. If this is intended set error_on_filtered_all=False",
+            exception_text="FilterByQuery filtered out every instance in stream 'test'. If this is intended set error_on_filtered_all=False",
             tester=self,
         )
 
@@ -676,9 +668,7 @@ class TestOperators(unittest.TestCase):
             tester=self,
         )
         check_operator(
-            operator=FilterByLambdaCondition(
-                lambda_conditions={"b": "lambda x: x in [3, 4]"}
-            ),
+            operator=FilterByQuery(queries=["b in [3, 4]"]),
             inputs=inputs,
             targets=targets,
             tester=self,

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -748,6 +748,20 @@ class TestOperators(unittest.TestCase):
             "Inner lists in arg 'queries_to_fields' should be of length 2. Received this inner list: ['a', 'b', 'c'].",
             str(ae.exception),
         )
+        inputs = [
+            {
+                "labels": ["person", "location", "person"],
+                "entity": ["Jane", "New York", "John"],
+            }
+        ]
+        operator = ExecuteQuery(
+            queries_to_fields=[
+                ['[e for l,e in zip(labels, entity) if l=="person"]', "entity"],
+                ['[l for l in labels if l == "person"]', "labels"],
+            ]
+        )
+        targets = [{"labels": ["person", "person"], "entity": ["Jane", "John"]}]
+        check_operator(operator=operator, inputs=inputs, targets=targets, tester=self)
 
     def test_intersect(self):
         inputs = [


### PR DESCRIPTION
It seems that the simple conditions, listed in `FilterByCondition` , can all be replaced by simple lambda conditions.  We can thus replace, and enjoy from additional, perhaps more involved, conditions that lambda can express. 
This also refers to [an issue](https://github.com/IBM/unitxt/issues/415) by @matanor 