### PR TITLE
structured data operators for serializing tablerows, triples and keyvalue pairs added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ docs/modules.rst
 docs/unitxt.*.rst
 ibmcosdataset/
 ibmcos_datasets/
+kaggle.json

--- a/prepare/cards/dart.py
+++ b/prepare/cards/dart.py
@@ -19,7 +19,7 @@ card = TaskCard(
             field_to_field={"annotations/text/0": "output"},
             use_query=True,
         ),
-        AddFields(fields={"type_of_input": "Triples"}),
+        AddFields(fields={"type_of_input": "Triples", "type_of_output": "Text"}),
     ],
     task="tasks.generation",
     templates="templates.generation.all",

--- a/prepare/cards/dart.py
+++ b/prepare/cards/dart.py
@@ -1,0 +1,35 @@
+from src.unitxt.blocks import (
+    CopyFields,
+    LoadHF,
+    RenameFields,
+    SerializeTriples,
+    TaskCard,
+)
+from src.unitxt.catalog import add_to_catalog
+from src.unitxt.templates import InputOutputTemplate, TemplatesList
+from src.unitxt.test_utils.card import test_card
+
+card = TaskCard(
+    loader=LoadHF(path="dart"),
+    preprocess_steps=[
+        "splitters.small_no_test",
+        SerializeTriples(field_to_field=[["tripleset", "serialized_triples"]]),
+        RenameFields(field_to_field={"serialized_triples": "input"}),
+        CopyFields(
+            field_to_field={"annotations/text/0": "output"},
+            use_query=True,
+        ),
+    ],
+    task="tasks.generation",
+    templates=TemplatesList(
+        [
+            InputOutputTemplate(
+                input_format="Given the following triples, generate a text sentence out of them. Triples = {input} ",
+                output_format="{output}",
+            ),
+        ]
+    ),
+)
+
+test_card(card)
+add_to_catalog(card, "cards.dart", overwrite=True)

--- a/prepare/cards/dart.py
+++ b/prepare/cards/dart.py
@@ -1,4 +1,5 @@
 from src.unitxt.blocks import (
+    AddFields,
     CopyFields,
     LoadHF,
     RenameFields,
@@ -6,7 +7,6 @@ from src.unitxt.blocks import (
     TaskCard,
 )
 from src.unitxt.catalog import add_to_catalog
-from src.unitxt.templates import InputOutputTemplate, TemplatesList
 from src.unitxt.test_utils.card import test_card
 
 card = TaskCard(
@@ -19,16 +19,10 @@ card = TaskCard(
             field_to_field={"annotations/text/0": "output"},
             use_query=True,
         ),
+        AddFields(fields={"type_of_input": "Triples"}),
     ],
     task="tasks.generation",
-    templates=TemplatesList(
-        [
-            InputOutputTemplate(
-                input_format="Given the following triples, generate a text sentence out of them. Triples = {input} ",
-                output_format="{output}",
-            ),
-        ]
-    ),
+    templates="templates.generation.all",
 )
 
 test_card(card)

--- a/prepare/cards/tablerow_classify.py
+++ b/prepare/cards/tablerow_classify.py
@@ -23,7 +23,7 @@ card = TaskCard(
         MapInstanceValues(mappers={"label": {"0": "Normal", "1": "Heart Disease"}}),
         AddFields(
             fields={
-                "text_type": "Person",
+                "text_type": "Person medical record",
                 "type_of_class": "Heart Disease Possibility",
             }
         ),

--- a/prepare/cards/tablerow_classify.py
+++ b/prepare/cards/tablerow_classify.py
@@ -1,6 +1,5 @@
 from src.unitxt.blocks import (
     AddFields,
-    FormTask,
     LoadFromKaggle,
     MapInstanceValues,
     RenameFields,
@@ -9,7 +8,7 @@ from src.unitxt.blocks import (
     TaskCard,
 )
 from src.unitxt.catalog import add_to_catalog
-from src.unitxt.templates import InputOutputTemplate, TemplatesList
+from src.unitxt.operators import ExtractFieldValues
 from src.unitxt.test_utils.card import test_card
 
 card = TaskCard(
@@ -24,9 +23,11 @@ card = TaskCard(
         MapInstanceValues(mappers={"label": {"0": "Normal", "1": "Heart Disease"}}),
         AddFields(
             fields={
-                "choices": ["Normal", "Heart Disease"],
+                "text_type": "Person",
+                "type_of_class": "Heart Disease Possibility",
             }
         ),
+        ExtractFieldValues(field="label", to_field="classes", stream_name="train"),
         SerializeTableRowAsText(
             fields=[
                 "Age",
@@ -41,25 +42,12 @@ card = TaskCard(
                 "Oldpeak",
                 "ST_Slope",
             ],
-            to_field="serialized_row",
+            to_field="text",
             max_cell_length=25,
         ),
     ],
-    task=FormTask(
-        inputs=["serialized_row", "choices"],
-        outputs=["label"],
-        metrics=["metrics.accuracy"],
-    ),
-    templates=TemplatesList(
-        [
-            InputOutputTemplate(
-                input_format="""
-                    Given the following details of a person {serialized_row} we need to predict the possibility of heart disease for the person. Classify if the person is {choices}
-                """.strip(),
-                output_format="{label}",
-            ),
-        ]
-    ),
+    task="tasks.classification.multi_class",
+    templates="templates.classification.multi_class.all",
 )
 
 test_card(card, num_demos=3)

--- a/prepare/cards/tablerow_classify.py
+++ b/prepare/cards/tablerow_classify.py
@@ -1,0 +1,66 @@
+from src.unitxt.blocks import (
+    AddFields,
+    FormTask,
+    LoadFromKaggle,
+    MapInstanceValues,
+    RenameFields,
+    SerializeTableRowAsText,
+    SplitRandomMix,
+    TaskCard,
+)
+from src.unitxt.catalog import add_to_catalog
+from src.unitxt.templates import InputOutputTemplate, TemplatesList
+from src.unitxt.test_utils.card import test_card
+
+card = TaskCard(
+    loader=LoadFromKaggle(
+        url="https://www.kaggle.com/datasets/fedesoriano/heart-failure-prediction"
+    ),
+    preprocess_steps=[
+        SplitRandomMix(
+            {"train": "train[70%]", "validation": "train[10%]", "test": "train[20%]"}
+        ),
+        RenameFields(field_to_field={"HeartDisease": "label"}),
+        MapInstanceValues(mappers={"label": {"0": "Normal", "1": "Heart Disease"}}),
+        AddFields(
+            fields={
+                "choices": ["Normal", "Heart Disease"],
+            }
+        ),
+        SerializeTableRowAsText(
+            fields=[
+                "Age",
+                "Sex",
+                "ChestPainType",
+                "RestingBP",
+                "Cholesterol",
+                "FastingBS",
+                "RestingECG",
+                "MaxHR",
+                "ExerciseAngina",
+                "Oldpeak",
+                "ST_Slope",
+            ],
+            to_field="serialized_row",
+            max_cell_length=25,
+        ),
+    ],
+    task=FormTask(
+        inputs=["serialized_row", "choices"],
+        outputs=["label"],
+        metrics=["metrics.accuracy"],
+    ),
+    templates=TemplatesList(
+        [
+            InputOutputTemplate(
+                input_format="""
+                    Given the following details of a person {serialized_row} we need to predict the possibility of heart disease for the person. Classify if the person is {choices}
+                """.strip(),
+                output_format="{label}",
+            ),
+        ]
+    ),
+)
+
+test_card(card, num_demos=3)
+add_to_catalog(card, "cards.tablerow_classify", overwrite=True)

--- a/prepare/cards/wiki_bio.py
+++ b/prepare/cards/wiki_bio.py
@@ -21,7 +21,9 @@ card = TaskCard(
         ),
         SerializeKeyValPairs(field_to_field=[["kvpairs", "input"]]),
         RenameFields(field_to_field={"target_text": "output"}),
-        AddFields(fields={"type_of_input": "Key-Value pairs"}),
+        AddFields(
+            fields={"type_of_input": "Key-Value pairs", "type_of_output": "Text"}
+        ),
     ],
     task="tasks.generation",
     templates="templates.generation.all",

--- a/prepare/cards/wiki_bio.py
+++ b/prepare/cards/wiki_bio.py
@@ -1,0 +1,37 @@
+from src.unitxt.blocks import (
+    ListToKeyValPairs,
+    LoadHF,
+    RenameFields,
+    SerializeKeyValPairs,
+    SplitRandomMix,
+    TaskCard,
+)
+from src.unitxt.catalog import add_to_catalog
+from src.unitxt.templates import InputOutputTemplate, TemplatesList
+from src.unitxt.test_utils.card import test_card
+
+card = TaskCard(
+    loader=LoadHF(path="wiki_bio"),
+    preprocess_steps=[
+        SplitRandomMix({"train": "train", "validation": "val", "test": "test"}),
+        ListToKeyValPairs(
+            fields=["input_text/table/column_header", "input_text/table/content"],
+            to_field="kvpairs",
+            use_query=True,
+        ),
+        SerializeKeyValPairs(field_to_field=[["kvpairs", "input"]]),
+        RenameFields(field_to_field={"target_text": "output"}),
+    ],
+    task="tasks.generation",
+    templates=TemplatesList(
+        [
+            InputOutputTemplate(
+                input_format="Given the following Key-Value pairs, generate text from this data. Key-Value pairs = {input}. Text = ",
+                output_format="{output}",
+            ),
+        ]
+    ),
+)
+
+test_card(card)
+add_to_catalog(card, "cards.wiki_bio", overwrite=True)

--- a/prepare/cards/wiki_bio.py
+++ b/prepare/cards/wiki_bio.py
@@ -1,4 +1,5 @@
 from src.unitxt.blocks import (
+    AddFields,
     ListToKeyValPairs,
     LoadHF,
     RenameFields,
@@ -7,7 +8,6 @@ from src.unitxt.blocks import (
     TaskCard,
 )
 from src.unitxt.catalog import add_to_catalog
-from src.unitxt.templates import InputOutputTemplate, TemplatesList
 from src.unitxt.test_utils.card import test_card
 
 card = TaskCard(
@@ -21,16 +21,10 @@ card = TaskCard(
         ),
         SerializeKeyValPairs(field_to_field=[["kvpairs", "input"]]),
         RenameFields(field_to_field={"target_text": "output"}),
+        AddFields(fields={"type_of_input": "Key-Value pairs"}),
     ],
     task="tasks.generation",
-    templates=TemplatesList(
-        [
-            InputOutputTemplate(
-                input_format="Given the following Key-Value pairs, generate text from this data. Key-Value pairs = {input}. Text = ",
-                output_format="{output}",
-            ),
-        ]
-    ),
+    templates="templates.generation.all",
 )
 
 test_card(card)

--- a/prepare/tasks/generation.py
+++ b/prepare/tasks/generation.py
@@ -3,7 +3,7 @@ from src.unitxt.catalog import add_to_catalog
 
 add_to_catalog(
     FormTask(
-        inputs=["input", "type_of_input"],
+        inputs=["input", "type_of_input", "type_of_output"],
         outputs=["output"],
         metrics=["metrics.normalized_sacrebleu"],
         augmentable_inputs=["input"],

--- a/prepare/tasks/generation.py
+++ b/prepare/tasks/generation.py
@@ -3,7 +3,7 @@ from src.unitxt.catalog import add_to_catalog
 
 add_to_catalog(
     FormTask(
-        inputs=["input"],
+        inputs=["input", "type_of_input"],
         outputs=["output"],
         metrics=["metrics.normalized_sacrebleu"],
         augmentable_inputs=["input"],

--- a/prepare/templates/classification/classification.py
+++ b/prepare/templates/classification/classification.py
@@ -5,7 +5,7 @@ from src.unitxt.templates import InputOutputTemplate, MultiLabelTemplate, Templa
 
 add_to_catalog(
     InputOutputTemplate(
-        input_format="Classify the {type_of_class} of following {text_type} to one of these options: {classes}. Text: {text}",
+        input_format="Classify the {type_of_class} of following {text_type} to one of these options: {classes}. {text_type}: {text}",
         output_format="{label}",
         postprocessors=[
             "processors.take_first_non_empty_line",

--- a/prepare/templates/generation/generation.py
+++ b/prepare/templates/generation/generation.py
@@ -5,7 +5,7 @@ from src.unitxt.templates import InputOutputTemplate, TemplatesList
 
 add_to_catalog(
     InputOutputTemplate(
-        input_format="Given the following {type_of_input}, generate the corresponding text. {type_of_input}: {input}",
+        input_format="Given the following {type_of_input}, generate the corresponding {type_of_output}. {type_of_input}: {input}",
         output_format="{output}",
         postprocessors=[
             "processors.take_first_non_empty_line",

--- a/prepare/templates/generation/generation.py
+++ b/prepare/templates/generation/generation.py
@@ -1,0 +1,27 @@
+from src.unitxt.catalog import add_to_catalog
+from src.unitxt.templates import InputOutputTemplate, TemplatesList
+
+### Generation
+
+add_to_catalog(
+    InputOutputTemplate(
+        input_format="Given the following {type_of_input}, generate the corresponding text. {type_of_input}: {input}",
+        output_format="{output}",
+        postprocessors=[
+            "processors.take_first_non_empty_line",
+            "processors.lower_case_till_punc",
+        ],
+    ),
+    "templates.generation.default",
+    overwrite=True,
+)
+
+add_to_catalog(
+    TemplatesList(
+        [
+            "templates.generation.default",
+        ]
+    ),
+    "templates.generation.all",
+    overwrite=True,
+)

--- a/src/unitxt/blocks.py
+++ b/src/unitxt/blocks.py
@@ -4,7 +4,7 @@ from .collections import ItemPicker, RandomPicker
 from .instructions import (
     TextualInstruction,
 )
-from .loaders import LoadFromIBMCloud, LoadHF
+from .loaders import LoadFromIBMCloud, LoadFromKaggle, LoadHF
 from .metrics import Accuracy
 from .normalizers import NormalizeListFields
 from .operators import (
@@ -20,9 +20,14 @@ from .processors import ToString, ToStringStripped
 from .recipe import SequentialRecipe
 from .splitters import RandomSampler, SliceSplit, SplitRandomMix, SpreadSplit
 from .stream import MultiStream
-from .table_operators import (
+from .struct_data_operators import (
+    ListToKeyValPairs,
+    SerializeKeyValPairs,
     SerializeTableAsIndexedRowMajor,
     SerializeTableAsMarkdown,
+    SerializeTableRowAsList,
+    SerializeTableRowAsText,
+    SerializeTriples,
     TruncateTableCells,
     TruncateTableRows,
 )

--- a/src/unitxt/catalog/cards/dart.json
+++ b/src/unitxt/catalog/cards/dart.json
@@ -27,17 +27,14 @@
                 "annotations/text/0": "output"
             },
             "use_query": true
+        },
+        {
+            "type": "add_fields",
+            "fields": {
+                "type_of_input": "Triples"
+            }
         }
     ],
     "task": "tasks.generation",
-    "templates": {
-        "type": "templates_list",
-        "items": [
-            {
-                "type": "input_output_template",
-                "input_format": "Given the following triples, generate a text sentence out of them. Triples = {input} ",
-                "output_format": "{output}"
-            }
-        ]
-    }
+    "templates": "templates.generation.all"
 }

--- a/src/unitxt/catalog/cards/dart.json
+++ b/src/unitxt/catalog/cards/dart.json
@@ -1,0 +1,43 @@
+{
+    "type": "task_card",
+    "loader": {
+        "type": "load_hf",
+        "path": "dart"
+    },
+    "preprocess_steps": [
+        "splitters.small_no_test",
+        {
+            "type": "serialize_triples",
+            "field_to_field": [
+                [
+                    "tripleset",
+                    "serialized_triples"
+                ]
+            ]
+        },
+        {
+            "type": "rename_fields",
+            "field_to_field": {
+                "serialized_triples": "input"
+            }
+        },
+        {
+            "type": "copy_fields",
+            "field_to_field": {
+                "annotations/text/0": "output"
+            },
+            "use_query": true
+        }
+    ],
+    "task": "tasks.generation",
+    "templates": {
+        "type": "templates_list",
+        "items": [
+            {
+                "type": "input_output_template",
+                "input_format": "Given the following triples, generate a text sentence out of them. Triples = {input} ",
+                "output_format": "{output}"
+            }
+        ]
+    }
+}

--- a/src/unitxt/catalog/cards/dart.json
+++ b/src/unitxt/catalog/cards/dart.json
@@ -31,7 +31,8 @@
         {
             "type": "add_fields",
             "fields": {
-                "type_of_input": "Triples"
+                "type_of_input": "Triples",
+                "type_of_output": "Text"
             }
         }
     ],

--- a/src/unitxt/catalog/cards/tablerow_classify.json
+++ b/src/unitxt/catalog/cards/tablerow_classify.json
@@ -31,7 +31,7 @@
         {
             "type": "add_fields",
             "fields": {
-                "text_type": "Person",
+                "text_type": "Person medical record",
                 "type_of_class": "Heart Disease Possibility"
             }
         },

--- a/src/unitxt/catalog/cards/tablerow_classify.json
+++ b/src/unitxt/catalog/cards/tablerow_classify.json
@@ -31,11 +31,15 @@
         {
             "type": "add_fields",
             "fields": {
-                "choices": [
-                    "Normal",
-                    "Heart Disease"
-                ]
+                "text_type": "Person",
+                "type_of_class": "Heart Disease Possibility"
             }
+        },
+        {
+            "type": "extract_field_values",
+            "field": "label",
+            "to_field": "classes",
+            "stream_name": "train"
         },
         {
             "type": "serialize_table_row_as_text",
@@ -52,31 +56,10 @@
                 "Oldpeak",
                 "ST_Slope"
             ],
-            "to_field": "serialized_row",
+            "to_field": "text",
             "max_cell_length": 25
         }
     ],
-    "task": {
-        "type": "form_task",
-        "inputs": [
-            "serialized_row",
-            "choices"
-        ],
-        "outputs": [
-            "label"
-        ],
-        "metrics": [
-            "metrics.accuracy"
-        ]
-    },
-    "templates": {
-        "type": "templates_list",
-        "items": [
-            {
-                "type": "input_output_template",
-                "input_format": "Given the following details of a person {serialized_row} we need to predict the possibility of heart disease for the person. Classify if the person is {choices}",
-                "output_format": "{label}"
-            }
-        ]
-    }
+    "task": "tasks.classification.multi_class",
+    "templates": "templates.classification.multi_class.all"
 }

--- a/src/unitxt/catalog/cards/tablerow_classify.json
+++ b/src/unitxt/catalog/cards/tablerow_classify.json
@@ -1,0 +1,82 @@
+{
+    "type": "task_card",
+    "loader": {
+        "type": "load_from_kaggle",
+        "url": "https://www.kaggle.com/datasets/fedesoriano/heart-failure-prediction"
+    },
+    "preprocess_steps": [
+        {
+            "type": "split_random_mix",
+            "mix": {
+                "train": "train[70%]",
+                "validation": "train[10%]",
+                "test": "train[20%]"
+            }
+        },
+        {
+            "type": "rename_fields",
+            "field_to_field": {
+                "HeartDisease": "label"
+            }
+        },
+        {
+            "type": "map_instance_values",
+            "mappers": {
+                "label": {
+                    "0": "Normal",
+                    "1": "Heart Disease"
+                }
+            }
+        },
+        {
+            "type": "add_fields",
+            "fields": {
+                "choices": [
+                    "Normal",
+                    "Heart Disease"
+                ]
+            }
+        },
+        {
+            "type": "serialize_table_row_as_text",
+            "fields": [
+                "Age",
+                "Sex",
+                "ChestPainType",
+                "RestingBP",
+                "Cholesterol",
+                "FastingBS",
+                "RestingECG",
+                "MaxHR",
+                "ExerciseAngina",
+                "Oldpeak",
+                "ST_Slope"
+            ],
+            "to_field": "serialized_row",
+            "max_cell_length": 25
+        }
+    ],
+    "task": {
+        "type": "form_task",
+        "inputs": [
+            "serialized_row",
+            "choices"
+        ],
+        "outputs": [
+            "label"
+        ],
+        "metrics": [
+            "metrics.accuracy"
+        ]
+    },
+    "templates": {
+        "type": "templates_list",
+        "items": [
+            {
+                "type": "input_output_template",
+                "input_format": "Given the following details of a person {serialized_row} we need to predict the possibility of heart disease for the person. Classify if the person is {choices}",
+                "output_format": "{label}"
+            }
+        ]
+    }
+}

--- a/src/unitxt/catalog/cards/wiki_bio.json
+++ b/src/unitxt/catalog/cards/wiki_bio.json
@@ -36,17 +36,14 @@
             "field_to_field": {
                 "target_text": "output"
             }
+        },
+        {
+            "type": "add_fields",
+            "fields": {
+                "type_of_input": "Key-Value pairs"
+            }
         }
     ],
     "task": "tasks.generation",
-    "templates": {
-        "type": "templates_list",
-        "items": [
-            {
-                "type": "input_output_template",
-                "input_format": "Given the following Key-Value pairs, generate text from this data. Key-Value pairs = {input}. Text = ",
-                "output_format": "{output}"
-            }
-        ]
-    }
+    "templates": "templates.generation.all"
 }

--- a/src/unitxt/catalog/cards/wiki_bio.json
+++ b/src/unitxt/catalog/cards/wiki_bio.json
@@ -1,0 +1,52 @@
+{
+    "type": "task_card",
+    "loader": {
+        "type": "load_hf",
+        "path": "wiki_bio"
+    },
+    "preprocess_steps": [
+        {
+            "type": "split_random_mix",
+            "mix": {
+                "train": "train",
+                "validation": "val",
+                "test": "test"
+            }
+        },
+        {
+            "type": "list_to_key_val_pairs",
+            "fields": [
+                "input_text/table/column_header",
+                "input_text/table/content"
+            ],
+            "to_field": "kvpairs",
+            "use_query": true
+        },
+        {
+            "type": "serialize_key_val_pairs",
+            "field_to_field": [
+                [
+                    "kvpairs",
+                    "input"
+                ]
+            ]
+        },
+        {
+            "type": "rename_fields",
+            "field_to_field": {
+                "target_text": "output"
+            }
+        }
+    ],
+    "task": "tasks.generation",
+    "templates": {
+        "type": "templates_list",
+        "items": [
+            {
+                "type": "input_output_template",
+                "input_format": "Given the following Key-Value pairs, generate text from this data. Key-Value pairs = {input}. Text = ",
+                "output_format": "{output}"
+            }
+        ]
+    }
+}

--- a/src/unitxt/catalog/cards/wiki_bio.json
+++ b/src/unitxt/catalog/cards/wiki_bio.json
@@ -40,7 +40,8 @@
         {
             "type": "add_fields",
             "fields": {
-                "type_of_input": "Key-Value pairs"
+                "type_of_input": "Key-Value pairs",
+                "type_of_output": "Text"
             }
         }
     ],

--- a/src/unitxt/catalog/tasks/generation.json
+++ b/src/unitxt/catalog/tasks/generation.json
@@ -2,7 +2,8 @@
     "type": "form_task",
     "inputs": [
         "input",
-        "type_of_input"
+        "type_of_input",
+        "type_of_output"
     ],
     "outputs": [
         "output"

--- a/src/unitxt/catalog/tasks/generation.json
+++ b/src/unitxt/catalog/tasks/generation.json
@@ -1,7 +1,8 @@
 {
     "type": "form_task",
     "inputs": [
-        "input"
+        "input",
+        "type_of_input"
     ],
     "outputs": [
         "output"

--- a/src/unitxt/catalog/templates/classification/multi_class/default.json
+++ b/src/unitxt/catalog/templates/classification/multi_class/default.json
@@ -1,6 +1,6 @@
 {
     "type": "input_output_template",
-    "input_format": "Classify the {type_of_class} of following {text_type} to one of these options: {classes}. Text: {text}",
+    "input_format": "Classify the {type_of_class} of following {text_type} to one of these options: {classes}. {text_type}: {text}",
     "output_format": "{label}",
     "postprocessors": [
         "processors.take_first_non_empty_line",

--- a/src/unitxt/catalog/templates/generation/all.json
+++ b/src/unitxt/catalog/templates/generation/all.json
@@ -1,0 +1,6 @@
+{
+    "type": "templates_list",
+    "items": [
+        "templates.generation.default"
+    ]
+}

--- a/src/unitxt/catalog/templates/generation/default.json
+++ b/src/unitxt/catalog/templates/generation/default.json
@@ -1,6 +1,6 @@
 {
     "type": "input_output_template",
-    "input_format": "Given the following {type_of_input}, generate the corresponding text. {type_of_input}: {input}",
+    "input_format": "Given the following {type_of_input}, generate the corresponding {type_of_output}. {type_of_input}: {input}",
     "output_format": "{output}",
     "postprocessors": [
         "processors.take_first_non_empty_line",

--- a/src/unitxt/catalog/templates/generation/default.json
+++ b/src/unitxt/catalog/templates/generation/default.json
@@ -1,0 +1,9 @@
+{
+    "type": "input_output_template",
+    "input_format": "Given the following {type_of_input}, generate the corresponding text. {type_of_input}: {input}",
+    "output_format": "{output}",
+    "postprocessors": [
+        "processors.take_first_non_empty_line",
+        "processors.lower_case_till_punc"
+    ]
+}

--- a/src/unitxt/dataset.py
+++ b/src/unitxt/dataset.py
@@ -36,8 +36,8 @@ from .split_utils import __file__ as _
 from .splitters import __file__ as _
 from .standard import __file__ as _
 from .stream import __file__ as _
+from .struct_data_operators import __file__ as _
 from .system_prompts import __file__ as _
-from .table_operators import __file__ as _
 from .task import __file__ as _
 from .templates import __file__ as _
 from .text_utils import __file__ as _

--- a/src/unitxt/metric.py
+++ b/src/unitxt/metric.py
@@ -35,8 +35,8 @@ from .split_utils import __file__ as _
 from .splitters import __file__ as _
 from .standard import __file__ as _
 from .stream import __file__ as _
+from .struct_data_operators import __file__ as _
 from .system_prompts import __file__ as _
-from .table_operators import __file__ as _
 from .task import __file__ as _
 from .templates import __file__ as _
 from .text_utils import __file__ as _

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -20,7 +20,7 @@ Some operators are specielized in specific task such as:
 
 - :class:`loaders<unitxt.loaders>` for loading data.
 - :class:`splitters<unitxt.splitters>` for fixing data splits.
-- :class:`table_operators<unitxt.table_operators>` for tabular data operators.
+- :class:`struct_data_operators<unitxt.struct_data_operators>` for structured data operators.
 
 Other specelized operators are used by unitxt internally:
 

--- a/tests/library/test_recipe.py
+++ b/tests/library/test_recipe.py
@@ -307,7 +307,7 @@ class TestRecipes(UnitxtTestCase):
         stream = recipe()
         sample = list(stream["test"])[1]
         source = sample["source"]
-        pattern = "Classify the sentiment of following sentence to one of these options: ((negative, positive)|(positive, negative)). Text: (.*)"
+        pattern = "Classify the sentiment of following sentence to one of these options: ((negative, positive)|(positive, negative)). sentence: (.*)"
         result = re.match(pattern, sample["source"], re.DOTALL)
         assert result, f"Unable to find '{pattern}' in '{source}'"
         result = result.group(4)

--- a/tests/library/test_struct_data_operators.py
+++ b/tests/library/test_struct_data_operators.py
@@ -1,6 +1,6 @@
 import unittest
 
-from unitxt.struct_data_operators import (
+from src.unitxt.struct_data_operators import (
     ListToKeyValPairs,
     SerializeKeyValPairs,
     SerializeTableAsIndexedRowMajor,
@@ -11,13 +11,12 @@ from unitxt.struct_data_operators import (
     TruncateTableCells,
     TruncateTableRows,
 )
-
 from src.unitxt.test_utils.operators import (
     check_operator,
 )
 
 
-class TestTableOperators(unittest.TestCase):
+class TestStructDataOperators(unittest.TestCase):
     """Tests for tabular data processing operators."""
 
     def test_serializetable_markdown(self):

--- a/tests/library/test_struct_data_operators.py
+++ b/tests/library/test_struct_data_operators.py
@@ -1,11 +1,17 @@
 import unittest
 
-from src.unitxt.table_operators import (
+from unitxt.struct_data_operators import (
+    ListToKeyValPairs,
+    SerializeKeyValPairs,
     SerializeTableAsIndexedRowMajor,
     SerializeTableAsMarkdown,
+    SerializeTableRowAsList,
+    SerializeTableRowAsText,
+    SerializeTriples,
     TruncateTableCells,
     TruncateTableRows,
 )
+
 from src.unitxt.test_utils.operators import (
     check_operator,
 )
@@ -137,6 +143,140 @@ class TestTableOperators(unittest.TestCase):
 
         check_operator(
             operator=TruncateTableRows(field="table", rows_to_keep=0),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
+    def test_serializetablerow_as_text(self):
+        inputs = [
+            {
+                "name": "Alex",
+                "age": "26",
+            }
+        ]
+
+        serialized_str = "name is Alex, age is 26, "
+
+        targets = [
+            {
+                "name": "Alex",
+                "age": "26",
+                "serialized_row": serialized_str,
+            },
+        ]
+
+        check_operator(
+            operator=SerializeTableRowAsText(
+                fields=["name", "age"], to_field="serialized_row", max_cell_length=25
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
+    def test_serializetablerow_as_list(self):
+        inputs = [
+            {
+                "name": "Alex",
+                "age": "26",
+            }
+        ]
+
+        serialized_str = "name: Alex, age: 26, "
+
+        targets = [
+            {
+                "name": "Alex",
+                "age": "26",
+                "serialized_row": serialized_str,
+            },
+        ]
+
+        check_operator(
+            operator=SerializeTableRowAsList(
+                fields=["name", "age"], to_field="serialized_row", max_cell_length=25
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
+    def test_serialize_triples(self):
+        inputs = [
+            {
+                "tripleset": [
+                    ["First Clearing", "LOCATION", "On NYS 52 1 Mi. Youngsville"],
+                    [
+                        "On NYS 52 1 Mi. Youngsville",
+                        "CITY_OR_TOWN",
+                        "Callicoon, New York",
+                    ],
+                ]
+            }
+        ]
+
+        serialized_str = "First Clearing : location : On NYS 52 1 Mi. Youngsville | On NYS 52 1 Mi. Youngsville : city_or_town : Callicoon, New York"
+
+        targets = [
+            {
+                "tripleset": [
+                    ["First Clearing", "LOCATION", "On NYS 52 1 Mi. Youngsville"],
+                    [
+                        "On NYS 52 1 Mi. Youngsville",
+                        "CITY_OR_TOWN",
+                        "Callicoon, New York",
+                    ],
+                ],
+                "serialized_triples": serialized_str,
+            },
+        ]
+
+        check_operator(
+            operator=SerializeTriples(
+                field_to_field={"tripleset": "serialized_triples"}
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
+    def test_serialize_kvpairs(self):
+        inputs = [{"kvpairs": {"name": "Alex", "age": 31, "sex": "M"}}]
+
+        serialized_str = "name is Alex, age is 31, sex is M"
+
+        targets = [
+            {
+                "kvpairs": {"name": "Alex", "age": 31, "sex": "M"},
+                "serialized_kvpairs": serialized_str,
+            },
+        ]
+
+        check_operator(
+            operator=SerializeKeyValPairs(
+                field_to_field={"kvpairs": "serialized_kvpairs"}
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
+    def test_list_to_kvpairs(self):
+        inputs = [{"keys": ["name", "age", "sex"], "values": ["Alex", 31, "M"]}]
+
+        targets = [
+            {
+                "keys": ["name", "age", "sex"],
+                "values": ["Alex", 31, "M"],
+                "kvpairs": {"name": "Alex", "age": 31, "sex": "M"},
+            },
+        ]
+
+        check_operator(
+            operator=ListToKeyValPairs(
+                fields=["keys", "values"], to_field="kvpairs", use_query=True
+            ),
             inputs=inputs,
             targets=targets,
             tester=self,


### PR DESCRIPTION
* Added new serialization operators for structured data: Table rows, Triples & KeyValue pairs
* Renamed table_operators -> struct_data_operators so that it best captures all structured data operators like the ones for Tables, Triples etc. and makes better sense to add other structured data operators to this in future.
* Added 3 new datatask cards to validate new operators
- wiki_bio : KeyValue Pair to Text(Data2Text task), Uses KeyValuePairs Serializer
- dart : Triples to Text(Data2Text task), Uses TriplesSerializer
- tablerow_classify : Table row classification using a Kaggle dataset(Heart disease prediction), Uses TableRowSerializer