### PR TITLE
Fix classification code so multi-label metrics are not aware of 'none'

### DIFF
--- a/prepare/cards/hellaswag.py
+++ b/prepare/cards/hellaswag.py
@@ -20,5 +20,7 @@ card = TaskCard(
     task="tasks.completion.multiple_choice.standard",
     templates="templates.completion.multiple_choice.all",
 )
-test_card(card, debug=False)
+# We disable strict checking because garbage predictions (when using the post processor
+# that takes the first letter) is sometimes right and yields a non zero score.
+test_card(card, debug=False, strict=False)
 add_to_catalog(card, "cards.hellaswag", overwrite=True)

--- a/prepare/metrics/precision_recall.py
+++ b/prepare/metrics/precision_recall.py
@@ -16,8 +16,8 @@ recall_macro_metric = RecallMacroMultiLabel()
 
 
 # Binary case: micro = macro
-predictions = [["yes"], ["yes"], ["none"], ["none"]]
-references = [[["yes"]], [["none"]], [["yes"]], [["yes"]]]
+predictions = [["yes"], ["yes"], [], []]
+references = [[["yes"]], [[]], [["yes"]], [["yes"]]]
 
 
 instance_targets_precision_micro = [
@@ -121,13 +121,13 @@ outputs = test_metric(
 
 # multi-class case
 
-predictions = [["yes"], ["yes"], ["none"], ["none"], ["maybe"], ["maybe"], ["maybe"]]
+predictions = [["yes"], ["yes"], [], [], ["maybe"], ["maybe"], ["maybe"]]
 references = [
     [["yes"]],
-    [["none"]],
+    [[]],
     [["yes"]],
     [["yes"]],
-    [["none"]],
+    [[]],
     [["maybe"]],
     [["yes"]],
 ]

--- a/prepare/processors/processors.py
+++ b/prepare/processors/processors.py
@@ -1,6 +1,7 @@
 from src.unitxt import add_to_catalog
 from src.unitxt.logging_utils import get_logger
 from src.unitxt.operator import SequentialOperator
+from src.unitxt.operators import RemoveValues
 from src.unitxt.processors import (
     ConvertToBoolean,
     FirstCharacter,
@@ -152,5 +153,25 @@ add_to_catalog(
         ]
     ),
     "processors.first_character",
+    overwrite=True,
+)
+
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            RemoveValues(
+                field="prediction",
+                unallowed_values=["none"],
+                process_every_value=False,
+            ),
+            RemoveValues(
+                field="references/*",
+                unallowed_values=["none"],
+                use_query=True,
+                process_every_value=False,
+            ),
+        ]
+    ),
+    "processors.remove_none_from_list",
     overwrite=True,
 )

--- a/prepare/templates/classification/classification.py
+++ b/prepare/templates/classification/classification.py
@@ -47,6 +47,7 @@ add_to_catalog(
             "processors.take_first_non_empty_line",
             "processors.lower_case",
             "processors.to_list_by_comma",
+            "processors.remove_none_from_list",
         ],
     ),
     "templates.classification.multi_label.default",

--- a/src/unitxt/catalog/cards/unfair_tos.json
+++ b/src/unitxt/catalog/cards/unfair_tos.json
@@ -38,17 +38,6 @@
                 "text_type": "text",
                 "type_of_classes": "contractual clauses"
             }
-        },
-        {
-            "type": "map_instance_values",
-            "mappers": {
-                "labels": {
-                    "[]": [
-                        "none"
-                    ]
-                }
-            },
-            "strict": false
         }
     ],
     "sampler": {

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -34,6 +34,9 @@ settings = get_settings()
 warnings.filterwarnings("ignore", category=DegenerateDataWarning)
 
 
+warnings.filterwarnings("ignore", category=DegenerateDataWarning)
+
+
 def abstract_factory():
     return {}
 

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -763,7 +763,6 @@ class F1MultiLabel(GlobalMetric):
     _metric = None
     main_score = "f1_macro"
     average = None  # Report per class then aggregate by mean
-    classes_to_ignore = ["none"]
     metric = "f1"
 
     def prepare(self):
@@ -796,13 +795,9 @@ class F1MultiLabel(GlobalMetric):
         self._validate_references_and_prediction(references, predictions)
         references = [reference[0] for reference in references]
 
-        labels = [
-            lbl
-            for lbl in {label for reference in references for label in reference}
-            if lbl not in self.classes_to_ignore
-        ]
+        labels = list({label for reference in references for label in reference})
+
         # if no classes are left then F1 is not defined
-        # (e.g. only "none" in references)
         if len(labels) == 0:
             return {self.main_score: float("nan")}
 

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -154,12 +154,29 @@ def test_with_eval(
             examples = load_examples_from_standard_recipe(
                 card, template_card_index=template_card_index, debug=debug, **kwargs
             )
+            test_predictions(
+                examples=examples,
+                strict=strict,
+                exact_match_score=exact_match_score,
+                full_mismatch_score=full_mismatch_score,
+            )
     else:
         num_templates = len(card.templates)
         for template_card_index in range(0, num_templates):
             examples = load_examples_from_standard_recipe(
                 card, template_card_index=template_card_index, debug=debug, **kwargs
             )
+            test_predictions(
+                examples=examples,
+                strict=strict,
+                exact_match_score=exact_match_score,
+                full_mismatch_score=full_mismatch_score,
+            )
+
+
+def test_predictions(
+    examples, strict=True, exact_match_score=1.0, full_mismatch_score=0.0
+):
     # metric = evaluate.load('unitxt/metric')
     correct_predictions = []
     for example in examples:

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -250,23 +250,23 @@ class TestMetrics(UnitxtTestCase):
     def test_f1_macro_multilabel_with_nones(self):
         metric = F1MacroMultiLabel()
 
-        references = [[["none"]]]
-        predictions = [["none"]]
+        references = [[[]]]
+        predictions = [[]]
         global_target = float("nan")
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
         self.assertTrue(isnan(outputs[0]["score"]["global"]["score"]))
 
-        references = [[["none"]]]
+        references = [[[]]]
         predictions = [["x", "y"]]
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
         self.assertTrue(isnan(outputs[0]["score"]["global"]["score"]))
 
-        references = [[["none"]]]
-        predictions = [["none", "x", "y"]]
+        references = [[[]]]
+        predictions = [[], "x", "y"]
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
@@ -282,8 +282,8 @@ class TestMetrics(UnitxtTestCase):
         )
         self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
 
-        references = [[["none"]], [["x"]], [["y"]], [["none"]], [["none"]]]
-        predictions = [["none"], ["x"], ["x"], ["none"], ["none"]]
+        references = [[[]], [["x"]], [["y"]], [[]], [[]]]
+        predictions = [[], ["x"], ["x"], [], []]
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
@@ -291,7 +291,7 @@ class TestMetrics(UnitxtTestCase):
 
     def test_f1_micro_multilabel_with_nones(self):
         metric = F1MicroMultiLabel()
-        references = [[["none"]]]
+        references = [[[]]]
         predictions = [["cat", "dog"]]
 
         outputs = apply_metric(
@@ -299,8 +299,8 @@ class TestMetrics(UnitxtTestCase):
         )
         self.assertTrue(isnan(outputs[0]["score"]["global"]["score"]))
 
-        references = [[["none"]]]
-        predictions = [["none"]]
+        references = [[[]]]
+        predictions = [[]]
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
@@ -320,7 +320,7 @@ class TestMetrics(UnitxtTestCase):
         )
         self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
 
-        references = [[["none"]], [["sad"]]]
+        references = [[[]], [["sad"]]]
         predictions = [["dog", "fustrated"], ["sad"]]
         # precision = TP / (FP + TP) = 1 / 1 = 1
         # recall = TP /( FN + TP) =  1 / 1 = 1


### PR DESCRIPTION
The template is responsible for verbalization and hence it should deal with converting empty label list to 'none' and then from 'none' to an empty list in the post processor.

Until now the second part ('none' to empty list)  was handled in the metric, which complicates its code, and is error prone, in case a different verbalization is used (e.g. in other languages)

Also changed code card_test code to check metrics on ground truth and random predictions in all the templates and not only the last one as was before.  
