### PR TITLE
Add plugin operators

### DIFF
--- a/prepare/cards/wikitq.py
+++ b/prepare/cards/wikitq.py
@@ -2,12 +2,14 @@ from src.unitxt.blocks import (
     AddFields,
     CopyFields,
     LoadHF,
+    RenameFields,
     SerializeTableAsIndexedRowMajor,
     TaskCard,
     TruncateTableCells,
     TruncateTableRows,
 )
 from src.unitxt.catalog import add_to_catalog
+from src.unitxt.operator import PlugInOperator
 from src.unitxt.test_utils.card import test_card
 
 card = TaskCard(
@@ -18,7 +20,13 @@ card = TaskCard(
         AddFields({"context_type": "table"}),
         TruncateTableCells(max_length=15, table="table", text_output="answer"),
         TruncateTableRows(field="table", rows_to_keep=50),
-        SerializeTableAsIndexedRowMajor(field_to_field=[["table", "context"]]),
+        PlugInOperator(
+            field="table_serializer",
+            default=SerializeTableAsIndexedRowMajor(
+                field_to_field=[["table", "table"]]
+            ),
+        ),
+        RenameFields(field_to_field={"table": "context"}),
     ],
     task="tasks.qa.with_context.extractive",
     templates="templates.qa.with_context.all",

--- a/prepare/serializers/table.py
+++ b/prepare/serializers/table.py
@@ -1,0 +1,10 @@
+from src.unitxt import add_to_catalog
+from src.unitxt.table_operators import (
+    SerializeTableAsIndexedRowMajor,
+    SerializeTableAsMarkdown,
+)
+
+add_to_catalog(SerializeTableAsMarkdown(field="table"), "serializers.table.markdown")
+add_to_catalog(
+    SerializeTableAsIndexedRowMajor(field="table"), "serializers.table.indexed_row"
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ target-version = "py38"
 "src/unitxt/type_utils.py" = ["C901"]
 "src/unitxt/dataclass.py" = ["C901"]
 "src/unitxt/operators.py" = ["C901"]
+"src/unitxt/standard.py" = ["C901"]
 "docs/conf.py" = ["E402"]
 "prepare/instructions/models/llama.py" = ["RUF001"]
 "utils/hf/prepare_dataset.py" = ["T201"]

--- a/src/unitxt/catalog/cards/wikitq.json
+++ b/src/unitxt/catalog/cards/wikitq.json
@@ -34,13 +34,23 @@
             "rows_to_keep": 50
         },
         {
-            "type": "serialize_table_as_indexed_row_major",
-            "field_to_field": [
-                [
-                    "table",
-                    "context"
+            "type": "plug_in_operator",
+            "field": "table_serializer",
+            "default": {
+                "type": "serialize_table_as_indexed_row_major",
+                "field_to_field": [
+                    [
+                        "table",
+                        "table"
+                    ]
                 ]
-            ]
+            }
+        },
+        {
+            "type": "rename_fields",
+            "field_to_field": {
+                "table": "context"
+            }
         }
     ],
     "task": "tasks.qa.with_context.extractive",

--- a/src/unitxt/catalog/serializers/table/indexed_row.json
+++ b/src/unitxt/catalog/serializers/table/indexed_row.json
@@ -1,0 +1,4 @@
+{
+    "type": "serialize_table_as_indexed_row_major",
+    "field": "table"
+}

--- a/src/unitxt/catalog/serializers/table/markdown.json
+++ b/src/unitxt/catalog/serializers/table/markdown.json
@@ -1,0 +1,4 @@
+{
+    "type": "serialize_table_as_markdown",
+    "field": "table"
+}

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -6,11 +6,7 @@ from .formats import Format, SystemFormat
 from .instructions import EmptyInstruction, Instruction
 from .logging_utils import get_logger
 from .operator import SourceSequentialOperator, StreamingOperator
-from .operators import (
-    Augmentor,
-    NullAugmentor,
-    StreamRefiner,
-)
+from .operators import AddFields, Augmentor, NullAugmentor, StreamRefiner
 from .recipe import Recipe
 from .schema import ToUnitxtGroup
 from .splitters import Sampler, SeparateSplit, SpreadSplit
@@ -29,6 +25,7 @@ class AddDemosField(SpreadSplit):
 
 
 class BaseRecipe(Recipe, SourceSequentialOperator):
+    __allow_unexpected_arguments__ = True
     card: TaskCard
     template: Template = None
     instruction: Instruction = Field(default_factory=EmptyInstruction)
@@ -114,6 +111,10 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
         self.steps = [
             self.card.loader,
         ]
+
+        if hasattr(self, "_kwargs"):
+            if len(self._kwargs) > 0:
+                self.steps.append(AddFields(fields=self._kwargs))
 
         if self.loader_limit:
             self.card.loader.loader_limit = self.loader_limit

--- a/tests/library/test_api.py
+++ b/tests/library/test_api.py
@@ -43,3 +43,27 @@ class TestAPI(UnitxtTestCase):
         predictions = ["2.5", "2.5", "2.2", "3", "4"]
         results = evaluate(predictions, dataset["train"])
         self.assertAlmostEqual(results[0]["score"]["global"]["score"], 0.026, 3)
+
+    def test_load_dataset_with_setting_table_serializer(self):
+        dataset = load_dataset(
+            "card=cards.wikitq,table_serializer=serializers.table.markdown,template=templates.qa.with_context.question_first,max_train_instances=5,max_validation_instances=5,max_test_instances=5"
+        )
+        instance = {
+            "metrics": ["metrics.squad"],
+            "source": "what was the last year where this team was a part of the usl a-league?\nAnswer based on this table:\n |Year|Division|League|Regular Season|Playoffs|Open Cup|Avg. Attendance|\n|---|---|---|---|---|---|---|\n|2001|2|USL A-League|4th, Western|Quarterfinals|Did not qualify|7,169|\n|2002|2|USL A-League|2nd, Pacific|1st Round|Did not qualify|6,260|\n|2003|2|USL A-League|3rd, Pacific|Did not qualify|Did not qualify|5,871|\n|2004|2|USL A-League|1st, Western|Quarterfinals|4th Round|5,628|\n|2005|2|USL First Divis|5th|Quarterfinals|4th Round|6,028|\n|2006|2|USL First Divis|11th|Did not qualify|3rd Round|5,575|\n|2007|2|USL First Divis|2nd|Semifinals|2nd Round|6,851|\n|2008|2|USL First Divis|11th|Did not qualify|1st Round|8,567|\n|2009|2|USL First Divis|1st|Semifinals|3rd Round|9,734|\n|2010|2|USSF D-2 Pro Le|3rd, USL (3rd)|Quarterfinals|3rd Round|10,727|\n",
+            "target": "2004",
+            "references": ["2004"],
+            "additional_inputs": {
+                "key": ["context", "context_type", "question", "answer"],
+                "value": [
+                    "|Year|Division|League|Regular Season|Playoffs|Open Cup|Avg. Attendance|\n|---|---|---|---|---|---|---|\n|2001|2|USL A-League|4th, Western|Quarterfinals|Did not qualify|7,169|\n|2002|2|USL A-League|2nd, Pacific|1st Round|Did not qualify|6,260|\n|2003|2|USL A-League|3rd, Pacific|Did not qualify|Did not qualify|5,871|\n|2004|2|USL A-League|1st, Western|Quarterfinals|4th Round|5,628|\n|2005|2|USL First Divis|5th|Quarterfinals|4th Round|6,028|\n|2006|2|USL First Divis|11th|Did not qualify|3rd Round|5,575|\n|2007|2|USL First Divis|2nd|Semifinals|2nd Round|6,851|\n|2008|2|USL First Divis|11th|Did not qualify|1st Round|8,567|\n|2009|2|USL First Divis|1st|Semifinals|3rd Round|9,734|\n|2010|2|USSF D-2 Pro Le|3rd, USL (3rd)|Quarterfinals|3rd Round|10,727|",
+                    "table",
+                    "what was the last year where this team was a part of the usl a-league?",
+                    "['2004']",
+                ],
+            },
+            "group": "unitxt",
+            "postprocessors": ["processors.to_string_stripped"],
+        }
+        self.assertEqual(len(dataset["train"]), 5)
+        self.assertDictEqual(dataset["train"][0], instance)

--- a/tests/library/test_plugin_operator.py
+++ b/tests/library/test_plugin_operator.py
@@ -1,0 +1,63 @@
+from src.unitxt.operator import PlugInOperator
+from src.unitxt.test_utils.operators import (
+    check_operator,
+)
+from tests.utils import UnitxtTestCase
+
+inputs = [
+    {
+        "prediction": "abc",
+        "references": [],
+        "b": 2,
+        "c": "processors.first_character",
+    },
+    {
+        "prediction": "cba",
+        "references": [],
+        "b": 3,
+        "c": "processors.first_character",
+    },
+]
+
+targets = [
+    {
+        "prediction": "a",
+        "references": [],
+        "b": 2,
+        "c": "processors.first_character",
+    },
+    {
+        "prediction": "c",
+        "references": [],
+        "b": 3,
+        "c": "processors.first_character",
+    },
+]
+
+
+class TestOperators(UnitxtTestCase):
+    def test_plugin_operator(self):
+        check_operator(
+            operator=PlugInOperator(field="c"),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
+    def test_plugin_operator_with_default_opearator(self):
+        check_operator(
+            operator=PlugInOperator(
+                field="not_a_field", default="processors.first_character"
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
+    def test_plugin_operator_without_plug(self):
+        check_operator(
+            operator=PlugInOperator(field="not_a_field"),
+            inputs=inputs,
+            targets=inputs,
+            tester=self,
+        )

--- a/tests/library/test_recipe.py
+++ b/tests/library/test_recipe.py
@@ -52,6 +52,46 @@ class TestRecipes(UnitxtTestCase):
             )
             break
 
+    def test_standard_recipe_with_additional_field(self):
+        recipe = StandardRecipe(
+            card="cards.wnli",
+            instruction=TextualInstruction(text="classify"),
+            template=InputOutputTemplate(
+                input_format="{premise}",
+                output_format="{label}",
+            ),
+            format=SystemFormat(
+                demo_format="User:{source}\nAgent:{target}\n\n",
+                model_input_format="{instruction}\n\n{demos}User:{source}\nAgent:",
+            ),
+            additional_field="test",
+        )
+        stream = recipe()
+
+        for instance in stream["train"]:
+            print_dict(instance)
+            self.assertDictEqual(
+                instance,
+                {
+                    "metrics": ["metrics.accuracy"],
+                    "source": "classify\n\nUser:I stuck a pin through a carrot. When I pulled the pin out, it had a hole.\nAgent:",
+                    "target": "not entailment",
+                    "references": ["not entailment"],
+                    "additional_inputs": {
+                        "key": ["choices", "premise", "hypothesis", "label"],
+                        "value": [
+                            "['entailment', 'not entailment']",
+                            "I stuck a pin through a carrot. When I pulled the pin out, it had a hole.",
+                            "The carrot had a hole.",
+                            "not entailment",
+                        ],
+                    },
+                    "group": "unitxt",
+                    "postprocessors": ["processors.to_string_stripped"],
+                },
+            )
+            break
+
     def test_standard_recipe_with_catalog(self):
         recipe = StandardRecipe(
             card="cards.mmlu.marketing",


### PR DESCRIPTION
This is a proposal for a new behaviour that allows to change card operators from the final command such that:
`load_dataset("card=cards.wikitq,table_serializer=serializers.table.markdown")`
will be loading the wikitq with different table serializer, markdown serializer in this case.