### PR TITLE
override Matthews correlation in cases of perfect correlation

### DIFF
--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -979,6 +979,27 @@ class MatthewsCorrelation(HuggingfaceMetric):
         formatted_predictions = [
             self.get_str_id(prediction) for prediction in predictions
         ]
+
+        if (
+            len(formatted_predictions) > 1
+            and len(Counter(formatted_predictions)) == 1
+            and all(p == r for p, r in zip(formatted_predictions, formatted_references))
+        ):
+            # override because when all components are identical, there is only TP or only TN, out of the four
+            # {TP, TN, FP, FN}, and by definition, mcc is them 0.0, in spite of the full correlation.
+            # For a single-component prediction, the by-definition 0 is OK
+            return {"matthews_correlation": 1.0}
+
+        if (
+            len(formatted_predictions) > 1
+            and len(Counter(formatted_predictions)) == 1
+            and all(p != r for p, r in zip(formatted_predictions, formatted_references))
+        ):
+            # override because when all components of predictions are identical, and none hits its reference,
+            # we only have FP or only FN, out of the four {TP, TN, FP, FN}, and by definition, mcc is them 0.0,
+            # in spite of the perfect anti-correlation. For a single-component prediction, the by-definition 0 is OK
+            return {"matthews_correlation": -1.0}
+
         return self.metric.compute(
             predictions=formatted_predictions, references=formatted_references
         )


### PR DESCRIPTION
and perfect anti-correlation, when all prediction components are identical, and their number is > 1.
Addressing issue #439 

@yoavkatz , do we really want this? and not return the true MCC ?
https://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-019-6413-7   (the section with the epsilon..

users might compare our results with their own, or any other implementation of Matthews correlation, and might wonder about our anti-definition result.  See also scikit-learn:

![sklearn](https://github.com/IBM/unitxt/assets/46454972/83f237d6-980b-4b32-b0f9-00754a11f7be)

and exactly as in the example that started this issue:
![mcc2](https://github.com/IBM/unitxt/assets/46454972/3077e399-3f62-4955-92aa-012ef274f9b2)
