### PR TITLE
Add scipy to base requirements

### DIFF
--- a/requirements/base.rqr
+++ b/requirements/base.rqr
@@ -4,3 +4,4 @@ mecab-python3
 absl-py
 dpath
 ipadic
+scipy


### PR DESCRIPTION
This is required for confidence intervals computation.

To resolve:
```
(unitxt_env) matanorbach@matans-mbp unitxt % unitxt-explore
Traceback (most recent call last):
  File "/Users/matanorbach/opt/anaconda3/envs/unitxt_env/bin/unitxt-explore", line 5, in <module>
    from unitxt.ui import launch
  File "/Users/matanorbach/Documents/matan/src/fm_eval_workspace/metric_service/unitxt/src/unitxt/__init__.py", line 9, in <module>
    register_all_artifacts()
  File "/Users/matanorbach/Documents/matan/src/fm_eval_workspace/metric_service/unitxt/src/unitxt/register.py", line 106, in register_all_artifacts
    ProjectArtifactRegisterer()
  File "/Users/matanorbach/Documents/matan/src/fm_eval_workspace/metric_service/unitxt/src/unitxt/utils.py", line 12, in __call__
    cls._instances[cls] = super().__call__(*args, **kwargs)
  File "/Users/matanorbach/Documents/matan/src/fm_eval_workspace/metric_service/unitxt/src/unitxt/register.py", line 101, in __init__
    _register_all_artifacts()
  File "/Users/matanorbach/Documents/matan/src/fm_eval_workspace/metric_service/unitxt/src/unitxt/register.py", line 84, in _register_all_artifacts
    module = importlib.import_module("." + module_name, __package__)
  File "/Users/matanorbach/opt/anaconda3/envs/unitxt_env/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/Users/matanorbach/Documents/matan/src/fm_eval_workspace/metric_service/unitxt/src/unitxt/metrics.py", line 15, in <module>
    from scipy.stats import bootstrap
ModuleNotFoundError: No module named 'scipy'
```