### PR TITLE
suggest new features of Tempate for ffqa

### DIFF
--- a/prepare/cards/ffqa_filtered.py
+++ b/prepare/cards/ffqa_filtered.py
@@ -94,12 +94,12 @@ def add_card(split: str):
                 condition="lt",
             ),
             ExecuteExpression(
-                expression='re.search(r"Document:\\s(.*)(\\n\\n|$)", inputs, re.DOTALL).group(1)',
+                expression='re.search(r"Document:\\s(.*)(\\n\\n|$)", inputs).group(1)',
                 imports_list=["re"],
                 to_field="context",
             ),
             ExecuteExpression(
-                expression='re.search(r"Question:\\s(.*)(\\n\\n|$)", inputs, re.DOTALL).group(1)',
+                expression='re.search(r"Question:\\s(.*)(\\n\\n|$)", inputs).group(1)',
                 imports_list=["re"],
                 to_field="question",
             ),

--- a/prepare/templates/qa/with_context.py
+++ b/prepare/templates/qa/with_context.py
@@ -40,11 +40,10 @@ add_to_catalog(
 # Template from https://huggingface.co/datasets/abacusai/WikiQA-Free_Form_QA
 add_to_catalog(
     MultiReferenceTemplate(
-        input_format="""\
-Answer the question based on the information provided in the document given below. The answer should be a single word or a number or a short phrase of few words
-Document: {context}
-Question: {question}
-Answer: """,
+        instruction="Answer the question based on the information provided in the document given below. The answer should be a single word or a number or a short phrase of few words.\n\n",
+        input_format="Document: {context}\nQuestion: {question}",
+        output_format="{answer}",
+        target_prefix="Answer: ",
         references_field="answers",
     ),
     "templates.qa.with_context.ffqa",

--- a/src/unitxt/catalog/cards/ffqa_filtered/16k.json
+++ b/src/unitxt/catalog/cards/ffqa_filtered/16k.json
@@ -30,7 +30,7 @@
         },
         {
             "type": "execute_expression",
-            "expression": "re.search(r\"Document:\\s(.*)(\\n\\n|$)\", inputs, re.DOTALL).group(1)",
+            "expression": "re.search(r\"Document:\\s(.*)(\\n\\n|$)\", inputs).group(1)",
             "imports_list": [
                 "re"
             ],
@@ -38,7 +38,7 @@
         },
         {
             "type": "execute_expression",
-            "expression": "re.search(r\"Question:\\s(.*)(\\n\\n|$)\", inputs, re.DOTALL).group(1)",
+            "expression": "re.search(r\"Question:\\s(.*)(\\n\\n|$)\", inputs).group(1)",
             "imports_list": [
                 "re"
             ],

--- a/src/unitxt/catalog/cards/ffqa_filtered/2k.json
+++ b/src/unitxt/catalog/cards/ffqa_filtered/2k.json
@@ -30,7 +30,7 @@
         },
         {
             "type": "execute_expression",
-            "expression": "re.search(r\"Document:\\s(.*)(\\n\\n|$)\", inputs, re.DOTALL).group(1)",
+            "expression": "re.search(r\"Document:\\s(.*)(\\n\\n|$)\", inputs).group(1)",
             "imports_list": [
                 "re"
             ],
@@ -38,7 +38,7 @@
         },
         {
             "type": "execute_expression",
-            "expression": "re.search(r\"Question:\\s(.*)(\\n\\n|$)\", inputs, re.DOTALL).group(1)",
+            "expression": "re.search(r\"Question:\\s(.*)(\\n\\n|$)\", inputs).group(1)",
             "imports_list": [
                 "re"
             ],

--- a/src/unitxt/catalog/cards/ffqa_filtered/4k.json
+++ b/src/unitxt/catalog/cards/ffqa_filtered/4k.json
@@ -30,7 +30,7 @@
         },
         {
             "type": "execute_expression",
-            "expression": "re.search(r\"Document:\\s(.*)(\\n\\n|$)\", inputs, re.DOTALL).group(1)",
+            "expression": "re.search(r\"Document:\\s(.*)(\\n\\n|$)\", inputs).group(1)",
             "imports_list": [
                 "re"
             ],
@@ -38,7 +38,7 @@
         },
         {
             "type": "execute_expression",
-            "expression": "re.search(r\"Question:\\s(.*)(\\n\\n|$)\", inputs, re.DOTALL).group(1)",
+            "expression": "re.search(r\"Question:\\s(.*)(\\n\\n|$)\", inputs).group(1)",
             "imports_list": [
                 "re"
             ],

--- a/src/unitxt/catalog/cards/ffqa_filtered/8k.json
+++ b/src/unitxt/catalog/cards/ffqa_filtered/8k.json
@@ -30,7 +30,7 @@
         },
         {
             "type": "execute_expression",
-            "expression": "re.search(r\"Document:\\s(.*)(\\n\\n|$)\", inputs, re.DOTALL).group(1)",
+            "expression": "re.search(r\"Document:\\s(.*)(\\n\\n|$)\", inputs).group(1)",
             "imports_list": [
                 "re"
             ],
@@ -38,7 +38,7 @@
         },
         {
             "type": "execute_expression",
-            "expression": "re.search(r\"Question:\\s(.*)(\\n\\n|$)\", inputs, re.DOTALL).group(1)",
+            "expression": "re.search(r\"Question:\\s(.*)(\\n\\n|$)\", inputs).group(1)",
             "imports_list": [
                 "re"
             ],

--- a/src/unitxt/catalog/templates/qa/with_context/ffqa.json
+++ b/src/unitxt/catalog/templates/qa/with_context/ffqa.json
@@ -1,5 +1,8 @@
 {
     "type": "multi_reference_template",
-    "input_format": "Answer the question based on the information provided in the document given below. The answer should be a single word or a number or a short phrase of few words\nDocument: {context}\nQuestion: {question}\nAnswer: ",
+    "instruction": "Answer the question based on the information provided in the document given below. The answer should be a single word or a number or a short phrase of few words.\n\n",
+    "input_format": "Document: {context}\nQuestion: {question}",
+    "output_format": "{answer}",
+    "target_prefix": "Answer: ",
     "references_field": "answers"
 }


### PR DESCRIPTION
I was playing with the newly added ffqa cards.
I like the song  [these boots are made for walking](https://youtu.be/sbAM2HGGCVY), and was glad to see it among the first instances.. 

I suggest to shorten the text used for context. That text is so long, that printing it out generates "message too long" error on a linux console (I highlighted the error message):   
[ffqa_now_in_main.pdf](https://github.com/IBM/unitxt/files/14452506/ffqa_now_in_main.pdf)

I think that the  re.DOTALL flag used now misleads the regular expression engine, and it skips the \n\n looked for.

Last, and most importantly, the new features of Template allow to separate the instruction from the input, which comes handy in particular when using demos.
Here is how the printout looks when applying the above items, shortening context to only first 300 words. The latter modification is done ad-hoc, not inside the card. We may want to consider adding it into the card:   
[ffqa_suggested.pdf](https://github.com/IBM/unitxt/files/14452555/ffqa_suggested.pdf)


