### PR TITLE
Make postprocessors a general operator that operates on 'prediction' and on 'references' which enables the use of every possible operator as postprocessor

### DIFF
--- a/prepare/processors/processors.py
+++ b/prepare/processors/processors.py
@@ -1,5 +1,6 @@
 from src.unitxt import add_to_catalog
 from src.unitxt.logging_utils import get_logger
+from src.unitxt.operator import SequentialOperator
 from src.unitxt.processors import (
     ConvertToBoolean,
     FirstCharacter,
@@ -14,51 +15,142 @@ from src.unitxt.processors import (
 )
 
 logger = get_logger()
-operator = TakeFirstNonEmptyLine(field="TBD")
 
-add_to_catalog(operator, "processors.take_first_non_empty_line", overwrite=True)
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            TakeFirstNonEmptyLine(field="prediction", process_every_value=False),
+            TakeFirstNonEmptyLine(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.take_first_non_empty_line",
+    overwrite=True,
+)
 
-operator2 = LowerCaseTillPunc(field="TBD")
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            LowerCaseTillPunc(field="prediction", process_every_value=False),
+            LowerCaseTillPunc(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.lower_case_till_punc",
+    overwrite=True,
+)
 
-add_to_catalog(operator2, "processors.lower_case_till_punc", overwrite=True)
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            StringOrNotString(
+                string="hate speech", field="prediction", process_every_value=False
+            ),
+            StringOrNotString(
+                string="hate speech", field="references", process_every_value=True
+            ),
+        ]
+    ),
+    "processors.hate_speech_or_not_hate_speech",
+    overwrite=True,
+)
 
-operator3 = StringOrNotString(string="hate speech", field="TBD")
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            LowerCase(field="prediction", process_every_value=False),
+            LowerCase(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.lower_case",
+    overwrite=True,
+)
 
-add_to_catalog(operator3, "processors.hate_speech_or_not_hate_speech", overwrite=True)
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            StringOrNotString(
+                string="toxic", field="prediction", process_every_value=False
+            ),
+            StringOrNotString(
+                string="toxic", field="references", process_every_value=True
+            ),
+        ]
+    ),
+    "processors.toxic_or_not_toxic",
+    overwrite=True,
+)
 
-operator4 = LowerCase(field="TBD")
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            ConvertToBoolean(field="prediction", process_every_value=False),
+            ConvertToBoolean(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.convert_to_boolean",
+    overwrite=True,
+)
 
-add_to_catalog(operator4, "processors.lower_case", overwrite=True)
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            TakeFirstWord(field="prediction", process_every_value=False),
+            TakeFirstWord(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.take_first_word",
+    overwrite=True,
+)
 
-operator5 = StringOrNotString(string="toxic", field="TBD")
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            YesNoToInt(field="prediction", process_every_value=False),
+            YesNoToInt(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.yes_no_to_int",
+    overwrite=True,
+)
 
-add_to_catalog(operator5, "processors.toxic_or_not_toxic", overwrite=True)
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            ToYesOrNone(field="prediction", process_every_value=False),
+            ToYesOrNone(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.to_yes_or_none",
+    overwrite=True,
+)
 
-operator6 = ConvertToBoolean(field="TBD")
-add_to_catalog(operator6, "processors.convert_to_boolean", overwrite=True)
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            StanceToProCon(field="prediction", process_every_value=False),
+            StanceToProCon(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.stance_to_pro_con",
+    overwrite=True,
+)
 
-operator7 = TakeFirstWord(field="TBD")
-add_to_catalog(operator7, "processors.take_first_word", overwrite=True)
-
-operator8 = YesNoToInt(field="TBD")
-add_to_catalog(operator8, "processors.yes_no_to_int", overwrite=True)
-
-operator9 = ToYesOrNone(field="TBD")
-add_to_catalog(operator9, "processors.to_yes_or_none", overwrite=True)
-
-operator10 = StanceToProCon(field="TBD")
-add_to_catalog(operator10, "processors.stance_to_pro_con", overwrite=True)
 
 parser = FirstCharacter(field="TBD")
-
 example = " A. This is the answer."
-
 logger.info(parser.process_value(example))
 assert parser.process_value(example) == "A"
 
 example = "   "
-
 logger.info(parser.process_value(example))
 assert parser.process_value(example) == ""
 
-add_to_catalog(parser, "processors.first_character", overwrite=True)
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            FirstCharacter(field="prediction", process_every_value=False),
+            FirstCharacter(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.first_character",
+    overwrite=True,
+)

--- a/prepare/processors/to_list_by_comma.py
+++ b/prepare/processors/to_list_by_comma.py
@@ -1,6 +1,14 @@
 from src.unitxt import add_to_catalog
+from src.unitxt.operator import SequentialOperator
 from src.unitxt.processors import ToListByComma
 
-operator = ToListByComma(field="TBD")
-
-add_to_catalog(operator, "processors.to_list_by_comma", overwrite=True)
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            ToListByComma(field="prediction", process_every_value=False),
+            ToListByComma(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.to_list_by_comma",
+    overwrite=True,
+)

--- a/prepare/processors/to_string.py
+++ b/prepare/processors/to_string.py
@@ -1,10 +1,25 @@
 from src.unitxt import add_to_catalog
 from src.unitxt.blocks import ToString, ToStringStripped
+from src.unitxt.operator import SequentialOperator
 
-operator = ToString(field="TBD")
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            ToString(field="prediction", process_every_value=False),
+            ToString(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.to_string",
+    overwrite=True,
+)
 
-add_to_catalog(operator, "processors.to_string", overwrite=True)
-
-operator = ToStringStripped(field="TBD")
-
-add_to_catalog(operator, "processors.to_string_stripped", overwrite=True)
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            ToStringStripped(field="prediction", process_every_value=False),
+            ToStringStripped(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.to_string_stripped",
+    overwrite=True,
+)

--- a/src/unitxt/catalog/processors/convert_to_boolean.json
+++ b/src/unitxt/catalog/processors/convert_to_boolean.json
@@ -1,4 +1,15 @@
 {
-    "type": "convert_to_boolean",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "convert_to_boolean",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "convert_to_boolean",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/dict_of_lists_to_value_key_pairs.json
+++ b/src/unitxt/catalog/processors/dict_of_lists_to_value_key_pairs.json
@@ -1,5 +1,17 @@
 {
-    "type": "dict_of_lists_to_pairs",
-    "position_key_before_value": false,
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "dict_of_lists_to_pairs",
+            "position_key_before_value": false,
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "dict_of_lists_to_pairs",
+            "position_key_before_value": false,
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/first_character.json
+++ b/src/unitxt/catalog/processors/first_character.json
@@ -1,4 +1,15 @@
 {
-    "type": "first_character",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "first_character",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "first_character",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/hate_speech_or_not_hate_speech.json
+++ b/src/unitxt/catalog/processors/hate_speech_or_not_hate_speech.json
@@ -1,5 +1,17 @@
 {
-    "type": "string_or_not_string",
-    "string": "hate speech",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "string_or_not_string",
+            "string": "hate speech",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "string_or_not_string",
+            "string": "hate speech",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/list_to_empty_entity_tuples.json
+++ b/src/unitxt/catalog/processors/list_to_empty_entity_tuples.json
@@ -1,4 +1,15 @@
 {
-    "type": "list_to_empty_entities_tuples",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "list_to_empty_entities_tuples",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "list_to_empty_entities_tuples",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/load_json.json
+++ b/src/unitxt/catalog/processors/load_json.json
@@ -1,4 +1,15 @@
 {
-    "type": "load_json",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "load_json",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "load_json",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/lower_case.json
+++ b/src/unitxt/catalog/processors/lower_case.json
@@ -1,4 +1,15 @@
 {
-    "type": "lower_case",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "lower_case",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "lower_case",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/lower_case_till_punc.json
+++ b/src/unitxt/catalog/processors/lower_case_till_punc.json
@@ -1,4 +1,15 @@
 {
-    "type": "lower_case_till_punc",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "lower_case_till_punc",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "lower_case_till_punc",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/stance_to_pro_con.json
+++ b/src/unitxt/catalog/processors/stance_to_pro_con.json
@@ -1,4 +1,15 @@
 {
-    "type": "stance_to_pro_con",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "stance_to_pro_con",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "stance_to_pro_con",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/take_first_non_empty_line.json
+++ b/src/unitxt/catalog/processors/take_first_non_empty_line.json
@@ -1,4 +1,15 @@
 {
-    "type": "take_first_non_empty_line",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "take_first_non_empty_line",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "take_first_non_empty_line",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/take_first_word.json
+++ b/src/unitxt/catalog/processors/take_first_word.json
@@ -1,4 +1,15 @@
 {
-    "type": "take_first_word",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "take_first_word",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "take_first_word",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/to_list_by_comma.json
+++ b/src/unitxt/catalog/processors/to_list_by_comma.json
@@ -1,4 +1,15 @@
 {
-    "type": "to_list_by_comma",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "to_list_by_comma",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "to_list_by_comma",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/to_span_label_pairs.json
+++ b/src/unitxt/catalog/processors/to_span_label_pairs.json
@@ -1,5 +1,17 @@
 {
-    "type": "regex_parser",
-    "regex": "\\s*((?:[^,:\\\\]|\\\\.)+?)\\s*:\\s*((?:[^,:\\\\]|\\\\.)+?)\\s*(?=,|$)",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "regex_parser",
+            "regex": "\\s*((?:[^,:\\\\]|\\\\.)+?)\\s*:\\s*((?:[^,:\\\\]|\\\\.)+?)\\s*(?=,|$)",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "regex_parser",
+            "regex": "\\s*((?:[^,:\\\\]|\\\\.)+?)\\s*:\\s*((?:[^,:\\\\]|\\\\.)+?)\\s*(?=,|$)",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/to_span_label_pairs_surface_only.json
+++ b/src/unitxt/catalog/processors/to_span_label_pairs_surface_only.json
@@ -1,6 +1,19 @@
 {
-    "type": "regex_parser",
-    "regex": "\\s*((?:\\\\.|[^,])+?)\\s*(?:,|$)()",
-    "termination_regex": "^\\s*None\\s*$",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "regex_parser",
+            "regex": "\\s*((?:\\\\.|[^,])+?)\\s*(?:,|$)()",
+            "termination_regex": "^\\s*None\\s*$",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "regex_parser",
+            "regex": "\\s*((?:\\\\.|[^,])+?)\\s*(?:,|$)()",
+            "termination_regex": "^\\s*None\\s*$",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/to_string.json
+++ b/src/unitxt/catalog/processors/to_string.json
@@ -1,4 +1,15 @@
 {
-    "type": "to_string",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "to_string",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "to_string",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/to_string_stripped.json
+++ b/src/unitxt/catalog/processors/to_string_stripped.json
@@ -1,4 +1,15 @@
 {
-    "type": "to_string_stripped",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "to_string_stripped",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "to_string_stripped",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/to_yes_or_none.json
+++ b/src/unitxt/catalog/processors/to_yes_or_none.json
@@ -1,4 +1,15 @@
 {
-    "type": "to_yes_or_none",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "to_yes_or_none",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "to_yes_or_none",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/toxic_or_not_toxic.json
+++ b/src/unitxt/catalog/processors/toxic_or_not_toxic.json
@@ -1,5 +1,17 @@
 {
-    "type": "string_or_not_string",
-    "string": "toxic",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "string_or_not_string",
+            "string": "toxic",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "string_or_not_string",
+            "string": "toxic",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/catalog/processors/yes_no_to_int.json
+++ b/src/unitxt/catalog/processors/yes_no_to_int.json
@@ -1,4 +1,15 @@
 {
-    "type": "yes_no_to_int",
-    "field": "TBD"
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "yes_no_to_int",
+            "field": "prediction",
+            "process_every_value": false
+        },
+        {
+            "type": "yes_no_to_int",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
 }

--- a/src/unitxt/metric.py
+++ b/src/unitxt/metric.py
@@ -32,7 +32,6 @@ from .operators import (
     Apply,
     ApplyMetric,
     ApplyOperatorsField,
-    ApplyStreamOperatorsField,
     FlattenInstances,
     MergeStreams,
     SplitByValue,
@@ -145,10 +144,7 @@ class MetricRecipe(SequentialOperatorInitilizer):
                 to_field="additional_inputs",
             ),
             ApplyOperatorsField(
-                inputs_fields=["prediction", "references"],
-                fields_to_treat_as_list=["references"],
                 operators_field="postprocessors",
-                default_operators=["processors.to_string_stripped"],
             ),
             SplitByValue(["group"]),
             ApplyMetric(

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -61,6 +61,7 @@ from .operator import (
     MultiStream,
     MultiStreamOperator,
     PagedStreamOperator,
+    SequentialOperator,
     SingleStreamOperator,
     SingleStreamReducer,
     StreamingOperator,
@@ -1091,24 +1092,23 @@ class ApplyOperatorsField(StreamInstanceOperator, ArtifactFetcherMixin):
     """Applies value operators to each instance in a stream based on specified fields.
 
     Args:
-        inputs_fields (List[str]): list of field names, the values in which are to be processed
-        fields_to_treat_as_list (List[str]): sublist of input_fields, each member of this sublist is supposed to contain
-            a list of values, each of which is to be processed.
-        operators_field (str): name of the field that contains the list of names of the operators to be applied,
-            one after the other, for the processing. Operators are all (extensions of) FieldOperator
+        operators_field (str): name of the field that contains a single name, or a list of names, of the operators to be applied,
+            one after the other, for the processing of the instance. Each operator is equipped with 'process_instance()'
+            method.
+
         default_operators (List[str]): A list of default operators to be used if no operators are found in the instance.
 
     Example:
-        when instance {"a": 111, "b": 2, "c": ["processors.to_string", "processors.first_character"]} is processed by operator:
-        operator = ApplyOperatorsField(inputs_fields=["a"], operators_field="c", default_operators=["add"]),
-        the resulting instance is: {"a": "1", "b": 2, "c": ["processors.to_string", "processors.first_character"]}
+        when instance {"prediction": 111, "references": [222, 333] , "c": ["processors.to_string", "processors.first_character"]}
+        is processed by operator (please look up the catalog that these operators, they are tuned to process fields "prediction" and
+        "references"):
+        operator = ApplyOperatorsField(operators_field="c"),
+        the resulting instance is: {"prediction": "1", "references": ["2", "3"], "c": ["processors.to_string", "processors.first_character"]}
 
     """
 
-    inputs_fields: List[str]
     operators_field: str
     default_operators: List[str] = None
-    fields_to_treat_as_list: List[str] = NonPositionalField(default_factory=list)
 
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
@@ -1122,17 +1122,11 @@ class ApplyOperatorsField(StreamInstanceOperator, ArtifactFetcherMixin):
 
         if isinstance(operator_names, str):
             operator_names = [operator_names]
+        # otherwise , operator_names is already a list
 
-        for name in operator_names:
-            operator = self.get_artifact(name)
-            for field_name in self.inputs_fields:
-                value = instance[field_name]
-                if field_name in self.fields_to_treat_as_list:
-                    instance[field_name] = [operator.process_value(v) for v in value]
-                else:
-                    instance[field_name] = operator.process_value(value)
-
-        return instance
+        # we now have a list of nanes of operators, each is equipped with process_instance method.
+        operator = SequentialOperator(steps=operator_names)
+        return operator.process_instance(instance)
 
 
 class FilterByCondition(SingleStreamOperator):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,8 +30,10 @@ class TestExamples(unittest.TestCase):
         from src.unitxt.metrics import Accuracy
         from src.unitxt.text_utils import print_dict
 
-        add_to_catalog(ToString(field="TBD"), "processors.to_string", overwrite=True)
-        add_to_catalog(Accuracy(), "metrics.accuracy", overwrite=True)
+        add_to_catalog(
+            ToString(field="TBD"), "processors.example.to_string", overwrite=True
+        )
+        add_to_catalog(Accuracy(), "metrics.example.accuracy", overwrite=True)
 
         data = [
             {

--- a/tests/test_postprocessors.py
+++ b/tests/test_postprocessors.py
@@ -1,6 +1,12 @@
 import unittest
+from typing import Any, List
 
 from src.unitxt.artifact import fetch_artifact
+from src.unitxt.test_utils.operators import check_operator
+
+
+def list_to_stream_with_prediction_and_references(list: List[Any]) -> List[Any]:
+    return [{"prediction": item, "references": [item]} for item in list]
 
 
 class TestPostProcessors(unittest.TestCase):
@@ -17,9 +23,12 @@ class TestPostProcessors(unittest.TestCase):
         ]
         targets = ["TRUE", "TRUE", "FALSE", "TRUE", "TRUE", "FALSE", "OTHER"]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_to_span_label_pairs(self):
         parser, _ = fetch_artifact("processors.to_span_label_pairs")
@@ -29,70 +38,93 @@ class TestPostProcessors(unittest.TestCase):
             [],
         ]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_to_list_by_comma(self):
         parser, _ = fetch_artifact("processors.to_list_by_comma")
         inputs = ["cat, dog", "man, woman, dog"]
         targets = [["cat", "dog"], ["man", "woman", "dog"]]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_take_first_word(self):
         parser, _ = fetch_artifact("processors.take_first_word")
         inputs = ["- yes, I think it is"]
         targets = ["yes"]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
-
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
         inputs = ["..."]
         targets = [""]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_yes_no_to_int(self):
         parser, _ = fetch_artifact("processors.yes_no_to_int")
         inputs = ["yes", "no", "yaa"]
         targets = ["1", "0", "0"]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_to_yes_or_none(self):
         parser, _ = fetch_artifact("processors.to_yes_or_none")
         inputs = ["yes", "no", "yaa"]
         targets = ["yes", "none", "none"]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_stance_to_pro_con(self):
         parser, _ = fetch_artifact("processors.stance_to_pro_con")
         inputs = ["positive", "negative", "suggestion", "neutral", "nothing"]
         targets = ["PRO", "CON", "CON", "none", "none"]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_to_span_label_pairs_surface_only(self):
         parser, _ = fetch_artifact("processors.to_span_label_pairs_surface_only")
         inputs = [r"John\,\: Doe, New York", "None"]
         targets = [[("John\\,\\: Doe", ""), ("New York", "")], []]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_load_json(self):
         parser, _ = fetch_artifact("processors.load_json")
@@ -106,9 +138,12 @@ class TestPostProcessors(unittest.TestCase):
             [],
         ]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_dict_of_lists_to_value_key_pairs(self):
         parser, _ = fetch_artifact("processors.dict_of_lists_to_value_key_pairs")
@@ -122,9 +157,12 @@ class TestPostProcessors(unittest.TestCase):
             [],
         ]
 
-        for input, target in zip(inputs, targets):
-            parsed = parser.process_value(input)
-            self.assertEqual(target, parsed)
+        check_operator(
+            operator=parser,
+            inputs=list_to_stream_with_prediction_and_references(inputs),
+            targets=list_to_stream_with_prediction_and_references(targets),
+            tester=self,
+        )
 
     def test_span_labeling_json_template_errors(self):
         postprocessor1, _ = fetch_artifact("processors.load_json")
@@ -137,10 +175,15 @@ class TestPostProcessors(unittest.TestCase):
         post1_targets = [{}, {"d": {"b": "c"}}, [], ["djje", "djjjd"]]
         post2_targets = [[], [("b", "d")], [], []]
 
-        for pred, post_target1, post_target2 in zip(
-            predictions, post1_targets, post2_targets
-        ):
-            post1 = postprocessor1.process_value(pred)
-            self.assertEqual(post1, post_target1)
-            post2 = postprocessor2.process_value(post1)
-            self.assertEqual(post2, post_target2)
+        check_operator(
+            operator=postprocessor1,
+            inputs=list_to_stream_with_prediction_and_references(predictions),
+            targets=list_to_stream_with_prediction_and_references(post1_targets),
+            tester=self,
+        )
+        check_operator(
+            operator=postprocessor2,
+            inputs=list_to_stream_with_prediction_and_references(post1_targets),
+            targets=list_to_stream_with_prediction_and_references(post2_targets),
+            tester=self,
+        )


### PR DESCRIPTION
@elronbandel , please see if this is in the direction of what you had in mind, and I will complete for all the other postprocessors, and the needed unit_tests.