### PR TITLE
Following Elron's fix, remove all special tweaks  

### DIFF
--- a/prepare/cards/multidoc2dial.py
+++ b/prepare/cards/multidoc2dial.py
@@ -1,7 +1,12 @@
 from src.unitxt.blocks import LoadHF, TaskCard
 from src.unitxt.catalog import add_to_catalog
 from src.unitxt.operators import ExecuteExpression, ListFieldValues, RenameFields
+from src.unitxt.settings_utils import get_settings
 from src.unitxt.test_utils.card import test_card
+
+settings = get_settings()
+orig_settings = settings.allow_unverified_code
+settings.allow_unverified_code = True
 
 card_abstractive = TaskCard(
     loader=LoadHF(path="multidoc2dial"),
@@ -36,3 +41,5 @@ for name, card in zip(
 ):
     test_card(card)
     add_to_catalog(card, f"cards.multidoc2dial.{name}", overwrite=True)
+
+settings.allow_unverified_code = orig_settings

--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -237,7 +237,7 @@ def get_raw(obj):
         return obj._to_raw_dict()
 
     if isinstance(obj, tuple) and hasattr(obj, "_fields"):  # named tuple
-        return type(obj)([get_raw(v) for v in obj])
+        return type(obj)(*[get_raw(v) for v in obj])
 
     if isinstance(obj, (list, tuple)):
         return type(obj)([get_raw(v) for v in obj])

--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -207,7 +207,7 @@ class Artifact(Dataclass):
 
     @final
     def __pre_init__(self, **kwargs):
-        self._init_dict = deepcopy(get_raw(kwargs))
+        self._init_dict = get_raw(kwargs)
 
     @final
     def __post_init__(self):
@@ -232,14 +232,20 @@ class Artifact(Dataclass):
         save_json(path, data)
 
 
-def get_raw(element):
-    if isinstance(element, Artifact):
-        return element._to_raw_dict()
-    if isinstance(element, (list, tuple)):
-        return type(element)([get_raw(sub_element) for sub_element in element])
-    if isinstance(element, dict):
-        return {key: get_raw(value) for key, value in element.items()}
-    return element
+def get_raw(obj):
+    if isinstance(obj, Artifact):
+        return obj._to_raw_dict()
+
+    if isinstance(obj, tuple) and hasattr(obj, "_fields"):  # named tuple
+        return type(obj)([get_raw(v) for v in obj])
+
+    if isinstance(obj, (list, tuple)):
+        return type(obj)([get_raw(v) for v in obj])
+
+    if isinstance(obj, dict):
+        return type(obj)({get_raw(k): get_raw(v) for k, v in obj.items()})
+
+    return deepcopy(obj)
 
 
 class ArtifactList(list, Artifact):

--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -236,7 +236,7 @@ def get_raw(element):
     if isinstance(element, Artifact):
         return element._to_raw_dict()
     if isinstance(element, (list, tuple)):
-        return [get_raw(sub_element) for sub_element in element]
+        return type(element)([get_raw(sub_element) for sub_element in element])
     if isinstance(element, dict):
         return {key: get_raw(value) for key, value in element.items()}
     return element

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1232,17 +1232,13 @@ class ComputeExpressionMixin(Artifact):
 
     def prepare(self):
         # can not do the imports here, because object does not pickle with imports
-        self.globs = {}
-        self.to_import = True
+        self.globals = {
+            module_name: import_module(module_name) for module_name in self.imports_list
+        }
 
     def compute_expression(self, instance: dict) -> Any:
-        if self.to_import:
-            for module_name in self.imports_list:
-                self.globs[module_name] = import_module(module_name)
-            self.to_import = False
-
         if settings.allow_unverified_code:
-            return eval(self.expression, self.globs, instance)
+            return eval(self.expression, self.globals, instance)
 
         raise ValueError(
             f"Cannot run expression by {self} when unitxt.settings.allow_unverified_code=False either set it to True or set {settings.allow_unverified_code_key} environment variable."

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -151,22 +151,12 @@ def test_with_eval(
 ):
     if type(card.templates) is TemplatesDict:
         for template_card_index in card.templates.keys():
-            # restore the operators on the card, so that they are fresh for second invocation of
-            # StandardRecipe as they are for the first one
-            if card.preprocess_steps is not None:
-                for step in card.preprocess_steps:
-                    step.prepare()
             examples = load_examples_from_standard_recipe(
                 card, template_card_index=template_card_index, debug=debug, **kwargs
             )
     else:
         num_templates = len(card.templates)
         for template_card_index in range(0, num_templates):
-            # restore the operators on the card, so that they are fresh for second invocation of
-            # StandardRecipe as they are for the first one
-            if card.preprocess_steps is not None:
-                for step in card.preprocess_steps:
-                    step.prepare()
             examples = load_examples_from_standard_recipe(
                 card, template_card_index=template_card_index, debug=debug, **kwargs
             )

--- a/tests/test_function_operators.py
+++ b/tests/test_function_operators.py
@@ -52,7 +52,7 @@ class TestFunctionOperators(unittest.TestCase):
                 "type": "apply",
                 "function": "str.upper",
                 "to_field": "b",
-                "_argv": ("a",),
+                "_argv": ["a"],
             },
             dic,
         )

--- a/tests/test_function_operators.py
+++ b/tests/test_function_operators.py
@@ -52,7 +52,7 @@ class TestFunctionOperators(unittest.TestCase):
                 "type": "apply",
                 "function": "str.upper",
                 "to_field": "b",
-                "_argv": ["a"],
+                "_argv": ("a",),
             },
             dic,
         )


### PR DESCRIPTION
Following Elron's fix, remove all special tweaks  to not import modules in init, and artificially postpone to process.  After Elron's fix, these tweaks are not needed.