### PR TITLE
Improve catalog UI on documentation website by separating catalog objects to files and adding information  per catalog item

### DIFF
--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -103,9 +103,14 @@ class CatalogEntry:
             sub_catalog_entry = CatalogEntry.from_dir_entry(
                 dir_entry=sub_dir_entry, start_directory=start_directory
             )
+            # TODO sort put folders on top and alphabetic order
             sub_label = sub_catalog_entry.get_label()
             sub_name = os.path.basename(sub_dir_entry.path)
-            dir_doc_content += f":ref:`{sub_name} <{sub_label}>`\n" f"*************\n\n"
+            folder_mark = "📁 " if sub_catalog_entry.is_dir else ""
+            folder_slash = "/" if sub_catalog_entry.is_dir else ""
+            dir_doc_content += (
+                f":ref:`{folder_mark}{sub_name}{folder_slash} <{sub_label}>`\n\n"
+            )
 
         dir_doc_path = os.path.join(
             destination_directory,

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -70,7 +70,6 @@ def make_content(artifact, label, all_labels=None):
 
 
 def build_catalog_rst():
-    prints = [write_title("Catalog", "catalog", 0)]
     all_labels = set()
     current_dir = os.path.dirname(__file__)
     start_directory = os.path.join(current_dir, "..", "src", "unitxt", "catalog")
@@ -86,10 +85,8 @@ def build_catalog_rst():
     for path, is_dir, depth in custom_walk(start_directory):
         rel_path = path.replace(start_directory + "/", "")
         if is_dir:
-            prints.append(
-                write_title(
-                    rel_path.split("/")[-1], rel_path.replace("/", "."), depth + 1
-                )
+            create_dir_contents_rst(
+                start_directory, current_directory, path, rel_path, depth
             )
         else:
             if ".json" in rel_path:
@@ -109,10 +106,35 @@ def build_catalog_rst():
                 with open(artifact_doc_path, "w+") as f:
                     f.write(section)
 
-    target_file = os.path.join(current_directory, "catalog.rst")
+    create_dir_contents_rst(
+        start_directory,
+        current_directory,
+        dir_path=start_directory,
+        rel_path="catalog",
+        depth=0,
+    )
 
-    with open(target_file, "w+") as f:
-        f.write("\n\n".join(prints))
+
+def create_dir_contents_rst(
+    start_directory, current_directory, dir_path, rel_path, depth
+):
+    dir_doc_path = os.path.join(
+        current_directory,
+        rel_path + ".rst",
+    )
+    title = rel_path.split("/")[-1]
+    if title:
+        title = f"{title[0].upper()}{title[1:]}"
+    label = rel_path.replace("/", ".")
+    dir_doc_content = write_title(title, label, depth + 1)
+
+    for dir_entry in os.scandir(dir_path):
+        sub_rel_path = dir_entry.path.replace(start_directory + "/", "")
+        sub_label = sub_rel_path.replace("/", ".")
+        sub_name = os.path.basename(dir_entry.path)
+        dir_doc_content += f":ref:`{sub_name} <{sub_label}>`\n\n"
+    with open(dir_doc_path, "w+") as f:
+        f.write(dir_doc_content)
 
 
 if __name__ == "__main__":

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -58,10 +58,14 @@ def make_content(artifact, label, all_labels):
 class CatalogEntry:
     """A single catalog entry is an artifact json file, or a catalog directory."""
 
-    def __init__(self, path: str, is_dir: bool, start_directory: str):
+    def __init__(
+        self, path: str, is_dir: bool, start_directory: str, relative_path=None
+    ):
         self.path = path
         self.is_dir = is_dir
-        self.rel_path = path.replace(start_directory + "/", "")
+        self.rel_path = (
+            relative_path if relative_path else path.replace(start_directory + "/", "")
+        )
 
     @staticmethod
     def from_dir_entry(dir_entry: os.DirEntry, start_directory):
@@ -79,7 +83,7 @@ class CatalogEntry:
         return label.replace("/", ".")
 
     def get_title(self):
-        return self.rel_path.split("/")[-1]
+        return Path(self.rel_path).stem
 
     def get_artifact_doc_path(self, destination_directory):
         return os.path.join(
@@ -101,7 +105,7 @@ class CatalogEntry:
             )
             sub_label = sub_catalog_entry.get_label()
             sub_name = os.path.basename(sub_dir_entry.path)
-            dir_doc_content += f":ref:`{sub_name} <{sub_label}>`\n\n"
+            dir_doc_content += f":ref:`{sub_name} <{sub_label}>`\n" f"*************\n\n"
 
         dir_doc_path = os.path.join(
             destination_directory,
@@ -162,7 +166,10 @@ class CatalogDocsBuilder:
                 )
 
         catalog_main_entry = CatalogEntry(
-            path=self.start_directory, is_dir=True, start_directory=self.start_directory
+            path=self.start_directory + "/",
+            is_dir=True,
+            start_directory=self.start_directory,
+            relative_path="catalog",
         )
         catalog_main_entry.write_dir_contents_to_rst(
             destination_directory=current_directory,

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -76,7 +76,7 @@ class CatalogEntry:
         )
 
     def is_json(self):
-        return not self.is_dir and ".json" in self.rel_path
+        return not self.is_dir and self.rel_path.endswith(".json")
 
     def get_label(self):
         label = self.rel_path.replace(".json", "")

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -56,6 +56,8 @@ def make_content(artifact, label, all_labels):
 
 
 class CatalogEntry:
+    """A single catalog entry is an artifact json file, or a catalog directory."""
+
     def __init__(self, path: str, is_dir: bool, start_directory: str):
         self.path = path
         self.is_dir = is_dir
@@ -122,6 +124,11 @@ class CatalogEntry:
 
 
 class CatalogDocsBuilder:
+    """Creates the catalog documentation.
+
+    The builder goes over the catalog, and produces RST doc files for its contents.
+    """
+
     def __init__(self):
         current_dir = os.path.dirname(__file__)
         self.start_directory = os.path.join(

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -99,18 +99,26 @@ class CatalogEntry:
         label = self.get_label()
         dir_doc_content = write_title(title, label)
 
-        for sub_dir_entry in os.scandir(self.path):
-            sub_catalog_entry = CatalogEntry.from_dir_entry(
+        sub_catalog_entries = [
+            CatalogEntry.from_dir_entry(
                 dir_entry=sub_dir_entry, start_directory=start_directory
             )
-            # TODO sort put folders on top and alphabetic order
-            sub_label = sub_catalog_entry.get_label()
+            for sub_dir_entry in os.scandir(self.path)
+        ]
+
+        sub_dir_entries = [entry for entry in sub_catalog_entries if entry.is_dir]
+        sub_dir_entries.sort(key=lambda entry: entry.path)
+        for sub_dir_entry in sub_dir_entries:
+            sub_label = sub_dir_entry.get_label()
             sub_name = os.path.basename(sub_dir_entry.path)
-            folder_mark = "📁 " if sub_catalog_entry.is_dir else ""
-            folder_slash = "/" if sub_catalog_entry.is_dir else ""
-            dir_doc_content += (
-                f":ref:`{folder_mark}{sub_name}{folder_slash} <{sub_label}>`\n\n"
-            )
+            dir_doc_content += f":ref:`📁 {sub_name}/ <{sub_label}>`\n\n"
+
+        sub_file_entries = [entry for entry in sub_catalog_entries if not entry.is_dir]
+        sub_file_entries.sort(key=lambda entry: entry.path)
+        for sub_file_entry in sub_file_entries:
+            sub_label = sub_file_entry.get_label()
+            sub_name = os.path.basename(sub_file_entry.path)
+            dir_doc_content += f":ref:`{sub_name} <{sub_label}>`\n\n"
 
         dir_doc_path = os.path.join(
             destination_directory,

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -42,9 +42,7 @@ def custom_walk(top, depth=0):
             yield (entry.path, False, depth)
 
 
-def make_content(artifact, label, all_labels=None):
-    if all_labels is None:
-        all_labels = {}
+def make_content(artifact, label, all_labels):
     artifact_type = artifact["type"]
     artifact_class = Artifact._class_register.get(artifact_type)
     class_name = artifact_class.__name__

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -108,6 +108,18 @@ class CatalogEntry:
         with open(dir_doc_path, "w+") as f:
             f.write(dir_doc_content)
 
+    def write_json_contents_to_rst(self, all_labels, destination_directory):
+        artifact = load_json(self.path)
+        label = self.get_label()
+        content = make_content(artifact, label, all_labels)
+        section = write_section(self.get_title(), content, label)
+        artifact_doc_path = self.get_artifact_doc_path(
+            destination_directory=destination_directory
+        )
+        Path(artifact_doc_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(artifact_doc_path, "w+") as f:
+            f.write(section)
+
 
 class CatalogDocsBuilder:
     def __init__(self):
@@ -138,16 +150,9 @@ class CatalogDocsBuilder:
                     start_directory=self.start_directory,
                 )
             elif catalog_entry.is_json():
-                artifact = load_json(catalog_entry.path)
-                label = catalog_entry.get_label()
-                content = make_content(artifact, label, all_labels)
-                section = write_section(catalog_entry.get_title(), content, label)
-                artifact_doc_path = catalog_entry.get_artifact_doc_path(
-                    destination_directory=current_directory
+                catalog_entry.write_json_contents_to_rst(
+                    all_labels, destination_directory=current_directory
                 )
-                Path(artifact_doc_path).parent.mkdir(parents=True, exist_ok=True)
-                with open(artifact_doc_path, "w+") as f:
-                    f.write(section)
 
         catalog_main_entry = CatalogEntry(
             path=self.start_directory, is_dir=True, start_directory=self.start_directory

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -40,6 +40,7 @@ def make_content(artifact, label, all_labels):
 
     if artifact_class.__doc__:
         result += f"Explanation about `{type_class_name}`:\n\n"
+        result += "+++++++++++++++++++\n"
         result += artifact_class.__doc__ + "\n"
 
     references = []

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -111,6 +111,7 @@ class CatalogEntry:
             destination_directory,
             self.rel_path + ".rst",
         )
+        Path(dir_doc_path).parent.mkdir(exist_ok=True, parents=True)
         with open(dir_doc_path, "w+") as f:
             f.write(dir_doc_content)
 

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -39,8 +39,8 @@ def make_content(artifact, label, all_labels):
     )
 
     if artifact_class.__doc__:
-        result += f"Explanation about `{type_class_name}`:\n\n"
-        result += "+++++++++++++++++++\n"
+        result += f"\nExplanation about `{type_class_name}`\n"
+        result += "+++++++++++++++++++\n\n"
         result += artifact_class.__doc__ + "\n"
 
     references = []

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -24,10 +24,10 @@ def write_title(title, label):
 def custom_walk(top):
     for entry in os.scandir(top):
         if entry.is_dir():
-            yield (entry.path, True)
+            yield entry
             yield from custom_walk(entry.path)
         else:
-            yield (entry.path, False)
+            yield entry
 
 
 def make_content(artifact, label, all_labels):
@@ -55,66 +55,108 @@ def make_content(artifact, label, all_labels):
     return result
 
 
-def build_catalog_rst():
-    all_labels = set()
-    current_dir = os.path.dirname(__file__)
-    start_directory = os.path.join(current_dir, "..", "src", "unitxt", "catalog")
+class CatalogEntry:
+    def __init__(self, path: str, is_dir: bool, start_directory: str):
+        self.path = path
+        self.is_dir = is_dir
+        self.rel_path = path.replace(start_directory + "/", "")
 
-    for path, is_dir in custom_walk(start_directory):
-        rel_path = path.replace(start_directory + "/", "")
-        if not is_dir and ".json" in rel_path:
-            rel_path = rel_path.replace(".json", "")
-            label = rel_path.replace("/", ".")
-            all_labels.add(label)
+    @staticmethod
+    def from_dir_entry(dir_entry: os.DirEntry, start_directory):
+        return CatalogEntry(
+            path=dir_entry.path,
+            is_dir=dir_entry.is_dir(),
+            start_directory=start_directory,
+        )
 
-    current_directory = os.path.dirname(os.path.abspath(__file__))
-    for path, is_dir in custom_walk(start_directory):
-        rel_path = path.replace(start_directory + "/", "")
-        if is_dir:
-            create_dir_contents_rst(start_directory, current_directory, path, rel_path)
-        else:
-            if ".json" in rel_path:
-                artifact = load_json(path)
-                label = rel_path.replace("/", ".")
+    def is_json(self):
+        return not self.is_dir and ".json" in self.rel_path
+
+    def get_label(self):
+        label = self.rel_path.replace(".json", "")
+        return label.replace("/", ".")
+
+    def get_title(self):
+        return self.rel_path.split("/")[-1]
+
+    def get_artifact_doc_path(self, destination_directory):
+        return os.path.join(
+            destination_directory,
+            os.path.dirname(self.rel_path),
+            Path(self.rel_path).stem + ".rst",
+        )
+
+    def write_dir_contents_to_rst(self, destination_directory, start_directory):
+        title = self.get_title()
+        if title:
+            title = f"{title[0].upper()}{title[1:]}"
+        label = self.get_label()
+        dir_doc_content = write_title(title, label)
+
+        for sub_dir_entry in os.scandir(self.path):
+            sub_catalog_entry = CatalogEntry.from_dir_entry(
+                dir_entry=sub_dir_entry, start_directory=start_directory
+            )
+            sub_label = sub_catalog_entry.get_label()
+            sub_name = os.path.basename(sub_dir_entry.path)
+            dir_doc_content += f":ref:`{sub_name} <{sub_label}>`\n\n"
+
+        dir_doc_path = os.path.join(
+            destination_directory,
+            self.rel_path + ".rst",
+        )
+        with open(dir_doc_path, "w+") as f:
+            f.write(dir_doc_content)
+
+
+class CatalogDocsBuilder:
+    def __init__(self):
+        current_dir = os.path.dirname(__file__)
+        self.start_directory = os.path.join(
+            current_dir, "..", "src", "unitxt", "catalog"
+        )
+
+    def create_catalog_entries(self):
+        return [
+            CatalogEntry.from_dir_entry(dir_entry, self.start_directory)
+            for dir_entry in custom_walk(self.start_directory)
+        ]
+
+    def run(self):
+        catalog_entries = self.create_catalog_entries()
+        all_labels = {
+            catalog_entry.get_label()
+            for catalog_entry in catalog_entries
+            if catalog_entry.is_json()
+        }
+
+        current_directory = os.path.dirname(os.path.abspath(__file__))
+        for catalog_entry in catalog_entries:
+            if catalog_entry.is_dir:
+                catalog_entry.write_dir_contents_to_rst(
+                    destination_directory=current_directory,
+                    start_directory=self.start_directory,
+                )
+            elif catalog_entry.is_json():
+                artifact = load_json(catalog_entry.path)
+                label = catalog_entry.get_label()
                 content = make_content(artifact, label, all_labels)
-                section = write_section(rel_path.split("/")[-1], content, label)
-
-                artifact_doc_path = os.path.join(
-                    current_directory,
-                    os.path.dirname(rel_path),
-                    Path(rel_path).stem + ".rst",
+                section = write_section(catalog_entry.get_title(), content, label)
+                artifact_doc_path = catalog_entry.get_artifact_doc_path(
+                    destination_directory=current_directory
                 )
                 Path(artifact_doc_path).parent.mkdir(parents=True, exist_ok=True)
                 with open(artifact_doc_path, "w+") as f:
                     f.write(section)
 
-    create_dir_contents_rst(
-        start_directory,
-        current_directory,
-        dir_path=start_directory,
-        rel_path="catalog",
-    )
-
-
-def create_dir_contents_rst(start_directory, current_directory, dir_path, rel_path):
-    dir_doc_path = os.path.join(
-        current_directory,
-        rel_path + ".rst",
-    )
-    title = rel_path.split("/")[-1]
-    if title:
-        title = f"{title[0].upper()}{title[1:]}"
-    label = rel_path.replace("/", ".")
-    dir_doc_content = write_title(title, label)
-
-    for dir_entry in os.scandir(dir_path):
-        sub_rel_path = dir_entry.path.replace(start_directory + "/", "")
-        sub_label = sub_rel_path.replace("/", ".")
-        sub_name = os.path.basename(dir_entry.path)
-        dir_doc_content += f":ref:`{sub_name} <{sub_label}>`\n\n"
-    with open(dir_doc_path, "w+") as f:
-        f.write(dir_doc_content)
+        catalog_main_entry = CatalogEntry(
+            path=self.start_directory, is_dir=True, start_directory=self.start_directory
+        )
+        catalog_main_entry.write_dir_contents_to_rst(
+            destination_directory=current_directory,
+            start_directory=self.start_directory,
+        )
 
 
 if __name__ == "__main__":
-    build_catalog_rst()
+    CatalogDocsBuilder().run()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@ from unitxt.dataclass import Field
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from catalog import build_catalog_rst
+from catalog import CatalogDocsBuilder
 
-build_catalog_rst()
+CatalogDocsBuilder().run()
 
 
 # -- Project information -----------------------------------------------------

--- a/src/unitxt/formats.py
+++ b/src/unitxt/formats.py
@@ -35,23 +35,35 @@ class SystemFormat(Format):
 
     Example:
         when input instance:
-        {
-            "source": "1+1",
-            "target": "2",
-            "instruction": "Solve the math exercises.",
-            "demos": [{"source": "1+2", "target": "3"}, {"source": "4-2", "target": "2"}]
-        }
-        is process-ed by
-        system_format = SystemFormat(
-            demos_field="demos",
-            demo_format="Input: {source}\nOutput: {target}\n\n",
-            model_input_format="Instruction: {instruction}\n\n{demos}Input: {source}\nOutput: ",
-        )
+
+        .. code-block::
+
+            {
+                "source": "1+1",
+                "target": "2",
+                "instruction": "Solve the math exercises.",
+                "demos": [{"source": "1+2", "target": "3"}, {"source": "4-2", "target": "2"}]
+            }
+
+        is processed by
+
+        .. code-block::
+
+            system_format = SystemFormat(
+                demos_field="demos",
+                demo_format="Input: {source}\nOutput: {target}\n\n",
+                model_input_format="Instruction: {instruction}\n\n{demos}Input: {source}\nOutput: ",
+            )
+
         the resulting instance is:
-        {
-            "target": "2",
-            "source": "Instruction: Solve the math exercises.\n\nInput: 1+2\nOutput: 3\n\nInput: 4-2\nOutput: 2\n\nInput: 1+1\nOutput: ",
-        }
+
+        .. code-block::
+
+            {
+                "target": "2",
+                "source": "Instruction: Solve the math exercises.\n\nInput: 1+2\nOutput: 3\n\nInput: 4-2\nOutput: 2\n\nInput: 1+1\nOutput: ",
+            }
+
     """
 
     demos_field: str = "demos"


### PR DESCRIPTION
For https://github.com/IBM/unitxt/issues/460

- Under a directory (e.g. cards) list the content of the dir
- Each artifact should be in a separate file
- Artifact type docstring will be under the artifact's json
