### PR TITLE
Support artifact_identifier in Artifact objects

### DIFF
--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from functools import lru_cache
 from typing import Dict, List, Union, final
 
-from .dataclass import Dataclass, Field, fields
+from .dataclass import Dataclass, Field, InternalField, fields
 from .logging_utils import get_logger
 from .text_utils import camel_to_snake_case, is_camel_case
 from .type_utils import issubtype
@@ -102,6 +102,11 @@ class Artifact(Dataclass):
 
     _class_register = {}
 
+    artifact_identifier: str = InternalField(default=None, required=False)
+
+    def set_artifact_identifier(self, value):
+        self.artifact_identifier = value
+
     @classmethod
     def is_artifact_dict(cls, d):
         return isinstance(d, dict) and "type" in d
@@ -191,9 +196,11 @@ class Artifact(Dataclass):
         return cls._recursive_load(d)
 
     @classmethod
-    def load(cls, path):
+    def load(cls, path, artifact_identifier=None):
         d = load_json(path)
-        return cls.from_dict(d)
+        new_artifact = cls.from_dict(d)
+        new_artifact.set_artifact_identifier(artifact_identifier)
+        return new_artifact
 
     def prepare(self):
         pass

--- a/src/unitxt/catalog.py
+++ b/src/unitxt/catalog.py
@@ -52,7 +52,7 @@ class LocalCatalog(Catalog):
             artifact_identifier in self
         ), f"Artifact with name {artifact_identifier} does not exist"
         path = self.path(artifact_identifier)
-        return Artifact.load(path)
+        return Artifact.load(path, artifact_identifier)
 
     def __getitem__(self, name) -> Artifact:
         return self.load(name)

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -1,0 +1,32 @@
+import unittest
+
+from src.unitxt.artifact import (
+    Artifact,
+)
+from src.unitxt.dataclass import UnexpectedArgumentError
+from src.unitxt.logging_utils import get_logger
+
+logger = get_logger()
+
+
+class TestArtifact(unittest.TestCase):
+    def test_set_artifact_identifier(self):
+        artifact = Artifact()
+        artifact_identifier = "artifact.id.dummy"
+        artifact.set_artifact_identifier(value=artifact_identifier)
+        self.assertEqual(artifact_identifier, artifact.artifact_identifier)
+
+    def test_artifact_identifier_setter(self):
+        artifact = Artifact()
+        artifact_identifier = "artifact.id.dummy"
+        artifact.artifact_identifier = artifact_identifier
+        self.assertEqual(artifact_identifier, artifact.artifact_identifier)
+
+    def test_artifact_identifier_cannot_be_used_as_keyword_arg(self):
+        """Test that artifact_identifier cannot be set in construction.
+
+        Since it is an internal field, and isn't serialized, it should never be set when
+        constructing an Artifact from kwargs.
+        """
+        with self.assertRaises(UnexpectedArgumentError):
+            Artifact(artifact_identifier="artifact.id.dummy")


### PR DESCRIPTION
- Add a new artifact_identifier field to Artifact
- Added tests
- Motivation: sometimes, given an Artifact, it is useful to know the identifier that for used for fetching the artifact from the catalog. So this PR saves that identifier within the artifact, when it is loaded from the catalog.