### PR TITLE
Add a new Perturbate operator that is handy for faking prediction as a perturbated version of target or for any other perturbation use cases

### DIFF
--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -880,61 +880,54 @@ class TakeByField(StreamInstanceOperator):
         return instance
 
 
-class CopyWithPerturbation(StreamInstanceOperator):
-    """Assumes that instance contains field 'target' and copies its content, with some perturbation, to field 'prediction'.
+class CopyWithPerturbation(FieldOperator):
+    """Slightly perturbates the contents of 'field'. Could be Handy for imitating prediction from given target.
 
-    The operator also assumes that field "source" shows in instance, and it is a decent piece of text.
-    If target is a class (task was classification) then this operator assumes that field named 'classes' lists all the
-    potential classes.
+    The operator assumes that field "source" shows in instance, and it is a decent piece of text.
+    When target is a class (task was classification), argument 'select_from' can be used to list the other potential classes.
     """
 
-    is_class: bool = False
-    is_float: bool = False
-    is_text: bool = False
-    percentage_to_perturbate: int = 0
+    select_from: List[Any] = []
+    percentage_to_perturbate: int = 1  # 1 percent
 
-    def prepare(self):
-        assert (
-            isinstance(self.is_class, bool)
-            and isinstance(self.is_float, bool)
-            and isinstance(self.is_text, bool)
-        ), "All three args 'is_..' should be boolean"
-        assert (
-            1 == self.is_class + self.is_float + self.is_text
-        ), "Exactly one of the three boolean args 'is_..' should be True"
+    def verify(self):
         assert (
             0 <= self.percentage_to_perturbate and self.percentage_to_perturbate <= 100
         ), f"'percentage_to_perturbate' should be in the range 0..100. Received {self.percentage_to_perturbate}"
 
-    def process(
-        self, instance: Dict[str, Any], stream_name: Optional[str] = None
-    ) -> Dict[str, Any]:
-        random_generator = new_random_generator(sub_seed=instance["source"])
+    def prepare(self):
+        super().prepare()
+        self.random_generator = new_random_generator(sub_seed="CopyWithPerturbation")
 
-        perturbate = random_generator.randint(1, 100) <= self.percentage_to_perturbate
+    def process_value(self, value: Any) -> Any:
+        perturbate = (
+            self.random_generator.randint(1, 100) <= self.percentage_to_perturbate
+        )
         if not perturbate:
-            instance["prediction"] = instance["target"]
-            return instance
+            return value
 
-        if self.is_class:
-            instance["prediction"] = random_generator.choice(instance["classes"])
-        if self.is_text:
-            if len(instance["target"]) < 2:
+        if value in self.select_from:
+            # 80% of cases, return a decent class, otherwise, perturbate the value itself as follows
+            if self.random_generator.random() < 0.8:
+                return self.random_generator.choice(self.select_from)
+
+        if isinstance(value, float):
+            return value * (0.5 + self.random_generator.random())
+
+        if isinstance(value, int):
+            perturb = 1 if self.random_generator.random() < 0.5 else -1
+            return value + perturb
+
+        if isinstance(value, str):
+            if len(value) < 2:
                 # give up perturbation
-                instance["prediction"] = instance["target"]
-            else:
-                # throw one char out
-                prefix_len = random_generator.randint(1, len(instance["target"]) - 1)
-                instance["prediction"] = (
-                    instance["target"][:prefix_len]
-                    + instance["target"][prefix_len + 1 :]
-                )
-        if self.is_float:
-            instance["prediction"] = instance["target"] * (
-                0.5 + random_generator.random()
-            )
+                return value
+            # throw one char out
+            prefix_len = self.random_generator.randint(1, len(value) - 1)
+            return value[:prefix_len] + value[prefix_len + 1 :]
 
-        return instance
+        # and in any other case:
+        return value
 
 
 class CopyFields(FieldOperator):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -880,11 +880,11 @@ class TakeByField(StreamInstanceOperator):
         return instance
 
 
-class CopyWithPerturbation(FieldOperator):
+class Perturbate(FieldOperator):
     """Slightly perturbates the contents of 'field'. Could be Handy for imitating prediction from given target.
 
-    The operator assumes that field "source" shows in instance, and it is a decent piece of text.
-    When target is a class (task was classification), argument 'select_from' can be used to list the other potential classes.
+    When task was classification, argument 'select_from' can be used to list the other potential classes, as a
+    relevant perturbation
     """
 
     select_from: List[Any] = []

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -17,6 +17,7 @@ from src.unitxt.operators import (
     AugmentWhitespace,
     CastFields,
     CopyFields,
+    CopyWithPerturbation,
     DeterministicBalancer,
     DivideAllFieldsBy,
     EncodeLabels,
@@ -2624,3 +2625,47 @@ Agent:"""
         instance_out = system_format.process(instance)
         self.assertEqual(instance_out["source"], target)
         self.assertEqual(instance["source"], target)
+
+    def test_copy_with_perturbation(self):
+        instance = {
+            "target": 1,
+            "classes": [0, 1],
+            "source": "Classify the given text to yes or no",
+        }
+        operator = CopyWithPerturbation(is_class=True, percentage_to_perturbate=0)
+        out = operator.process(instance)
+        self.assertEqual(out["target"], out["prediction"])
+        operator = CopyWithPerturbation(is_class=True, percentage_to_perturbate=100)
+        predictions = []
+        for i in range(100):
+            instance["source"] = "Classify the given text to yes or no" + str(i)
+            out = operator.process(instance)
+            predictions.append(out["prediction"])
+        counter = Counter(predictions)
+        self.assertGreaterEqual(counter[0], 25)
+        self.assertGreaterEqual(counter[1], 25)
+        instance["target"] = "abcdefghijklmnop"
+        operator = CopyWithPerturbation(is_text=True, percentage_to_perturbate=100)
+        out = operator.process(instance)
+        self.assertGreater(len(out["target"]), len(out["prediction"]))
+        instance["target"] = "a"
+        operator = CopyWithPerturbation(is_text=True, percentage_to_perturbate=100)
+        out = operator.process(instance)
+        self.assertEqual(out["target"], out["prediction"])
+        instance["target"] = 10.0
+        operator = CopyWithPerturbation(is_float=True, percentage_to_perturbate=100)
+        out = operator.process(instance)
+        self.assertNotEqual(out["target"], out["prediction"])
+        with self.assertRaises(AssertionError) as ae:
+            operator = CopyWithPerturbation(
+                is_float=5, is_text=True, percentage_to_perturbate=100
+            )
+        self.assertEqual("All three args 'is_..' should be boolean", str(ae.exception))
+        with self.assertRaises(AssertionError) as ae:
+            operator = CopyWithPerturbation(
+                is_float=True, is_text=True, percentage_to_perturbate=100
+            )
+        self.assertEqual(
+            "Exactly one of the three boolean args 'is_..' should be True",
+            str(ae.exception),
+        )

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -2632,40 +2632,41 @@ Agent:"""
             "classes": [0, 1],
             "source": "Classify the given text to yes or no",
         }
-        operator = CopyWithPerturbation(is_class=True, percentage_to_perturbate=0)
+        operator = CopyWithPerturbation(
+            field="target", to_field="prediction", percentage_to_perturbate=0
+        )
         out = operator.process(instance)
         self.assertEqual(out["target"], out["prediction"])
-        operator = CopyWithPerturbation(is_class=True, percentage_to_perturbate=100)
+        operator = CopyWithPerturbation(
+            field="target",
+            to_field="prediction",
+            select_from=[0, 1],
+            percentage_to_perturbate=100,
+        )
         predictions = []
-        for i in range(100):
-            instance["source"] = "Classify the given text to yes or no" + str(i)
+        for _ in range(100):
             out = operator.process(instance)
             predictions.append(out["prediction"])
         counter = Counter(predictions)
         self.assertGreaterEqual(counter[0], 25)
         self.assertGreaterEqual(counter[1], 25)
         instance["target"] = "abcdefghijklmnop"
-        operator = CopyWithPerturbation(is_text=True, percentage_to_perturbate=100)
+        operator = CopyWithPerturbation(
+            field="target", to_field="prediction", percentage_to_perturbate=100
+        )
         out = operator.process(instance)
         self.assertGreater(len(out["target"]), len(out["prediction"]))
         instance["target"] = "a"
-        operator = CopyWithPerturbation(is_text=True, percentage_to_perturbate=100)
         out = operator.process(instance)
         self.assertEqual(out["target"], out["prediction"])
         instance["target"] = 10.0
-        operator = CopyWithPerturbation(is_float=True, percentage_to_perturbate=100)
         out = operator.process(instance)
         self.assertNotEqual(out["target"], out["prediction"])
         with self.assertRaises(AssertionError) as ae:
             operator = CopyWithPerturbation(
-                is_float=5, is_text=True, percentage_to_perturbate=100
-            )
-        self.assertEqual("All three args 'is_..' should be boolean", str(ae.exception))
-        with self.assertRaises(AssertionError) as ae:
-            operator = CopyWithPerturbation(
-                is_float=True, is_text=True, percentage_to_perturbate=100
+                field="target", percentage_to_perturbate=200
             )
         self.assertEqual(
-            "Exactly one of the three boolean args 'is_..' should be True",
+            "'percentage_to_perturbate' should be in the range 0..100. Received 200",
             str(ae.exception),
         )

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -17,7 +17,6 @@ from src.unitxt.operators import (
     AugmentWhitespace,
     CastFields,
     CopyFields,
-    CopyWithPerturbation,
     DeterministicBalancer,
     DivideAllFieldsBy,
     EncodeLabels,
@@ -38,6 +37,7 @@ from src.unitxt.operators import (
     MapInstanceValues,
     MergeStreams,
     NullAugmentor,
+    Perturbate,
     RemoveFields,
     RemoveValues,
     RenameFields,
@@ -2626,18 +2626,18 @@ Agent:"""
         self.assertEqual(instance_out["source"], target)
         self.assertEqual(instance["source"], target)
 
-    def test_copy_with_perturbation(self):
+    def test_perturbate(self):
         instance = {
             "target": 1,
             "classes": [0, 1],
             "source": "Classify the given text to yes or no",
         }
-        operator = CopyWithPerturbation(
+        operator = Perturbate(
             field="target", to_field="prediction", percentage_to_perturbate=0
         )
         out = operator.process(instance)
         self.assertEqual(out["target"], out["prediction"])
-        operator = CopyWithPerturbation(
+        operator = Perturbate(
             field="target",
             to_field="prediction",
             select_from=[0, 1],
@@ -2651,7 +2651,7 @@ Agent:"""
         self.assertGreaterEqual(counter[0], 25)
         self.assertGreaterEqual(counter[1], 25)
         instance["target"] = "abcdefghijklmnop"
-        operator = CopyWithPerturbation(
+        operator = Perturbate(
             field="target", to_field="prediction", percentage_to_perturbate=100
         )
         out = operator.process(instance)
@@ -2663,9 +2663,7 @@ Agent:"""
         out = operator.process(instance)
         self.assertNotEqual(out["target"], out["prediction"])
         with self.assertRaises(AssertionError) as ae:
-            operator = CopyWithPerturbation(
-                field="target", percentage_to_perturbate=200
-            )
+            operator = Perturbate(field="target", percentage_to_perturbate=200)
         self.assertEqual(
             "'percentage_to_perturbate' should be in the range 0..100. Received 200",
             str(ae.exception),


### PR DESCRIPTION
to be employed just one step before metric evaluation