### PR TITLE
Add ability to load from catalog with arguments overwrite

### DIFF
--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -7,10 +7,11 @@ from unitxt.utils import load_json
 
 
 def write_title(title, label):
-    underline_char = "-"
-    underline = underline_char * len(title)
+    title = f"📁 {title}/"
+    wrap_char = "="
+    wrap = wrap_char * len(title)
 
-    return f".. _{label}:\n\n----------\n\n{title}\n{underline}\n\n"
+    return f".. _{label}:\n\n{wrap}\n{title}\n{wrap}\n\n"
 
 
 def custom_walk(top):
@@ -88,7 +89,10 @@ def make_content(artifact, label, all_labels):
             references.append(f":ref:`{label_no_catalog} <{label}>`")
     if len(references) > 0:
         result += "\nReferences: " + ", ".join(references)
-    return result
+    return (
+        result
+        + "\n\n\n\n\nRead more about catalog usage :ref:`here <using_catalog>`.\n\n"
+    )
 
 
 class CatalogEntry:
@@ -178,20 +182,24 @@ class CatalogEntry:
         dir_doc_path = self.get_artifact_doc_path(destination_directory)
         Path(dir_doc_path).parent.mkdir(exist_ok=True, parents=True)
         with open(dir_doc_path, "w+") as f:
-            f.write(dir_doc_content)
+            f.write(
+                dir_doc_content
+                + "\n\n\n\n\nRead more about catalog usage :ref:`here <using_catalog>`.\n\n"
+            )
 
     def write_json_contents_to_rst(self, all_labels, destination_directory):
         artifact = load_json(self.path)
         label = self.get_label()
         content = make_content(artifact, label, all_labels)
 
-        underline_char = "-"
-        underline = underline_char * len(self.get_title())
+        title_char = "="
+        title = "📄 " + self.get_title()
+        title_wrapper = title_char * len(title)
         artifact_doc_contents = (
             f".. _{label}:\n\n"
-            f"----------\n\n"
-            f"{self.get_title()}\n"
-            f"{underline}\n\n"
+            f"{title_wrapper}\n"
+            f"{title}\n"
+            f"{title_wrapper}\n\n"
             f"{content}\n\n"
             f"|\n"
             f"|\n\n"
@@ -271,17 +279,6 @@ def replace_in_file(source_str, target_str, file_path):
 
 def create_catalog_docs():
     CatalogDocsBuilder().run()
-    current_dir = os.path.dirname(__file__)
-    catalog_rst_file = os.path.join(current_dir, "catalog.rst")
-    source_str = "Catalog\n-------\n"
-    target_str = (
-        "Catalog\n-------\n\n"
-        "The catalog is a place for the Unitxt community to share assets used for processing datasets.\n\n"
-        "You can load directly from the catalog with `fetch_artifact('artifact.id')`.\n"
-        "You can also place anywhere in Unitxt catalog ids instead of realclasses\n"
-        "Finally you can also state an ID with a modification to the asset parameters `asset.id[key=value]`.\n"
-    )
-    replace_in_file(source_str, target_str, catalog_rst_file)
 
 
 if __name__ == "__main__":

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -254,5 +254,35 @@ class CatalogDocsBuilder:
         )
 
 
-if __name__ == "__main__":
+def replace_in_file(source_str, target_str, file_path):
+    """Replace all occurrences of source_str with target_str in the file specified by file_path.
+
+    Parameters:
+    - source_str: The string to be replaced.
+    - target_str: The string to replace with.
+    - file_path: The path to the file where the replacement should occur.
+    """
+    with open(file_path) as file:
+        file_contents = file.read()
+    modified_contents = file_contents.replace(source_str, target_str)
+    with open(file_path, "w") as file:
+        file.write(modified_contents)
+
+
+def create_catalog_docs():
     CatalogDocsBuilder().run()
+    current_dir = os.path.dirname(__file__)
+    catalog_rst_file = os.path.join(current_dir, "catalog.rst")
+    source_str = "Catalog\n-------\n"
+    target_str = (
+        "Catalog\n-------\n\n"
+        "The catalog is a place for the Unitxt community to share assets used for processing datasets.\n\n"
+        "You can load directly from the catalog with `fetch_artifact('artifact.id')`.\n"
+        "You can also place anywhere in Unitxt catalog ids instead of realclasses\n"
+        "Finally you can also state an ID with a modification to the asset parameters `asset.id[key=value]`.\n"
+    )
+    replace_in_file(source_str, target_str, catalog_rst_file)
+
+
+if __name__ == "__main__":
+    create_catalog_docs()

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -7,7 +7,7 @@ from unitxt.utils import load_json
 
 
 def write_title(title, label):
-    title = f"📁 {title}/"
+    title = f"📁 {title}"
     wrap_char = "="
     wrap = wrap_char * len(title)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,7 @@ import os
 import sys
 from dataclasses import Field as _Field
 
+import unitxt
 from unitxt.artifact import Artifact
 from unitxt.dataclass import Field
 
@@ -23,7 +24,7 @@ create_catalog_docs()
 project = "Unitxt"
 copyright = "2023, IBM Research"
 author = "IBM Research"
-release = "1.0.0"
+release = unitxt.__version__
 html_short_title = "Unitxt"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@ from unitxt.dataclass import Field
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from catalog import CatalogDocsBuilder
+from catalog import create_catalog_docs
 
-CatalogDocsBuilder().run()
+create_catalog_docs()
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/docs/saving_and_loading_from_catalog.rst
+++ b/docs/docs/saving_and_loading_from_catalog.rst
@@ -1,0 +1,105 @@
+.. _using_catalog:
+
+=====================================
+Saving and Loading From the Catalog
+=====================================
+
+Unitxt catalog is a place for pepole to share their processing tools with others.
+Templates, formats, operators and more Unitxt assets can be shared thorugh a local catalog in a folder in the local filesystem or through a folder in a github repository.
+
+Defining local catalog
+----------------------
+
+In order do define a local private catalog you can:
+
+.. code-block:: python
+
+    from unitxt import register_local_catalog
+
+    register_local_catalog("path/to/catalog/directory")
+
+Adding assets to a catalog
+--------------------------
+
+Once your catalog is registered you can save artifacts to the catalog:
+
+.. code-block:: python
+
+    from unitxt.task import FormTask
+    from unitxt import save_to_catalog
+
+    my_task = FormTask(...)
+
+    catalog_name = "tasks.my_task"
+
+    save_to_catalog(my_task, catalog_name, catalog_path="path/to/catalog/directory")
+
+You can also save artifacts to the library default catalog:
+
+.. code-block:: python
+
+    save_to_catalog(my_task, catalog_name)
+
+
+Using catalog assets
+--------------------
+
+In order to use catalog objects you just need to specify their name to the unitxt object that will use them.
+
+For example now `tasks.my_task` can be used by the `StandardRecipe`:
+
+.. code-block:: python
+
+    from unitxt.card import TaskCard
+
+    card = TaskCard(
+        ...
+        task="tasks.my_task"
+    )
+
+Modifying catalog assets on the fly
+------------------------------------
+
+If we want to get asset from the catalog but to edit his fields we can do it with a simple syntax:
+`asset.name[key_to_modify=new_value]` we can also assign lists by `asset.name[key_to_modify=[new_value_0, new_value_1]]`
+For example if we want to use a task but change its metric list we can:
+
+.. code-block:: python
+
+    from unitxt.card import TaskCard
+
+    card = TaskCard(
+        ...
+        task="tasks.my_task[metrics=[matrics.accuracy, metrics.f1[reduction=median]]"
+    )
+
+Accessing catalog assets directly
+------------------------------------
+
+In order to access catalog assets directly we can use `get_from_catalog`
+
+.. code-block:: python
+
+    from unitxt import get_from_catalog
+
+    my_task = get_from_catalog("tasks.my_task")
+
+
+Using many catalogs
+-------------------
+
+Unitxt use by default many catalog such as the local library catalog and online community catalog hosted on github.
+Assets are always taken from the last catalog registered that have the asset.
+
+Defning catalog through environment variable
+--------------------------------------------
+
+In cases where unitxt is run by other application you might want to define your custom catalogs
+thorugh an environment variable.
+
+.. code-block:: bash
+
+    export UNITXT_ARTIFACTORIES="path/to/first/catalog:path/to/second/catalog"
+
+
+You can read more about catalogs here: :class:`catalog <unitxt.catalog>`.

--- a/docs/docs/saving_and_loading_from_catalog.rst
+++ b/docs/docs/saving_and_loading_from_catalog.rst
@@ -1,16 +1,15 @@
 .. _using_catalog:
 
 =====================================
-Saving and Loading From the Catalog
+Saving and Loading from the Catalog
 =====================================
 
-Unitxt catalog is a place for pepole to share their processing tools with others.
-Templates, formats, operators and more Unitxt assets can be shared thorugh a local catalog in a folder in the local filesystem or through a folder in a github repository.
+The Unitxt catalog serves as a repository for people to share their processing tools. This includes templates, formats, operators, and other Unitxt assets. These can be shared through a local catalog located in a directory on the local filesystem or via a directory in a GitHub repository.
 
-Defining local catalog
-----------------------
+Defining a Local Catalog
+------------------------
 
-In order do define a local private catalog you can:
+To define a local, private catalog, use the following code:
 
 .. code-block:: python
 
@@ -18,35 +17,32 @@ In order do define a local private catalog you can:
 
     register_local_catalog("path/to/catalog/directory")
 
-Adding assets to a catalog
---------------------------
+Adding Assets to the Catalog
+----------------------------
 
-Once your catalog is registered you can save artifacts to the catalog:
+Once your catalog is registered, you can add artifacts to it:
 
 .. code-block:: python
 
     from unitxt.task import FormTask
-    from unitxt import save_to_catalog
+    from unitxt import add_to_catalog
 
     my_task = FormTask(...)
 
     catalog_name = "tasks.my_task"
 
-    save_to_catalog(my_task, catalog_name, catalog_path="path/to/catalog/directory")
+    add_to_catalog(my_task, catalog_name, catalog_path="path/to/catalog/directory")
 
-You can also save artifacts to the library default catalog:
+It's also possible to save artifacts to the library's default catalog:
 
 .. code-block:: python
 
     save_to_catalog(my_task, catalog_name)
 
-
-Using catalog assets
+Using Catalog Assets
 --------------------
 
-In order to use catalog objects you just need to specify their name to the unitxt object that will use them.
-
-For example now `tasks.my_task` can be used by the `StandardRecipe`:
+To use catalog objects, simply specify their name in the Unitxt object that will use them. For example, `tasks.my_task` can now be utilized by the `StandardRecipe`:
 
 .. code-block:: python
 
@@ -57,12 +53,10 @@ For example now `tasks.my_task` can be used by the `StandardRecipe`:
         task="tasks.my_task"
     )
 
-Modifying catalog assets on the fly
-------------------------------------
+Modifying Catalog Assets on the Fly
+-----------------------------------
 
-If we want to get asset from the catalog but to edit his fields we can do it with a simple syntax:
-`asset.name[key_to_modify=new_value]` we can also assign lists by `asset.name[key_to_modify=[new_value_0, new_value_1]]`
-For example if we want to use a task but change its metric list we can:
+To modify a catalog asset's fields dynamically, use the syntax: `asset.name[key_to_modify=new_value]`. To assign lists, use: `asset.name[key_to_modify=[new_value_0, new_value_1]]`. For instance, to change the metric list of a task:
 
 .. code-block:: python
 
@@ -70,13 +64,13 @@ For example if we want to use a task but change its metric list we can:
 
     card = TaskCard(
         ...
-        task="tasks.my_task[metrics=[matrics.accuracy, metrics.f1[reduction=median]]"
+        task="tasks.my_task[metrics=[metrics.accuracy, metrics.f1[reduction=median]]]"
     )
 
-Accessing catalog assets directly
-------------------------------------
+Accessing Catalog Assets Directly
+---------------------------------
 
-In order to access catalog assets directly we can use `get_from_catalog`
+Use `get_from_catalog` to directly access catalog assets:
 
 .. code-block:: python
 
@@ -84,22 +78,18 @@ In order to access catalog assets directly we can use `get_from_catalog`
 
     my_task = get_from_catalog("tasks.my_task")
 
+Using Multiple Catalogs
+-----------------------
 
-Using many catalogs
--------------------
+By default, Unitxt uses several catalogs, such as the local library catalog and online community catalogs hosted on GitHub. Assets are sourced from the last registered catalog containing the asset.
 
-Unitxt use by default many catalog such as the local library catalog and online community catalog hosted on github.
-Assets are always taken from the last catalog registered that have the asset.
+Defining Catalogs Through Environment Variables
+-----------------------------------------------
 
-Defning catalog through environment variable
---------------------------------------------
-
-In cases where unitxt is run by other application you might want to define your custom catalogs
-thorugh an environment variable.
+When Unitxt is executed by another application, you might need to specify custom catalogs through an environment variable:
 
 .. code-block:: bash
 
     export UNITXT_ARTIFACTORIES="path/to/first/catalog:path/to/second/catalog"
 
-
-You can read more about catalogs here: :class:`catalog <unitxt.catalog>`.
+Learn more about catalogs here: :class:`catalog <unitxt.catalog>`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,6 +95,7 @@ Welcome!
    docs/backend
    docs/operators
    docs/contributors_guide
+   docs/saving_and_loading_from_catalog
    modules
    catalog
 

--- a/src/unitxt/__init__.py
+++ b/src/unitxt/__init__.py
@@ -1,7 +1,7 @@
 import random
 
 from .api import evaluate, load, load_dataset
-from .catalog import add_to_catalog
+from .catalog import add_to_catalog, get_from_catalog
 from .logging_utils import get_logger
 from .register import register_all_artifacts, register_local_catalog
 from .settings_utils import get_constants, get_settings

--- a/src/unitxt/catalog.py
+++ b/src/unitxt/catalog.py
@@ -34,15 +34,20 @@ class LocalCatalog(Catalog):
         parts[-1] = parts[-1] + ".json"
         return os.path.join(self.location, *parts)
 
-    def load(self, artifact_identifier: str):
+    def load(self, artifact_identifier: str, overwrite_args=None):
         assert (
             artifact_identifier in self
         ), f"Artifact with name {artifact_identifier} does not exist"
         path = self.path(artifact_identifier)
-        return Artifact.load(path, artifact_identifier)
+        return Artifact.load(
+            path, artifact_identifier=artifact_identifier, overwrite_args=overwrite_args
+        )
 
     def __getitem__(self, name) -> Artifact:
         return self.load(name)
+
+    def get_with_overwrite(self, name, overwrite_args):
+        return self.load(name, overwrite_args=overwrite_args)
 
     def __contains__(self, artifact_identifier: str):
         if not os.path.exists(self.location):
@@ -88,11 +93,11 @@ class GithubCatalog(LocalCatalog):
         tag = version
         self.location = f"https://raw.githubusercontent.com/{self.user}/{self.repo}/{tag}/{self.repo_dir}"
 
-    def load(self, artifact_identifier: str):
+    def load(self, artifact_identifier: str, overwrite_args=None):
         url = self.path(artifact_identifier)
         response = requests.get(url)
         data = response.json()
-        new_artifact = Artifact.from_dict(data)
+        new_artifact = Artifact.from_dict(data, overwrite_args=overwrite_args)
         new_artifact.artifact_identifier = artifact_identifier
         return new_artifact
 

--- a/src/unitxt/catalog.py
+++ b/src/unitxt/catalog.py
@@ -1,12 +1,19 @@
 import os
 import re
 from collections import Counter
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
 import requests
 
-from .artifact import Artifact, Artifactories, Artifactory, reset_artifacts_cache
+from .artifact import (
+    Artifact,
+    Artifactories,
+    Artifactory,
+    get_artifactory_name_and_args,
+    reset_artifacts_cache,
+)
 from .logging_utils import get_logger
 from .settings_utils import get_constants
 from .text_utils import print_dict
@@ -131,6 +138,30 @@ def add_to_catalog(
         artifact, name, overwrite=overwrite, verbose=verbose
     )  # remove collection (its actually the dir).
     # verify name
+
+
+@lru_cache(maxsize=None)
+def get_from_catalog(
+    name: str,
+    catalog: Catalog = None,
+    catalog_path: Optional[str] = None,
+):
+    if catalog_path is not None:
+        catalog = LocalCatalog(location=catalog_path)
+
+    if catalog is None:
+        artifactories = None
+    else:
+        artifactories = [catalog]
+
+    catalog, name, args = get_artifactory_name_and_args(
+        name, artifactories=artifactories
+    )
+
+    return catalog.get_with_overwrite(
+        name=name,
+        overwrite_args=args,
+    )
 
 
 def get_local_catalogs_paths():

--- a/src/unitxt/dataset.py
+++ b/src/unitxt/dataset.py
@@ -25,6 +25,7 @@ from .metrics import __file__ as _
 from .normalizers import __file__ as _
 from .operator import __file__ as _
 from .operators import __file__ as _
+from .parsing_utils import __file__ as _
 from .processors import __file__ as _
 from .random_utils import __file__ as _
 from .recipe import __file__ as _

--- a/src/unitxt/dataset_utils.py
+++ b/src/unitxt/dataset_utils.py
@@ -1,5 +1,6 @@
 from .artifact import Artifact, UnitxtArtifactNotFoundError, fetch_artifact
 from .logging_utils import get_logger
+from .parsing_utils import parse_key_equals_value_string_to_dict
 from .register import _reset_env_local_catalogs, register_all_artifacts
 from .settings_utils import get_settings
 
@@ -16,32 +17,7 @@ def fetch(artifact_name):
 
 
 def parse(query: str):
-    """Parses a query of the form 'key1=value1,key2=value2,...' into a dictionary."""
-    result = {}
-    kvs = query.split(",")
-    if len(kvs) == 0:
-        raise ValueError(
-            'Illegal query: "{query}" should contain at least one assignment of the form: key1=value1,key2=value2'
-        )
-    for kv in kvs:
-        key_val = kv.split("=")
-        if (
-            len(key_val) != 2
-            or len(key_val[0].strip()) == 0
-            or len(key_val[1].strip()) == 0
-        ):
-            raise ValueError(
-                f'Illegal query: "{query}" with wrong assignment "{kv}" should be of the form: key=value.'
-            )
-        key, val = key_val
-        if val.isdigit():
-            result[key] = int(val)
-        elif val.replace(".", "", 1).isdigit():
-            result[key] = float(val)
-        else:
-            result[key] = val
-
-    return result
+    return parse_key_equals_value_string_to_dict(query)
 
 
 def get_dataset_artifact(dataset_str):

--- a/src/unitxt/metric.py
+++ b/src/unitxt/metric.py
@@ -24,6 +24,7 @@ from .metrics import __file__ as _
 from .normalizers import __file__ as _
 from .operator import __file__ as _
 from .operators import __file__ as _
+from .parsing_utils import __file__ as _
 from .processors import __file__ as _
 from .random_utils import __file__ as _
 from .recipe import __file__ as _

--- a/src/unitxt/parsing_utils.py
+++ b/src/unitxt/parsing_utils.py
@@ -1,0 +1,71 @@
+def separate_inside_and_outside_square_brackets(s):
+    """Separates the content inside and outside the first level of square brackets in a string.
+
+    Allows text before the first bracket and nested brackets within the first level. Raises a ValueError for:
+    - Text following the closing bracket of the first bracket pair
+    - Unmatched brackets
+    - Multiple bracket pairs at the same level
+
+    :param s: The input string to be parsed.
+    :return: A tuple (outside, inside) where 'outside' is the content outside the first level of square brackets,
+             and 'inside' is the content inside the first level of square brackets. If there are no brackets,
+             'inside' will be None.
+    """
+    start = s.find("[")
+    end = s.rfind("]")
+
+    # Handle no brackets
+    if start == -1 and end == -1:
+        return s, None
+
+    # Validate brackets
+    if start == -1 or end == -1 or start > end:
+        raise ValueError("Illegal structure: unmatched square brackets.")
+
+    outside = s[:start]
+    inside = s[start + 1 : end]
+    after = s[end + 1 :]
+
+    # Check for text after the closing bracket
+    if len(after.strip()) != 0:
+        raise ValueError(
+            "Illegal structure: text follows after the closing square bracket."
+        )
+
+    return outside, inside
+
+
+def parse_key_equals_value_string_to_dict(query: str):
+    """Parses a query string of the form 'key1=value1,key2=value2,...' into a dictionary.
+
+    The function converts numeric values into integers or floats as appropriate, and raises an
+    exception if the query string is malformed or does not conform to the expected format.
+
+    :param query: The query string to be parsed.
+    :return: A dictionary with keys and values extracted from the query string, with spaces stripped from keys.
+    """
+    result = {}
+    kvs = query.split(",")
+    if len(kvs) == 0:
+        raise ValueError(
+            f'Illegal query: "{query}" should contain at least one assignment of the form: key1=value1,key2=value2'
+        )
+    for kv in kvs:
+        key_val = kv.split("=")
+        if (
+            len(key_val) != 2
+            or len(key_val[0].strip()) == 0
+            or len(key_val[1].strip()) == 0
+        ):
+            raise ValueError(
+                f'Illegal query: "{query}" with wrong assignment "{kv}" should be of the form: key=value.'
+            )
+        key, val = key_val[0].strip(), key_val[1].strip()
+        if val.isdigit():
+            result[key] = int(val)
+        elif val.replace(".", "", 1).isdigit() and val.count(".") < 2:
+            result[key] = float(val)
+        else:
+            result[key] = val
+
+    return result

--- a/src/unitxt/parsing_utils.py
+++ b/src/unitxt/parsing_utils.py
@@ -52,7 +52,7 @@ def parse_key_equals_value_string_to_dict(query: str):
         )
     for kv in kvs:
         kv = kv.strip()
-        key_val = split_within_depth(query, dellimiter="=")
+        key_val = split_within_depth(kv, dellimiter="=")
         if (
             len(key_val) != 2
             or len(key_val[0].strip()) == 0

--- a/src/unitxt/parsing_utils.py
+++ b/src/unitxt/parsing_utils.py
@@ -45,13 +45,14 @@ def parse_key_equals_value_string_to_dict(query: str):
     :return: A dictionary with keys and values extracted from the query string, with spaces stripped from keys.
     """
     result = {}
-    kvs = query.split(",")
+    kvs = split_within_depth(query, dellimiter=",")
     if len(kvs) == 0:
         raise ValueError(
             f'Illegal query: "{query}" should contain at least one assignment of the form: key1=value1,key2=value2'
         )
     for kv in kvs:
-        key_val = kv.split("=")
+        kv = kv.strip()
+        key_val = split_within_depth(query, dellimiter="=")
         if (
             len(key_val) != 2
             or len(key_val[0].strip()) == 0
@@ -66,6 +67,64 @@ def parse_key_equals_value_string_to_dict(query: str):
         elif val.replace(".", "", 1).isdigit() and val.count(".") < 2:
             result[key] = float(val)
         else:
-            result[key] = val
+            try:
+                result[key] = parse_list_string(val)
+            except:
+                result[key] = val
 
     return result
+
+
+def split_within_depth(
+    s, dellimiter=",", depth=0, forbbiden_chars=None, level_start="[", level_end="]"
+):
+    result = []
+    part = ""
+    current_depth = 0
+    for char in s:
+        if char == level_start:
+            current_depth += 1
+            part += char
+        elif char == level_end:
+            current_depth -= 1
+            part += char
+        elif (
+            forbbiden_chars is not None
+            and char in forbbiden_chars
+            and current_depth <= depth
+        ):
+            raise ValueError("")
+        elif char == dellimiter and current_depth <= depth:
+            result.append(part)
+            part = ""
+        else:
+            part += char
+    if part:
+        result.append(part)
+    return result
+
+
+def parse_list_string(s: str):
+    """Parses a query string of the form 'val1,val2,...' into a list."""
+    start = s.find("[")
+    end = s.rfind("]")
+
+    # Handle no brackets
+    if start == -1 and end == -1:
+        return s
+
+    # Validate brackets
+    if start == -1 or end == -1 or start > end:
+        raise ValueError("Illegal structure: unmatched square brackets.")
+
+    before = s[:start].strip()
+    inside = s[start + 1 : end].strip()
+    after = s[end + 1 :].strip()
+
+    # Check for text after the closing bracket
+    if len(before) != 0 or len(after) != 0:
+        raise ValueError(
+            "Illegal structure: text follows before or after the closing square bracket."
+        )
+    splitted = split_within_depth(inside.strip(), dellimiter=",", forbbiden_chars=["="])
+    return [s.strip() for s in splitted]

--- a/src/unitxt/register.py
+++ b/src/unitxt/register.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import os
+from pathlib import Path
 
 from .artifact import Artifact, Artifactories
 from .catalog import EnvironmentLocalCatalog, GithubCatalog, LocalCatalog
@@ -19,12 +20,32 @@ def _unregister_catalog(catalog: LocalCatalog):
     Artifactories().unregister(catalog)
 
 
+def is_local_catalog_registered(catalog_path: str):
+    if os.path.isdir(catalog_path):
+        for catalog in _catalogs_list():
+            if isinstance(catalog, LocalCatalog):
+                if os.path.isdir(catalog.location):
+                    if Path(catalog.location).resolve() == Path(catalog_path).resolve():
+                        return True
+    return False
+
+
 def register_local_catalog(catalog_path: str):
     assert os.path.exists(catalog_path), f"Catalog path {catalog_path} does not exist."
     assert os.path.isdir(
         catalog_path
     ), f"Catalog path {catalog_path} is not a directory."
-    _register_catalog(LocalCatalog(location=catalog_path))
+    if not is_local_catalog_registered(catalog_path=catalog_path):
+        _register_catalog(LocalCatalog(location=catalog_path))
+
+
+def unregister_local_catalog(catalog_path: str):
+    if is_local_catalog_registered(catalog_path=catalog_path):
+        for catalog in _catalogs_list():
+            if isinstance(catalog, LocalCatalog):
+                if os.path.isdir(catalog.location):
+                    if Path(catalog.location).resolve() == Path(catalog_path).resolve():
+                        _unregister_catalog(catalog)
 
 
 def _catalogs_list():

--- a/src/unitxt/test_utils/catalog.py
+++ b/src/unitxt/test_utils/catalog.py
@@ -1,6 +1,12 @@
 import os
+import tempfile
+from contextlib import contextmanager
 
-from ..register import _reset_env_local_catalogs
+from ..register import (
+    _reset_env_local_catalogs,
+    register_local_catalog,
+    unregister_local_catalog,
+)
 from ..settings_utils import get_constants, get_settings
 
 constants = get_constants()
@@ -10,3 +16,13 @@ settings = get_settings()
 def register_local_catalog_for_tests():
     os.environ[settings.artifactories_key] = constants.catalog_dir
     _reset_env_local_catalogs()
+
+
+@contextmanager
+def temp_catalog():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        register_local_catalog(temp_dir)
+        try:
+            yield temp_dir
+        finally:
+            unregister_local_catalog(temp_dir)

--- a/src/unitxt/test_utils/catalog.py
+++ b/src/unitxt/test_utils/catalog.py
@@ -3,7 +3,6 @@ import tempfile
 from contextlib import contextmanager
 
 from ..register import (
-    _reset_env_local_catalogs,
     register_local_catalog,
     unregister_local_catalog,
 )
@@ -15,7 +14,7 @@ settings = get_settings()
 
 def register_local_catalog_for_tests():
     os.environ[settings.artifactories_key] = constants.catalog_dir
-    _reset_env_local_catalogs()
+    # _reset_env_local_catalogs()
 
 
 @contextmanager

--- a/tests/library/test_artifact.py
+++ b/tests/library/test_artifact.py
@@ -2,8 +2,11 @@ from src.unitxt.artifact import (
     Artifact,
     fetch_artifact,
 )
+from src.unitxt.catalog import add_to_catalog
 from src.unitxt.dataclass import UnexpectedArgumentError
 from src.unitxt.logging_utils import get_logger
+from src.unitxt.processors import StringOrNotString
+from src.unitxt.test_utils.catalog import temp_catalog
 from tests.utils import UnitxtTestCase
 
 logger = get_logger()
@@ -29,3 +32,13 @@ class TestArtifact(UnitxtTestCase):
         artifact_identifier = "tasks.classification.binary"
         artifact, _ = fetch_artifact(artifact_identifier)
         self.assertEqual(artifact_identifier, artifact.artifact_identifier)
+
+    def test_artifact_loading_with_overwrite_args(self):
+        with temp_catalog() as catalog_path:
+            add_to_catalog(
+                StringOrNotString(string="yes", field="a_field"),
+                "test.test",
+                catalog_path=catalog_path,
+            )
+            artifact, _ = fetch_artifact("temp.test[string=hello]")
+            self.assertEqual(artifact.string, "hello")

--- a/tests/library/test_artifact_recovery.py
+++ b/tests/library/test_artifact_recovery.py
@@ -18,7 +18,19 @@ class TestArtifactRecovery(UnitxtTestCase):
             "demos_pool_size": 100,
             "num_demos": 0,
         }
-        Artifact.from_dict(args)
+        a = Artifact.from_dict(args)
+        self.assertEqual(a.num_demos, 0)
+
+    def test_correct_artifact_recovery_with_overwrite(self):
+        args = {
+            "type": "standard_recipe",
+            "card": "cards.sst2",
+            "template_card_index": 0,
+            "demos_pool_size": 100,
+            "num_demos": 0,
+        }
+        a = Artifact.from_dict(args, overwrite_args={"num_demos": 1})
+        self.assertEqual(a.num_demos, 1)
 
     def test_bad_artifact_recovery_missing_type(self):
         args = {

--- a/tests/library/test_catalogs.py
+++ b/tests/library/test_catalogs.py
@@ -1,10 +1,15 @@
+import json
 import os
 import tempfile
 
 from src import unitxt
-from src.unitxt import register_local_catalog
-from src.unitxt.artifact import Artifactories
-from src.unitxt.register import _reset_env_local_catalogs
+from src.unitxt import add_to_catalog
+from src.unitxt.artifact import Artifact, Artifactories
+from src.unitxt.register import (
+    _reset_env_local_catalogs,
+    register_local_catalog,
+    unregister_local_catalog,
+)
 from tests.utils import UnitxtTestCase
 
 
@@ -17,6 +22,14 @@ class TestCatalogs(UnitxtTestCase):
             self.assertTrue(isinstance(first_artif, unitxt.catalog.LocalCatalog))
             self.assertEqual(first_artif.location, tmp_dir)
 
+    def test_catalog_unregistration(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            register_local_catalog(tmp_dir)
+            unregister_local_catalog(tmp_dir)
+            artifs = Artifactories()
+            first_artif = next(iter(artifs))
+            self.assertNotEqual(first_artif.location, tmp_dir)
+
     def test_catalog_registration_with_env_var(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.environ["UNITXT_ARTIFACTORIES"] = tmp_dir
@@ -25,3 +38,16 @@ class TestCatalogs(UnitxtTestCase):
             first_artif = next(iter(artifs))
             self.assertTrue(isinstance(first_artif, unitxt.catalog.LocalCatalog))
             self.assertEqual(first_artif.location, tmp_dir)
+
+    def test_add_to_catalog(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+
+            class ClassToSave(Artifact):
+                t: int = 0
+
+            add_to_catalog(ClassToSave(t=1), "test.save", catalog_path=tmp_dir)
+
+            with open(os.path.join(tmp_dir, "test", "save.json")) as f:
+                content = json.load(f)
+
+            self.assertDictEqual(content, {"type": "class_to_save", "t": 1})

--- a/tests/library/test_parsing_utils.py
+++ b/tests/library/test_parsing_utils.py
@@ -1,0 +1,131 @@
+from src.unitxt.parsing_utils import (
+    parse_key_equals_value_string_to_dict,
+    separate_inside_and_outside_square_brackets,
+)
+from tests.utils import UnitxtTestCase
+
+
+class TestParsingUtils(UnitxtTestCase):
+    # Tests for parse_key_equals_value_string_to_dict
+    def test_parse_key_equals_value_string_to_dict_simple_query(self):
+        query = "name=John Doe,age=30,height=5.8"
+        expected = {"name": "John Doe", "age": 30, "height": 5.8}
+        self.assertEqual(parse_key_equals_value_string_to_dict(query), expected)
+
+    def test_parse_key_equals_value_string_to_dict_with_spaces(self):
+        query = "first name=Jane Doe, last name=Doe, country=USA, balance=100.50"
+        expected = {
+            "first name": "Jane Doe",
+            "last name": "Doe",
+            "country": "USA",
+            "balance": 100.50,
+        }
+        self.assertEqual(parse_key_equals_value_string_to_dict(query), expected)
+
+    def test_parse_key_equals_value_string_to_dict_empty_value(self):
+        query = "username=admin,password="
+        with self.assertRaises(ValueError):
+            parse_key_equals_value_string_to_dict(query)
+
+    def test_parse_key_equals_value_string_to_dict_missing_value(self):
+        query = "username=admin,role"
+        with self.assertRaises(ValueError):
+            parse_key_equals_value_string_to_dict(query)
+
+    def test_parse_key_equals_value_string_to_dict_numeric_values(self):
+        query = "year=2020,score=9.5,count=10"
+        expected = {"year": 2020, "score": 9.5, "count": 10}
+        self.assertEqual(parse_key_equals_value_string_to_dict(query), expected)
+
+    def test_parse_key_equals_value_string_to_dict_illegal_format(self):
+        query = "malformed"
+        with self.assertRaises(ValueError):
+            parse_key_equals_value_string_to_dict(query)
+
+    # Additional test for handling booleans
+    def test_parse_key_equals_value_string_to_dict_boolean_values(self):
+        query = "is_valid=true,has_errors=false"
+        expected = {"is_valid": "true", "has_errors": "false"}
+        self.assertEqual(parse_key_equals_value_string_to_dict(query), expected)
+
+    def test_base_structure(self):
+        self.assertEqual(
+            separate_inside_and_outside_square_brackets("text"), ("text", None)
+        )
+
+    def test_valid_structure(self):
+        self.assertEqual(
+            separate_inside_and_outside_square_brackets("before[inside]"),
+            ("before", "inside"),
+        )
+
+    def test_valid_nested_structure(self):
+        self.assertEqual(
+            separate_inside_and_outside_square_brackets(
+                "before[inside_before[inside_inside]]"
+            ),
+            ("before", "inside_before[inside_inside]"),
+        )
+
+    def test_valid_nested_structure_with_broken_structre(self):
+        self.assertEqual(
+            separate_inside_and_outside_square_brackets(
+                "before[inside_before[inside_inside]"
+            ),
+            ("before", "inside_before[inside_inside"),
+        )
+
+    def test_valid_nested_structure_with_broken_structre_inside(self):
+        self.assertEqual(
+            separate_inside_and_outside_square_brackets(
+                "before[inside_a]between[inside_b]"
+            ),
+            ("before", "inside_a]between[inside_b"),
+        )
+
+    def test_valid_empty_inside(self):
+        self.assertEqual(
+            separate_inside_and_outside_square_brackets("before[]"), ("before", "")
+        )
+
+    def test_illegal_text_following_brackets(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Illegal structure: text follows after the closing square bracket.",
+        ):
+            separate_inside_and_outside_square_brackets("before[inside]after")
+
+    def test_illegal_unmatched_left_bracket(self):
+        with self.assertRaisesRegex(
+            ValueError, "Illegal structure: unmatched square brackets."
+        ):
+            separate_inside_and_outside_square_brackets("before[inside")
+
+    def test_illegal_unmatched_right_bracket(self):
+        with self.assertRaisesRegex(
+            ValueError, "Illegal structure: unmatched square brackets."
+        ):
+            separate_inside_and_outside_square_brackets("before]inside")
+
+    def test_illegal_extra_characters_after_closing_bracket(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Illegal structure: text follows after the closing square bracket.",
+        ):
+            separate_inside_and_outside_square_brackets("[inside]extra")
+
+    def test_illegal_nested_brackets(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Illegal structure: text follows after the closing square bracket.",
+        ):
+            separate_inside_and_outside_square_brackets("before[inside[nested]]after")
+
+    def test_illegal_multiple_bracket_pairs(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Illegal structure: text follows after the closing square bracket.",
+        ):
+            separate_inside_and_outside_square_brackets(
+                "before[inside]middle[another]after"
+            )


### PR DESCRIPTION
This PR allows to specify artifact names with modifications. For example if you have `metrics.accuracy` in the catalog with a field `reduction="mean"` you can load it with a modification to median by: `metrics.accuracy[reduction=median]`