### PR TITLE
Fix parser to allow source name that starts with numeric

### DIFF
--- a/src/unitxt/split_utils.py
+++ b/src/unitxt/split_utils.py
@@ -31,7 +31,8 @@ def parse_random_mix_string(input_str):
             {'dale': 0.9, 'oren': 0.7, 'mike': 1.0}
     """
     if not re.fullmatch(
-        r"((\w+\[\d*\.?\d*%?\]|\w+)\+)*(\w+\[\d*\.?\d*%?\]|\w+)", input_str,
+        r"((\w+\[\d*\.?\d*%?\]|\w+)\+)*(\w+\[\d*\.?\d*%?\]|\w+)",
+        input_str,
     ):
         raise ValueError(f"Invalid input format for split '{input_str}'")
 

--- a/src/unitxt/split_utils.py
+++ b/src/unitxt/split_utils.py
@@ -31,12 +31,11 @@ def parse_random_mix_string(input_str):
             {'dale': 0.9, 'oren': 0.7, 'mike': 1.0}
     """
     if not re.fullmatch(
-        r"(([a-zA-Z]+\[\d*\.?\d*%?\]|[a-zA-Z]+)\+)*([a-zA-Z]+\[\d*\.?\d*%?\]|[a-zA-Z]+)",
-        input_str,
+        r"((\w+\[\d*\.?\d*%?\]|\w+)\+)*(\w+\[\d*\.?\d*%?\]|\w+)", input_str,
     ):
         raise ValueError(f"Invalid input format for split '{input_str}'")
 
-    pattern = re.compile(r"([a-zA-Z]+)(\[\d*\.?\d*%?\])?")
+    pattern = re.compile(r"(\w+)(\[\d*\.?\d*%?\])?")
     matches = pattern.findall(input_str)
 
     return {


### PR DESCRIPTION
close https://github.com/IBM/unitxt/issues/529

To allow source name that starts with numeric, I replaced `[a-zA-Z]` to `\w` in regex.

I read [CONTRIBUTING.md](https://github.com/IBM/unitxt/blob/main/CONTRIBUTING.md) but I don't have the permission to create a branch so I forked this repo.
