### PR TITLE
Added UNITXT_TEST_METRIC_DISABLE to disable test_metric

### DIFF
--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -43,6 +43,13 @@ def test_loading_from_catalog(card):
 
 
 def load_examples_from_standard_recipe(card, template_card_index, debug, **kwargs):
+    disable = os.getenv("UNITXT_TEST_CARD_DISABLE", None)
+    if disable is not None:
+        logger.info(
+            "load_examples_from_standard_recipe() functionality is disabled because UNITXT_TEST_CARD_DISABLE environment variable is set"
+        )
+        return None
+
     logger.info("*" * 80)
     logger.info(f"Using template card index: {template_card_index}")
 

--- a/src/unitxt/test_utils/metrics.py
+++ b/src/unitxt/test_utils/metrics.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any, List, Optional
 
 from ..logging_utils import get_logger
@@ -67,6 +68,13 @@ def test_metric(
     global_target: dict,
     additional_inputs: Optional[List[dict]] = None,
 ):
+    disable = os.getenv("UNITXT_TEST_METRIC_DISABLE", None)
+    if disable is not None:
+        logger.info(
+            "test_metric() functionality is disabled because UNITXT_TEST_METRIC_DISABLE environment variable is set"
+        )
+        return None
+
     assert isoftype(metric, Metric), "operator must be an Operator"
     assert isoftype(predictions, List[Any]), "predictions must be a list"
     assert isoftype(references, List[Any]), "references must be a list"


### PR DESCRIPTION
For quick check of catalog consistency

(Also made UNITXT_TEST_CARD_DISABLE effect load_examples_from_standard_recipe)