### PR TITLE
Fix catalog main entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,7 @@ t.py
 SECRETS.SH
 .DS_Store
 
-docs/catalog.rst
+docs/catalog.*.rst
 docs/unitxt.rst
 docs/modules.rst
 docs/unitxt.*.rst

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ t.py
 SECRETS.SH
 .DS_Store
 
+docs/catalog.rst
 docs/catalog.*.rst
 docs/unitxt.rst
 docs/modules.rst

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ clear-docs:
 	rm $(DIR)/docs/unitxt.rst
 	rm $(DIR)/docs/unitxt.*.rst
 	rm $(DIR)/docs/catalog.*.rst
+	rm -r $(DIR)/docs/_build/
 
 docs: docs-html
 

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -84,12 +84,16 @@ class CatalogEntry:
         return Path(self.rel_path).stem
 
     def get_artifact_doc_path(self, destination_directory, with_extension=True):
+        """Return the path to an RST file which describes this object."""
         dirname = os.path.dirname(self.rel_path)
         if dirname:
             dirname = dirname.replace(os.path.sep, ".") + "."
+        if not self.rel_path.startswith("catalog"):
+            # add prefix to the rst file path, if not the main catalog file
+            dirname = "catalog." + dirname
         result = os.path.join(
             destination_directory,
-            "catalog." + dirname + Path(self.rel_path).stem,
+            dirname + Path(self.rel_path).stem,
         )
 
         if with_extension:


### PR DESCRIPTION
- Fix the name of the catalog main file: catalog.catalog.rst -> catalog.rst
- Update .gitignore to ignore all catalog rst files.
- Update makefile to clear docs/_build when running clear-docs. Otherwise old htmls may be shown by the server, thus preventing the contents from properly reflecting the RST files.