### PR TITLE
Update catalog navigation Index on documentation side menu for easier catalog browsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ clear-docs:
 	rm $(DIR)/docs/modules.rst
 	rm $(DIR)/docs/unitxt.rst
 	rm $(DIR)/docs/unitxt.*.rst
+	rm $(DIR)/docs/catalog.*.rst
 
 docs: docs-html
 

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -83,20 +83,17 @@ class CatalogEntry:
         return Path(self.rel_path).stem
 
     def get_artifact_doc_path(self, destination_directory, with_extension=True):
+        dirname = os.path.dirname(self.rel_path)
+        if dirname:
+            dirname = dirname.replace(os.path.sep, ".") + "."
         result = os.path.join(
             destination_directory,
-            os.path.dirname(self.rel_path).replace("/", ".")
-            + "."
-            + Path(self.rel_path).stem,
+            dirname + Path(self.rel_path).stem,
         )
+
         if with_extension:
             result += ".rst"
         return result
-
-    def get_dir_doc_path(self, destination_directory, with_extension=True):
-        return self.get_artifact_doc_path(
-            destination_directory, with_extension=with_extension
-        )
 
     def write_dir_contents_to_rst(self, destination_directory, start_directory):
         title = self.get_title()
@@ -116,7 +113,7 @@ class CatalogEntry:
         sub_dir_entries = [entry for entry in sub_catalog_entries if entry.is_dir]
         sub_dir_entries.sort(key=lambda entry: entry.path)
         for sub_dir_entry in sub_dir_entries:
-            sub_name = sub_dir_entry.get_dir_doc_path(
+            sub_name = sub_dir_entry.get_artifact_doc_path(
                 destination_directory="", with_extension=False
             )
             dir_doc_content += f"   {sub_name}\n"
@@ -129,7 +126,7 @@ class CatalogEntry:
             )
             dir_doc_content += f"   {sub_name}\n"
 
-        dir_doc_path = self.get_dir_doc_path(destination_directory)
+        dir_doc_path = self.get_artifact_doc_path(destination_directory)
         Path(dir_doc_path).parent.mkdir(exist_ok=True, parents=True)
         with open(dir_doc_path, "w+") as f:
             f.write(dir_doc_content)

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -40,7 +40,7 @@ def make_content(artifact, label, all_labels):
 
     if artifact_class.__doc__:
         result += f"\nExplanation about `{type_class_name}`\n"
-        result += "+++++++++++++++++++\n\n"
+        result += "+++++++++++++++++++++++++++++++\n\n"
         result += artifact_class.__doc__ + "\n"
 
     references = []

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -88,7 +88,7 @@ class CatalogEntry:
             dirname = dirname.replace(os.path.sep, ".") + "."
         result = os.path.join(
             destination_directory,
-            dirname + Path(self.rel_path).stem,
+            "catalog." + dirname + Path(self.rel_path).stem,
         )
 
         if with_extension:

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -39,8 +39,9 @@ def make_content(artifact, label, all_labels):
     )
 
     if artifact_class.__doc__:
-        result += f"\nExplanation about `{type_class_name}`\n"
-        result += "+++++++++++++++++++++++++++++++\n\n"
+        explanation_str = f"Explanation about `{type_class_name}`"
+        result += f"\n{explanation_str}\n"
+        result += "+" * len(explanation_str) + "\n\n"
         result += artifact_class.__doc__ + "\n"
 
     references = []


### PR DESCRIPTION
Update catalog directory contents, to enable:
- The TOC panel on the left
- The breadcrumbs on the top

Also:
- This change avoids most of the warnings while creating the docs. 
- Fixed the length of the heading marker under the "Explanation for X" title, now its aligned with the title length.

To make this work, all the catalog RST files are now created in the main doc directory (i.e. not in subdirs), and their name is prefixed with `catalog.`.


![image](https://github.com/IBM/unitxt/assets/55045955/936cb183-7248-40bf-84f8-5526605e0f78)
