### PR TITLE
Update QA templates

### DIFF
--- a/prepare/cards/squad.py
+++ b/prepare/cards/squad.py
@@ -1,4 +1,4 @@
-from src.unitxt.blocks import CopyFields, FormTask, LoadHF, TaskCard
+from src.unitxt.blocks import CopyFields, LoadHF, TaskCard
 from src.unitxt.catalog import add_to_catalog
 from src.unitxt.test_utils.card import test_card
 
@@ -6,13 +6,9 @@ card = TaskCard(
     loader=LoadHF(path="squad"),
     preprocess_steps=[
         "splitters.small_no_test",
-        CopyFields(field_to_field=[["answers/text", "answers"]], use_query=True),
+        CopyFields(field_to_field=[["answers/text", "answer"]], use_query=True),
     ],
-    task=FormTask(
-        inputs=["context", "question"],
-        outputs=["answers"],
-        metrics=["metrics.squad"],
-    ),
+    task="tasks.qa.contextual.extractive",
     templates="templates.qa.contextual.all",
 )
 

--- a/prepare/templates/qa/contextual.py
+++ b/prepare/templates/qa/contextual.py
@@ -4,7 +4,7 @@ from src.unitxt.templates import MultiReferenceTemplate, TemplatesList
 add_to_catalog(
     MultiReferenceTemplate(
         input_format="Context: {context}\nQuestion: {question}",
-        references_field="answers",
+        references_field="answer",
     ),
     "templates.qa.contextual.simple",
     overwrite=True,
@@ -13,7 +13,7 @@ add_to_catalog(
 add_to_catalog(
     MultiReferenceTemplate(
         input_format="based on this text: {context}\n answer the question: {question}",
-        references_field="answers",
+        references_field="answer",
     ),
     "templates.qa.contextual.simple2",
     overwrite=True,

--- a/src/unitxt/catalog/cards/squad.json
+++ b/src/unitxt/catalog/cards/squad.json
@@ -11,24 +11,12 @@
             "field_to_field": [
                 [
                     "answers/text",
-                    "answers"
+                    "answer"
                 ]
             ],
             "use_query": true
         }
     ],
-    "task": {
-        "type": "form_task",
-        "inputs": [
-            "context",
-            "question"
-        ],
-        "outputs": [
-            "answers"
-        ],
-        "metrics": [
-            "metrics.squad"
-        ]
-    },
+    "task": "tasks.qa.contextual.extractive",
     "templates": "templates.qa.contextual.all"
 }

--- a/src/unitxt/catalog/templates/qa/contextual/simple.json
+++ b/src/unitxt/catalog/templates/qa/contextual/simple.json
@@ -1,5 +1,5 @@
 {
     "type": "multi_reference_template",
     "input_format": "Context: {context}\nQuestion: {question}",
-    "references_field": "answers"
+    "references_field": "answer"
 }

--- a/src/unitxt/catalog/templates/qa/contextual/simple2.json
+++ b/src/unitxt/catalog/templates/qa/contextual/simple2.json
@@ -1,5 +1,5 @@
 {
     "type": "multi_reference_template",
     "input_format": "based on this text: {context}\n answer the question: {question}",
-    "references_field": "answers"
+    "references_field": "answer"
 }


### PR DESCRIPTION
Standardize QA templates to use `answer` as the output field and not `answers`.
Update squad card to use the standard QA task.