### PR TITLE
Return copies of artifacts from the artifacts cache

### DIFF
--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -298,7 +298,19 @@ class UnitxtArtifactNotFoundError(Exception):
         return f"Artifact {self.name} does not exist, in artifactories:{self.artifactories}"
 
 
-@lru_cache(maxsize=None)
+def copying_lru_cache(maxsize=10, typed=False):
+    def decorator(f):
+        cached_func = lru_cache(maxsize=maxsize, typed=typed)(f)
+
+        def wrapper(*args, **kwargs):
+            return deepcopy(cached_func(*args, **kwargs))
+
+        return wrapper
+
+    return decorator
+
+
+@copying_lru_cache(maxsize=None)
 def fetch_artifact(name):
     if Artifact.is_artifact_file(name):
         return Artifact.load(name), None

--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -328,8 +328,7 @@ def verbosed_fetch_artifact(identifer):
 
 
 def reset_artifacts_cache():
-    fetch_artifact.cache_clear()
-    verbosed_fetch_artifact.cache_clear()
+    lru_cached_load_json.cache_clear()
 
 
 def maybe_recover_artifact(artifact):

--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -298,19 +298,22 @@ class UnitxtArtifactNotFoundError(Exception):
         return f"Artifact {self.name} does not exist, in artifactories:{self.artifactories}"
 
 
-def copying_lru_cache(maxsize=10, typed=False):
+def copying_lru_cache_for_first_tuple_item(maxsize=10, typed=False):
+    """An LRU cache wrapping a function that returns a tuple, which does deepcopy on the returned first  item."""
+
     def decorator(f):
         cached_func = lru_cache(maxsize=maxsize, typed=typed)(f)
 
         def wrapper(*args, **kwargs):
-            return deepcopy(cached_func(*args, **kwargs))
+            first_item, second_item = cached_func(*args, **kwargs)
+            return deepcopy(first_item), second_item
 
         return wrapper
 
     return decorator
 
 
-@copying_lru_cache(maxsize=None)
+@copying_lru_cache_for_first_tuple_item(maxsize=None)
 def fetch_artifact(name):
     if Artifact.is_artifact_file(name):
         return Artifact.load(name), None

--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -15,7 +15,7 @@ from .parsing_utils import (
 from .settings_utils import get_settings
 from .text_utils import camel_to_snake_case, is_camel_case
 from .type_utils import issubtype
-from .utils import lru_cached_load_json, save_json
+from .utils import artifacts_json_cache, save_json
 
 logger = get_logger()
 settings = get_settings()
@@ -209,7 +209,7 @@ class Artifact(Dataclass):
 
     @classmethod
     def load(cls, path, artifact_identifier=None, overwrite_args=None):
-        d = lru_cached_load_json(path)
+        d = artifacts_json_cache(path)
         new_artifact = cls.from_dict(d, overwrite_args=overwrite_args)
         new_artifact.artifact_identifier = artifact_identifier
         return new_artifact
@@ -327,8 +327,8 @@ def verbosed_fetch_artifact(identifer):
     return artifact
 
 
-def reset_artifacts_cache():
-    lru_cached_load_json.cache_clear()
+def reset_artifacts_json_cache():
+    artifacts_json_cache.cache_clear()
 
 
 def maybe_recover_artifact(artifact):

--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -1,4 +1,5 @@
 import difflib
+import functools
 import inspect
 import json
 import os
@@ -301,16 +302,17 @@ class UnitxtArtifactNotFoundError(Exception):
 def copying_lru_cache_for_first_tuple_item(maxsize=10, typed=False):
     """An LRU cache wrapping a function that returns a tuple, which does deepcopy on the returned first  item."""
 
-    def decorator(f):
-        cached_func = lru_cache(maxsize=maxsize, typed=typed)(f)
+    def decorating_function(user_function):
+        cached_func = lru_cache(maxsize=maxsize, typed=typed)(user_function)
 
         def wrapper(*args, **kwargs):
             first_item, second_item = cached_func(*args, **kwargs)
             return deepcopy(first_item), second_item
 
-        return wrapper
+        wrapper.cache_clear = cached_func.cache_clear
+        return functools.update_wrapper(wrapper, user_function)
 
-    return decorator
+    return decorating_function
 
 
 @copying_lru_cache_for_first_tuple_item(maxsize=None)

--- a/src/unitxt/catalog.py
+++ b/src/unitxt/catalog.py
@@ -12,7 +12,7 @@ from .artifact import (
     Artifactories,
     Artifactory,
     get_artifactory_name_and_args,
-    reset_artifacts_cache,
+    reset_artifacts_json_cache,
 )
 from .logging_utils import get_logger
 from .settings_utils import get_constants
@@ -128,7 +128,7 @@ def add_to_catalog(
     catalog_path: Optional[str] = None,
     verbose=True,
 ):
-    reset_artifacts_cache()
+    reset_artifacts_json_cache()
     if catalog is None:
         if catalog_path is None:
             catalog_path = constants.default_catalog_path

--- a/src/unitxt/eval_utils.py
+++ b/src/unitxt/eval_utils.py
@@ -37,7 +37,7 @@ def _(
 
         if not compute_conf_intervals:
             first_step = metrics_operator.steps[0]
-            n_resamples = first_step.disable_confidence_interval_calculation()
+            first_step.disable_confidence_interval_calculation()
 
         instances = list(metrics_operator(multi_stream)["test"])
         for entry, instance in zip(dataset, instances):
@@ -45,13 +45,6 @@ def _(
 
         if len(instances) > 0:
             global_scores[metric_name] = instances[0]["score"].get("global", {})
-
-        # To overcome issue #325: the modified metric artifact is cached and
-        # a sequential retrieval of an artifact with the same name will
-        # retrieve the metric with the previous modification.
-        # This reverts the confidence interval change and restores the initial metric.
-        if not compute_conf_intervals:
-            first_step.set_n_resamples(n_resamples)
 
     return dataset, global_scores
 

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -115,10 +115,6 @@ class Metric(Artifact):
     def disable_confidence_interval_calculation(self):
         pass
 
-    @abstractmethod
-    def set_n_resamples(self, n_resample):
-        pass
-
 
 class MetricWithConfidenceInterval(Metric):
     # The number of resamples used to estimate the confidence intervals of this metric.
@@ -135,12 +131,7 @@ class MetricWithConfidenceInterval(Metric):
         return np.random.default_rng(hash(get_seed()) & _max_32bit)
 
     def disable_confidence_interval_calculation(self):
-        n = self.n_resamples
         self.n_resamples = None
-        return n
-
-    def set_n_resamples(self, n_resamples):
-        self.n_resamples = n_resamples
 
     def _can_compute_confidence_intervals(self, num_predictions):
         return (
@@ -903,11 +894,7 @@ class MetricPipeline(MultiStreamOperator, Metric):
     metric: Metric = None
 
     def disable_confidence_interval_calculation(self):
-        return self.metric.disable_confidence_interval_calculation()
-
-    def set_n_resamples(self, n_resample):
-        if isinstance(self.metric, MetricWithConfidenceInterval):
-            self.metric.set_n_resamples(n_resample)
+        self.metric.disable_confidence_interval_calculation()
 
     def verify(self):
         assert self.main_score is not None, "main_score is not set"

--- a/src/unitxt/utils.py
+++ b/src/unitxt/utils.py
@@ -29,8 +29,8 @@ def flatten_dict(
 
 
 @lru_cache(maxsize=None)
-def lru_cached_load_json(path):
-    return load_json(path)
+def artifacts_json_cache(artifact_path):
+    return load_json(artifact_path)
 
 
 def load_json(path):

--- a/src/unitxt/utils.py
+++ b/src/unitxt/utils.py
@@ -1,4 +1,5 @@
 import json
+from functools import lru_cache
 from typing import Any, Dict
 
 import pkg_resources
@@ -25,6 +26,11 @@ def flatten_dict(
             items.append((new_key, v))
 
     return dict(items)
+
+
+@lru_cache(maxsize=None)
+def lru_cached_load_json(path):
+    return load_json(path)
 
 
 def load_json(path):

--- a/tests/library/test_artifact.py
+++ b/tests/library/test_artifact.py
@@ -1,7 +1,7 @@
 from src.unitxt.artifact import (
     Artifact,
     fetch_artifact,
-    reset_artifacts_cache,
+    reset_artifacts_json_cache,
 )
 from src.unitxt.catalog import add_to_catalog, get_from_catalog
 from src.unitxt.dataclass import UnexpectedArgumentError
@@ -129,5 +129,5 @@ class TestArtifact(UnitxtTestCase):
         # returned artifactories should be the same object
         self.assertTrue(artifactory1 == artifactory2)
 
-    def test_reset_artifacts_cache(self):
-        reset_artifacts_cache()
+    def test_reset_artifacts_json_cache(self):
+        reset_artifacts_json_cache()

--- a/tests/library/test_artifact.py
+++ b/tests/library/test_artifact.py
@@ -127,3 +127,6 @@ class TestArtifact(UnitxtTestCase):
 
         # returned artifactories should be the same object
         self.assertTrue(artifactory1 == artifactory2)
+
+    def test_clear_cache_of_fetch_artifact(self):
+        fetch_artifact.cache_clear()

--- a/tests/library/test_artifact.py
+++ b/tests/library/test_artifact.py
@@ -1,6 +1,7 @@
 from src.unitxt.artifact import (
     Artifact,
     fetch_artifact,
+    reset_artifacts_cache,
 )
 from src.unitxt.catalog import add_to_catalog, get_from_catalog
 from src.unitxt.dataclass import UnexpectedArgumentError
@@ -128,5 +129,5 @@ class TestArtifact(UnitxtTestCase):
         # returned artifactories should be the same object
         self.assertTrue(artifactory1 == artifactory2)
 
-    def test_clear_cache_of_fetch_artifact(self):
-        fetch_artifact.cache_clear()
+    def test_reset_artifacts_cache(self):
+        reset_artifacts_cache()

--- a/tests/library/test_artifact.py
+++ b/tests/library/test_artifact.py
@@ -112,3 +112,13 @@ class TestArtifact(UnitxtTestCase):
                 "type_of_class": "topic_test",
             }
             self.assertDictEqual(expected, artifact.fields)
+
+    def test_modifying_fetched_artifact_does_not_effect_cached_artifacts(self):
+        artifact_identifier = "metrics.accuracy"
+        artifact, _ = fetch_artifact(artifact_identifier)
+        self.assertNotEqual(artifact.n_resamples, None)
+        artifact.disable_confidence_interval_calculation()
+        self.assertEqual(artifact.n_resamples, None)
+
+        same_artifact_retrieved_again, _ = fetch_artifact(artifact_identifier)
+        self.assertNotEqual(same_artifact_retrieved_again.n_resamples, None)

--- a/tests/library/test_artifact.py
+++ b/tests/library/test_artifact.py
@@ -115,10 +115,15 @@ class TestArtifact(UnitxtTestCase):
 
     def test_modifying_fetched_artifact_does_not_effect_cached_artifacts(self):
         artifact_identifier = "metrics.accuracy"
-        artifact, _ = fetch_artifact(artifact_identifier)
+        artifact, artifactory1 = fetch_artifact(artifact_identifier)
         self.assertNotEqual(artifact.n_resamples, None)
         artifact.disable_confidence_interval_calculation()
         self.assertEqual(artifact.n_resamples, None)
 
-        same_artifact_retrieved_again, _ = fetch_artifact(artifact_identifier)
+        same_artifact_retrieved_again, artifactory2 = fetch_artifact(
+            artifact_identifier
+        )
         self.assertNotEqual(same_artifact_retrieved_again.n_resamples, None)
+
+        # returned artifactories should be the same object
+        self.assertTrue(artifactory1 == artifactory2)

--- a/tests/library/test_eval_utils.py
+++ b/tests/library/test_eval_utils.py
@@ -41,9 +41,5 @@ class TestEvalUtils(UnitxtTestCase):
                 "accuracy": 0.3333333333333333,
                 "score": 0.3333333333333333,
                 "score_name": "accuracy",
-                "accuracy_ci_low": 0.0,
-                "accuracy_ci_high": 1.0,
-                "score_ci_low": 0.0,
-                "score_ci_high": 1.0,
             },
         )

--- a/tests/library/test_eval_utils.py
+++ b/tests/library/test_eval_utils.py
@@ -41,5 +41,9 @@ class TestEvalUtils(UnitxtTestCase):
                 "accuracy": 0.3333333333333333,
                 "score": 0.3333333333333333,
                 "score_name": "accuracy",
+                "accuracy_ci_low": 0.0,
+                "accuracy_ci_high": 1.0,
+                "score_ci_low": 0.0,
+                "score_ci_high": 1.0,
             },
         )

--- a/tests/library/test_recipe.py
+++ b/tests/library/test_recipe.py
@@ -392,7 +392,7 @@ class TestRecipes(UnitxtTestCase):
 
         stream = recipe()
 
-        self.assertEqual(len(list(stream["train"])), 6)
+        self.assertEqual(len(list(stream["train"])), 10)
         self.assertEqual(len(list(stream["test"])), 5)
 
     def test_recipe_with_hf_with_twice_the_same_instance_demos(self):


### PR DESCRIPTION
This prevents any accidental changes to returned artifacts from affecting the cached objects.

Closes https://github.com/IBM/unitxt/issues/325