### PR TITLE
Docfix: Fix incorrect artifact names in Adding Dataset doc

### DIFF
--- a/docs/docs/adding_dataset.rst
+++ b/docs/docs/adding_dataset.rst
@@ -136,8 +136,8 @@ Once your card is ready you can test it:
                     }
                 ),
             ],
-            task="tasks.tanslation.directed",
-            templates="tasks.tanslation.directed.all"
+            task="tasks.translation.directed",
+            templates="templates.translation.directed.all"
         )
 
         test_card(card)


### PR DESCRIPTION
Change the task and template artifact names to the correct names.