### PR TITLE
filter on loading rather than increase loading limit

### DIFF
--- a/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/deu.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/deu.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "aya_human_annotated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"deu\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "deu"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/eng.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/eng.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "aya_human_annotated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"eng\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "eng"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/fra.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/fra.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "aya_human_annotated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"fra\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "fra"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/jpn.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/jpn.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "aya_human_annotated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"jpn\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "jpn"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/por.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/por.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "aya_human_annotated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"por\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "por"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/spa.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/aya_human_annotated/spa.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "aya_human_annotated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"spa\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "spa"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/dolly_human_edited/fra.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/dolly_human_edited/fra.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "dolly_human_edited",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"fra\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "fra"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/dolly_human_edited/spa.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/dolly_human_edited/spa.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "dolly_human_edited",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"spa\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "spa"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/deu.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/deu.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "dolly_machine_translated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"deu\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "deu"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/eng.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/eng.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "dolly_machine_translated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"eng\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "eng"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/fra.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/fra.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "dolly_machine_translated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"fra\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "fra"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/jpn.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/jpn.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "dolly_machine_translated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"jpn\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "jpn"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/por.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/por.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "dolly_machine_translated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"por\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "por"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/spa.json
+++ b/src/unitxt/catalog/cards/cohere_for_ai/dolly_machine_translated/spa.json
@@ -4,7 +4,8 @@
         "type": "load_hf",
         "path": "CohereForAI/aya_evaluation_suite",
         "name": "dolly_machine_translated",
-        "streaming": true
+        "streaming": true,
+        "filtering_lambda": "lambda instance: instance[\"language\"]==\"spa\""
     },
     "preprocess_steps": [
         {
@@ -14,13 +15,6 @@
                 "validation": "test[5%]",
                 "test": "test[5%]"
             }
-        },
-        {
-            "type": "filter_by_condition",
-            "values": {
-                "language": "spa"
-            },
-            "condition": "eq"
         },
         {
             "type": "rename_fields",

--- a/tests/library/test_loaders.py
+++ b/tests/library/test_loaders.py
@@ -145,3 +145,22 @@ class TestLoaders(UnitxtTestCase):
             "hide new secretions from the parental units ",
         )
         assert list(dataset.keys()) == ["train"], f"Unexpected fold {dataset.keys()}"
+
+    def test_load_from_HF_filter(self):
+        loader = LoadHF(
+            path="CohereForAI/aya_evaluation_suite",
+            name="aya_human_annotated",
+            filtering_lambda='lambda instance: instance["language"]=="eng"',
+        )
+        ms = loader.stream_dataset()
+        dataset = ms.to_dataset()
+        self.assertEqual(
+            list(dataset.keys()), ["test"]
+        )  # that HF dataset only has the 'test' split
+        self.assertEqual(dataset["test"][0]["language"], "eng")
+        ms = loader.load_dataset()
+        dataset = ms.to_dataset()
+        self.assertEqual(
+            list(dataset.keys()), ["test"]
+        )  # that HF dataset only has the 'test' split
+        self.assertEqual(dataset["test"][0]["language"], "eng")


### PR DESCRIPTION
per @elronbandel comment in [recent PR](https://github.com/IBM/unitxt/pull/579):  
Perhaps employing the HuggingFace filter upfront can ease load on the system, better than increase loading_limit only to allow the following pre-processing step that filters out.