### PR TITLE
Eval metrics

### DIFF
--- a/prepare/metrics/kendalltau.py
+++ b/prepare/metrics/kendalltau.py
@@ -20,7 +20,7 @@ instance_targets = [
 global_target = {
     "kendalltau_b": 0.82,
     "score": 0.82,
-    "kendalltau_p_val": 0.22,
+    "kendalltau_b_p_val": 0.22,
     "score_name": "kendalltau_b",
     "kendalltau_b_ci_low": np.nan,
     "kendalltau_b_ci_high": np.nan,

--- a/prepare/metrics/kendalltau.py
+++ b/prepare/metrics/kendalltau.py
@@ -20,7 +20,7 @@ instance_targets = [
 global_target = {
     "kendalltau_b": 0.82,
     "score": 0.82,
-    "p_val": 0.22,
+    "kendalltau_p_val": 0.22,
     "score_name": "kendalltau_b",
     "kendalltau_b_ci_low": np.nan,
     "kendalltau_b_ci_high": np.nan,

--- a/prepare/metrics/kendalltau.py
+++ b/prepare/metrics/kendalltau.py
@@ -1,27 +1,12 @@
 import numpy as np
 
 from src.unitxt import add_to_catalog
-from src.unitxt.blocks import CastFields, CopyFields
-from src.unitxt.metrics import KendallTauMetric, MetricPipeline
+from src.unitxt.metrics import KendallTauMetric
 from src.unitxt.test_utils.metrics import test_metric
 
-metric = MetricPipeline(
-    main_score="kendalltau_b",
-    preprocess_steps=[
-        CopyFields(
-            field_to_field=[("references/0", "references")],
-            use_query=True,
-        ),
-        CastFields(
-            fields={"prediction": "float", "references": "float"},
-            failure_defaults={"prediction": 0.0},
-            use_nested_query=True,
-        ),
-    ],
-    metric=KendallTauMetric(),
-)
+metric = KendallTauMetric()
 
-predictions = ["1.0", " 2.0", "1.0"]
+predictions = ["1.0", "2.0", "1.0"]
 references = [["-1.0"], ["1.0"], ["0.0"]]
 
 instance_targets = [

--- a/prepare/metrics/roc_auc.py
+++ b/prepare/metrics/roc_auc.py
@@ -1,22 +1,10 @@
 import numpy as np
 
 from src.unitxt import add_to_catalog
-from src.unitxt.blocks import CastFields, CopyFields
-from src.unitxt.metrics import MetricPipeline, RocAuc
+from src.unitxt.metrics import RocAuc
 from src.unitxt.test_utils.metrics import test_metric
 
-metric = MetricPipeline(
-    main_score="roc_auc",
-    preprocess_steps=[
-        CopyFields(field_to_field=[("references/0", "references")], use_query=True),
-        CastFields(
-            fields={"prediction": "float", "references": "float"},
-            failure_defaults={"prediction": 0.0},
-            use_nested_query=True,
-        ),
-    ],
-    metric=RocAuc(),
-)
+metric = RocAuc()
 
 predictions = ["0.2", "0.8", "1.0"]
 references = [["1.0"], ["0.0"], ["1.0"]]

--- a/src/unitxt/catalog/metrics/kendalltau_b.json
+++ b/src/unitxt/catalog/metrics/kendalltau_b.json
@@ -1,30 +1,3 @@
 {
-    "type": "metric_pipeline",
-    "main_score": "kendalltau_b",
-    "preprocess_steps": [
-        {
-            "type": "copy_fields",
-            "field_to_field": [
-                [
-                    "references/0",
-                    "references"
-                ]
-            ],
-            "use_query": true
-        },
-        {
-            "type": "cast_fields",
-            "fields": {
-                "prediction": "float",
-                "references": "float"
-            },
-            "failure_defaults": {
-                "prediction": 0.0
-            },
-            "use_nested_query": true
-        }
-    ],
-    "metric": {
-        "type": "kendall_tau_metric"
-    }
+    "type": "kendall_tau_metric"
 }

--- a/src/unitxt/catalog/metrics/roc_auc.json
+++ b/src/unitxt/catalog/metrics/roc_auc.json
@@ -1,30 +1,3 @@
 {
-    "type": "metric_pipeline",
-    "main_score": "roc_auc",
-    "preprocess_steps": [
-        {
-            "type": "copy_fields",
-            "field_to_field": [
-                [
-                    "references/0",
-                    "references"
-                ]
-            ],
-            "use_query": true
-        },
-        {
-            "type": "cast_fields",
-            "fields": {
-                "prediction": "float",
-                "references": "float"
-            },
-            "failure_defaults": {
-                "prediction": 0.0
-            },
-            "use_nested_query": true
-        }
-    ],
-    "metric": {
-        "type": "roc_auc"
-    }
+    "type": "roc_auc"
 }

--- a/src/unitxt/eval_utils.py
+++ b/src/unitxt/eval_utils.py
@@ -28,9 +28,7 @@ def _(
 
         if not compute_conf_intervals:
             first_step = metrics_operator.steps[0]
-            n_resamples = (
-                first_step.disable_confidence_interval_calculation_return_n_resamples()
-            )
+            n_resamples = first_step.disable_confidence_interval_calculation()
 
         instances = list(metrics_operator(multi_stream)["test"])
         for entry, instance in zip(dataset, instances):

--- a/src/unitxt/eval_utils.py
+++ b/src/unitxt/eval_utils.py
@@ -28,7 +28,9 @@ def _(
 
         if not compute_conf_intervals:
             first_step = metrics_operator.steps[0]
-            n_resamples = first_step.disable_confidence_interval_calculation()
+            n_resamples = (
+                first_step.disable_confidence_interval_calculation_return_n_resamples()
+            )
 
         instances = list(metrics_operator(multi_stream)["test"])
         for entry, instance in zip(dataset, instances):
@@ -42,7 +44,7 @@ def _(
         # retrieve the metric with the previous modification.
         # This reverts the confidence interval change and restores the initial metric.
         if not compute_conf_intervals:
-            first_step.set_n_resamples_for_metric(n_resamples)
+            first_step.set_n_resamples(n_resamples)
 
     return dataset, global_scores
 

--- a/src/unitxt/eval_utils.py
+++ b/src/unitxt/eval_utils.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 
 import pandas as pd
 
-from .metrics import MetricPipeline
 from .operator import SequentialOperator
 from .stream import MultiStream
 
@@ -29,12 +28,7 @@ def _(
 
         if not compute_conf_intervals:
             first_step = metrics_operator.steps[0]
-            if isinstance(first_step, MetricPipeline):
-                n_samples_before = first_step.metric.n_resamples
-                first_step.metric.disable_confidence_interval_calculation()
-            else:
-                n_samples_before = first_step.n_resamples
-                first_step.disable_confidence_interval_calculation()
+            n_resamples = first_step.disable_confidence_interval_calculation()
 
         instances = list(metrics_operator(multi_stream)["test"])
         for entry, instance in zip(dataset, instances):
@@ -48,11 +42,7 @@ def _(
         # retrieve the metric with the previous modification.
         # This reverts the confidence interval change and restores the initial metric.
         if not compute_conf_intervals:
-            first_step = metrics_operator.steps[0]
-            if isinstance(first_step, MetricPipeline):
-                first_step.metric.n_resamples = n_samples_before
-            else:
-                first_step.n_resamples = n_samples_before
+            first_step.set_n_resamples_for_metric(n_resamples)
 
     return dataset, global_scores
 

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -80,6 +80,9 @@ class MetricWithConfidenceInterval(Metric):
     def disable_confidence_interval_calculation(self):
         self.n_resamples = None
 
+    def set_n_resmaples(self, n_resamples):
+        self.n_resamples = n_resamples
+
     def _can_compute_confidence_intervals(self, num_predictions):
         return (
             self.n_resamples is not None
@@ -525,6 +528,14 @@ class MetricPipeline(MultiStreamOperator, Metric):
         default_factory=list
     )
     metric: Metric = None
+
+    def disable_confidence_interval_calculation(self):
+        if isinstance(self.metric, MetricWithConfidenceInterval):
+            self.metric.disable_confidence_interval_calculation()
+
+    def set_n_resamples_for_metric(self, n_resample):
+        if isinstance(self.metric, MetricWithConfidenceInterval):
+            self.metric.set_n_resmaples(n_resample)
 
     def verify(self):
         assert self.main_score is not None, "main_score is not set"

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -85,7 +85,7 @@ class MetricWithConfidenceInterval(Metric):
         self.n_resamples = None
         return n
 
-    def set_n_resmaples(self, n_resamples):
+    def set_n_resamples(self, n_resamples):
         self.n_resamples = n_resamples
 
     def _can_compute_confidence_intervals(self, num_predictions):
@@ -547,7 +547,7 @@ class MetricPipeline(MultiStreamOperator, Metric):
 
     def set_n_resamples(self, n_resample):
         if isinstance(self.metric, MetricWithConfidenceInterval):
-            self.metric.set_n_resmaples(n_resample)
+            self.metric.set_n_resamples(n_resample)
 
     def verify(self):
         assert self.main_score is not None, "main_score is not set"

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -1021,7 +1021,7 @@ class KendallTauMetric(GlobalMetric):
         corr = kendall_results.correlation
         return {
             self.main_score: corr,
-            "p_val": kendall_results.pvalue,
+            "kendalltau_p_val": kendall_results.pvalue,
         }
 
 

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -26,7 +26,7 @@ from .operators import CopyFields
 from .random_utils import get_seed
 from .settings_utils import get_settings
 from .stream import MultiStream, Stream
-from .type_utils import isoftype
+from .type_utils import isoftype, to_float_or_default
 
 logger = get_logger()
 settings = get_settings()
@@ -1008,10 +1008,15 @@ class KendallTauMetric(GlobalMetric):
 
     def compute(
         self,
-        references: List[float],
-        predictions: List[float],
+        references: List[List[str]],
+        predictions: List[str],
         additional_inputs: List[Dict],
     ) -> dict:
+        if isinstance(references[0], list):
+            references = [reference[0] for reference in references]
+        references = [to_float_or_default(r) for r in references]
+        predictions = [to_float_or_default(p) for p in predictions]
+
         kendall_results = self.kendalltau(references, predictions, variant=self.variant)
         corr = kendall_results.correlation
         return {
@@ -1061,10 +1066,15 @@ class RocAuc(GlobalMetric):
 
     def compute(
         self,
-        references: List[List[float]],
-        predictions: List[float],
+        references: List[List[str]],
+        predictions: List[str],
         additional_inputs: List[Dict],
     ) -> dict:
+        if isinstance(references[0], list):
+            references = [reference[0] for reference in references]
+        references = [to_float_or_default(r) for r in references]
+        predictions = [to_float_or_default(p) for p in predictions]
+
         fpr, tpr, thrs = self.roc_curve(y_true=references, y_score=predictions)
         roc_auc = self.auc(fpr, tpr)
         return {self.main_score: roc_auc}

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -78,6 +78,9 @@ class MetricWithConfidenceInterval(Metric):
         return np.random.default_rng(hash(get_seed()) & _max_32bit)
 
     def disable_confidence_interval_calculation(self):
+        self.n_resamples = None
+
+    def disable_confidence_interval_calculation_return_n_resamples(self):
         n = self.n_resamples
         self.n_resamples = None
         return n
@@ -533,10 +536,16 @@ class MetricPipeline(MultiStreamOperator, Metric):
 
     def disable_confidence_interval_calculation(self):
         if isinstance(self.metric, MetricWithConfidenceInterval):
-            return self.metric.disable_confidence_interval_calculation()
+            self.metric.disable_confidence_interval_calculation()
+
+    def disable_confidence_interval_calculation_return_n_resamples(self):
+        if isinstance(self.metric, MetricWithConfidenceInterval):
+            return (
+                self.metric.disable_confidence_interval_calculation_return_n_resamples()
+            )
         return None
 
-    def set_n_resamples_for_metric(self, n_resample):
+    def set_n_resamples(self, n_resample):
         if isinstance(self.metric, MetricWithConfidenceInterval):
             self.metric.set_n_resmaples(n_resample)
 

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -78,7 +78,9 @@ class MetricWithConfidenceInterval(Metric):
         return np.random.default_rng(hash(get_seed()) & _max_32bit)
 
     def disable_confidence_interval_calculation(self):
+        n = self.n_resamples
         self.n_resamples = None
+        return n
 
     def set_n_resmaples(self, n_resamples):
         self.n_resamples = n_resamples
@@ -531,7 +533,8 @@ class MetricPipeline(MultiStreamOperator, Metric):
 
     def disable_confidence_interval_calculation(self):
         if isinstance(self.metric, MetricWithConfidenceInterval):
-            self.metric.disable_confidence_interval_calculation()
+            return self.metric.disable_confidence_interval_calculation()
+        return None
 
     def set_n_resamples_for_metric(self, n_resample):
         if isinstance(self.metric, MetricWithConfidenceInterval):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1577,7 +1577,7 @@ class ApplyMetric(SingleStreamOperator, ArtifactFetcherMixin):
     calc_confidence_intervals: bool
 
     def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
-        from .metrics import Metric, MetricPipeline, MetricWithConfidenceInterval
+        from .metrics import Metric
 
         first_instance = stream.peek()
 
@@ -1603,12 +1603,7 @@ class ApplyMetric(SingleStreamOperator, ArtifactFetcherMixin):
             ), f"Operator {metric_name} must be a Metric"
 
             if not self.calc_confidence_intervals:
-                if isinstance(metric, MetricWithConfidenceInterval):
-                    metric.disable_confidence_interval_calculation()
-                elif isinstance(metric, MetricPipeline) and isinstance(
-                    metric.metric, MetricWithConfidenceInterval
-                ):
-                    metric.metric.disable_confidence_interval_calculation()
+                metric.disable_confidence_interval_calculation()
 
             stream = metric(MultiStream({"tmp": stream}))["tmp"]
 

--- a/src/unitxt/type_utils.py
+++ b/src/unitxt/type_utils.py
@@ -481,3 +481,12 @@ def issubtype(
             issubtype(typing.Dict[str, bytes], JSON, forward_refs={'JSON': JSON})  # False
     """
     return _is_normal_subtype(normalize(left), normalize(right), forward_refs)
+
+
+def to_float_or_default(v, failure_default=0):
+    try:
+        return float(v)
+    except Exception as e:
+        if failure_default is None:
+            raise e
+        return failure_default

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -8,6 +8,8 @@ from src.unitxt.metrics import (
     F1Micro,
     F1MicroMultiLabel,
     F1Weighted,
+    KendallTauMetric,
+    RocAuc,
     Rouge,
     Squad,
     TokenOverlap,
@@ -387,6 +389,26 @@ class TestMetrics(UnitxtTestCase):
         global_targets = {"f1": 7 / 8, "precision": 7 / 8, "recall": 1}
         for target, value in global_targets.items():
             self.assertAlmostEqual(value, outputs[0]["score"]["global"][target])
+
+    def test_roc_auc(self):
+        metric = RocAuc()
+        predictions = ["0.2", "0.8", "1.0"]
+        references = [["1.0"], ["0.0"], ["1.0"]]
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+        global_target = 0.5
+        self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
+
+    def test_kendalltau(self):
+        metric = KendallTauMetric()
+        predictions = ["1.0", "2.0", "1.0"]
+        references = [["-1.0"], ["1.0"], ["0.0"]]
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+        global_target = 0.81649658092772
+        self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
 
 
 class TestConfidenceIntervals(UnitxtTestCase):

--- a/tests/library/test_type_utils.py
+++ b/tests/library/test_type_utils.py
@@ -1,6 +1,6 @@
 import typing
 
-from src.unitxt.type_utils import isoftype, issubtype
+from src.unitxt.type_utils import isoftype, issubtype, to_float_or_default
 from tests.utils import UnitxtTestCase
 
 
@@ -96,3 +96,9 @@ class TestAssertTyping(UnitxtTestCase):
         self.assertFalse(
             issubtype(typing.Dict[Name, Name2], typing.Dict[BaseName, Name])
         )
+
+    def test_to_float_or_default(self):
+        self.assertEqual(to_float_or_default("1", 0), 1)
+        self.assertEqual(to_float_or_default("a", 0), 0)
+        with self.assertRaises(ValueError):
+            to_float_or_default("a", None)


### PR DESCRIPTION
1. Standard api for disabling/enabling confidence interval computation of metric/metricpipeline
2. make kendalltau and roc_auc metrics and not metric pipelines (to temporarily overcome the multiple metric pipeline issue) 