### PR TITLE
add CFPB from watson repository

### DIFF
--- a/prepare/cards/CFPB_product_5_classes.py
+++ b/prepare/cards/CFPB_product_5_classes.py
@@ -1,0 +1,43 @@
+from src.unitxt import add_to_catalog
+from src.unitxt.blocks import (
+    AddFields,
+    RenameFields,
+    SplitRandomMix,
+    TaskCard,
+)
+from src.unitxt.loaders import LoadCSV
+from src.unitxt.test_utils.card import test_card
+
+dataset_name = "CFPB_Product"
+
+
+card = TaskCard(
+    loader=LoadCSV(
+        files={
+            "train": "https://raw.githubusercontent.com/IBM/watson-machine-learning-samples/master/cloud/data/cfpb_complaints/cfpb_compliants.csv"
+        }
+    ),
+    preprocess_steps=[
+        SplitRandomMix(
+            {"train": "train[70%]", "validation": "train[10%]", "test": "train[20%]"}
+        ),
+        RenameFields(field_to_field={"narrative": "text", "product": "label"}),
+        AddFields(
+            fields={
+                "classes": [
+                    "retail_banking",
+                    "mortgages_and_loans",
+                    "debt_collection",
+                    "credit_card",
+                    "credit_reporting",
+                ],
+                "text_type": "text",
+                "type_of_class": "topic",
+            }
+        ),
+    ],
+    task="tasks.classification.multi_class",
+    templates="templates.classification.multi_class.all",
+)
+test_card(card, debug=False)
+add_to_catalog(card, f"cards.{dataset_name}.5_classes", overwrite=True)

--- a/src/unitxt/catalog/cards/CFPB_Product/5_classes.json
+++ b/src/unitxt/catalog/cards/CFPB_Product/5_classes.json
@@ -1,0 +1,42 @@
+{
+    "type": "task_card",
+    "loader": {
+        "type": "load_csv",
+        "files": {
+            "train": "https://raw.githubusercontent.com/IBM/watson-machine-learning-samples/master/cloud/data/cfpb_complaints/cfpb_compliants.csv"
+        }
+    },
+    "preprocess_steps": [
+        {
+            "type": "split_random_mix",
+            "mix": {
+                "train": "train[70%]",
+                "validation": "train[10%]",
+                "test": "train[20%]"
+            }
+        },
+        {
+            "type": "rename_fields",
+            "field_to_field": {
+                "narrative": "text",
+                "product": "label"
+            }
+        },
+        {
+            "type": "add_fields",
+            "fields": {
+                "classes": [
+                    "retail_banking",
+                    "mortgages_and_loans",
+                    "debt_collection",
+                    "credit_card",
+                    "credit_reporting"
+                ],
+                "text_type": "text",
+                "type_of_class": "topic"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class",
+    "templates": "templates.classification.multi_class.all"
+}


### PR DESCRIPTION
This is version that reflects watson version of CFPB. I got the following warning, hope that this is ok:
/u/ilyashn/.conda/envs/bzsm2.2/lib/python3.9/site-packages/scipy/stats/_resampling.py:100: DegenerateDataWarning: The BCa confidence interval cannot be calculated. This problem is known to occur when the distribution is degenerate or the statistic is np.min.
  warnings.warn(DegenerateDataWarning(msg))
/u/ilyashn/.conda/envs/bzsm2.2/lib/python3.9/site-packages/scipy/stats/_resampling.py:147: RuntimeWarning: invalid value encountered in scalar divide
  a_hat = 1/6 * sum(nums) / sum(dens)**(3/2)
/u/ilyashn/.conda/envs/bzsm2.2/lib/python3.9/site-packages/scipy/stats/_resampling.py:100: DegenerateDataWarning: The BCa confidence interval cannot be calculated. This problem is known to occur when the distribution is degenerate or the statistic is np.min.
  warnings.warn(DegenerateDataWarning(msg))
/u/ilyashn/.conda/envs/bzsm2.2/lib/python3.9/site-packages/scipy/stats/_resampling.py:147: RuntimeWarning: invalid value encountered in scalar divide
  a_hat = 1/6 * sum(nums) / sum(dens)**(3/2)
/u/ilyashn/.conda/envs/bzsm2.2/lib/python3.9/site-packages/scipy/stats/_resampling.py:100: DegenerateDataWarning: The BCa confidence interval cannot be calculated. This problem is known to occur when the distribution is degenerate or the statistic is np.min.
  warnings.warn(DegenerateDataWarning(msg))
