### PR TITLE
Eval metrics

### DIFF
--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -964,10 +964,7 @@ class CopyFields(FieldOperator):
     """
 
     def process_value(self, value: Any) -> Any:
-        try:
-            return copy.deepcopy(value)
-        except Exception:
-            return value
+        return copy.deepcopy(value)
 
 
 class GetItemByIndex(FieldOperator):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1578,13 +1578,6 @@ class ApplyStreamOperatorsField(SingleStreamOperator, ArtifactFetcherMixin):
         yield from stream
 
 
-def get_merged_stream(stream_orig, stream_new):
-    for instance1, instance2 in zip(stream_orig, stream_new):
-        instance1["score"] = deepcopy(instance2["score"])
-
-    yield from stream_new
-
-
 class ApplyMetric(SingleStreamOperator, ArtifactFetcherMixin):
     """Applies metric operators to a stream based on a metric field specified in each instance.
 

--- a/src/unitxt/processors.py
+++ b/src/unitxt/processors.py
@@ -111,7 +111,7 @@ class FirstCharacter(FieldOperator):
 
 class TakeFirstWord(FieldOperator):
     def process_value(self, text: Any) -> Any:
-        match = re.search(r"[\w]+", text)
+        match = re.search(r"([-]*[0-9]+(\.([0-9]+))*)|([\w]+)", text)
         if match:
             return text[match.start() : match.end()]
         return ""

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -246,6 +246,18 @@ class DiverseLabelsSampler(Sampler):
         return result
 
 
+class DiverseLabelsSamplerFromClasses(DiverseLabelsSampler):
+    valid_classes: List[str] = ["yes", "no"]
+
+    def sample(
+        self, instances_pool: List[Dict[str, object]]
+    ) -> List[Dict[str, object]]:
+        instance_pool = list(
+            filter(lambda x: x["target"] in self.valid_classes, instances_pool)
+        )
+        return super().sample(instance_pool)
+
+
 class SpreadSplit(InstanceOperatorWithMultiStreamAccess):
     source_stream: str = None
     target_field: str = None

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -70,6 +70,7 @@ class SeparateSplit(Splitter):
     from_split: str
     to_split_names: List[str]
     to_split_sizes: List[int]
+    remove_targets_from_source_split: bool = True
 
     def verify(self):
         assert (
@@ -82,13 +83,14 @@ class SeparateSplit(Splitter):
         mapping = {
             key: {key: [(None, None)]}
             for key in multi_stream.keys()
-            if key != self.from_split
+            if not self.remove_targets_from_source_split or key != self.from_split
         }
         so_far = 0
         for name, size in itertools.zip_longest(
             self.to_split_names, self.to_split_sizes
         ):
-            mapping[name] = {self.from_split: [(so_far, size)]}
+            if self.remove_targets_from_source_split or name != self.from_split:
+                mapping[name] = {self.from_split: [(so_far, size)]}
             if size:
                 so_far += size
         generators = slice_streams(multi_stream, mapping)

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -134,7 +134,10 @@ class Sampler(Artifact):
     def filter_source_by_instance(
         self, instances_pool: List[Dict[str, object]], instance: Dict[str, object]
     ) -> List[Dict[str, object]]:
-        return instances_pool
+        if "inputs" not in instance:
+            raise ValueError(f"'inputs' field is missing from '{instance}'.")
+
+        return list(filter(lambda x: x["inputs"] != instance["inputs"], instances_pool))
 
 
 class RandomSampler(Sampler):
@@ -249,30 +252,6 @@ class DiverseLabelsSampler(Sampler):
 
         self.random_generator.shuffle(result)
         return result
-
-
-class DiverseLabelsSamplerFromClasses(DiverseLabelsSampler):
-    valid_classes: List[str] = ["yes", "no"]
-
-    def sample(
-        self, instances_pool: List[Dict[str, object]]
-    ) -> List[Dict[str, object]]:
-        first_instance = instances_pool[0]
-        if "target" not in first_instance:
-            raise ValueError(f"'target' field is missing from '{first_instance}'.")
-
-        instance_pool = list(
-            filter(lambda x: x["target"] in self.valid_classes, instances_pool)
-        )
-        return super().sample(instance_pool)
-
-    def filter_source_by_instance(
-        self, instances_pool: List[Dict[str, object]], instance: Dict[str, object]
-    ) -> List[Dict[str, object]]:
-        if "inputs" not in instance:
-            raise ValueError(f"'inputs' field is missing from '{instance}'.")
-
-        return list(filter(lambda x: x["inputs"] != instance["inputs"], instances_pool))
 
 
 class SpreadSplit(InstanceOperatorWithMultiStreamAccess):

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -46,6 +46,7 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
 
     demos_pool_size: int = None
     num_demos: int = 0
+    demos_removed_from_data: bool = True
 
     demos_pool_name: str = "demos_pool"
     demos_taken_from: str = "train"
@@ -135,6 +136,7 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
                     from_split=self.demos_taken_from,
                     to_split_names=[self.demos_pool_name, self.demos_taken_from],
                     to_split_sizes=[int(self.demos_pool_size)],
+                    remove_targets_from_source_split=self.demos_removed_from_data,
                 )
             )
 
@@ -225,6 +227,7 @@ class StandardRecipe(StandardRecipeWithIndexes):
         demos_pool_name (str, optional): Name of the demos pool. Default is "demos_pool".
         demos_taken_from (str, optional): Specifies from where the demos are taken. Default is "train".
         demos_field (str, optional): Field name for demos. Default is "demos".
+        demos_removed_from_data (bool, optional): whether to remove the demos from the source data, Default is True
         sampler (Sampler, optional): Sampler object to be used in the recipe.
         steps (List[StreamingOperator], optional): List of StreamingOperator objects to be used in the recipe.
         augmentor (Augmentor) : Augmentor to be used to pseudo randomly augment the source text

--- a/src/unitxt/templates.py
+++ b/src/unitxt/templates.py
@@ -106,6 +106,25 @@ class InputOutputTemplate(Template):
         return target, references
 
 
+class InputOutputReferenceTemplate(InputOutputTemplate):
+    reference: str
+
+    def outputs_to_target_and_references(self, outputs: Dict[str, object]) -> str:
+        output_fields = {}
+        for name, val in [
+            ("target", self.output_format),
+            ("reference", self.reference),
+        ]:
+            try:
+                result = self.process_template(val, outputs)
+                output_fields[name] = result
+            except KeyError as e:
+                raise KeyError(
+                    f"Available outputs are {outputs.keys()} but {name} requires a different one: {val}"
+                ) from e
+        return output_fields["target"], [output_fields["reference"]]
+
+
 class MultipleChoiceTemplate(Template):
     """Formats the input (that specifies the question), the multiple choices to select the answer from, and specifies the field with the correct answer."""
 

--- a/tests/library/test_recipe.py
+++ b/tests/library/test_recipe.py
@@ -79,6 +79,36 @@ class TestRecipes(UnitxtTestCase):
             print_dict(instance)
             break
 
+    def test_standard_recipe_with_demos_not_removed_from_data(self):
+        recipe = StandardRecipe(
+            card="cards.wnli",
+            template_card_index=0,
+            demos_pool_size=100,
+            num_demos=3,
+            demos_removed_from_data=True,
+        )
+
+        stream = recipe()
+        n_trains_remove_demos = len(list(stream["train"]))
+        n_demos_remove_demos = len(list(stream["demos_pool"]))
+
+        recipe = StandardRecipeWithIndexes(
+            card="cards.wnli",
+            template_card_index=0,
+            demos_pool_size=100,
+            num_demos=3,
+            demos_removed_from_data=False,
+        )
+
+        stream = recipe()
+        n_trains_keep_demos = len(list(stream["train"]))
+        n_demos_keep_demos = len(list(stream["demos_pool"]))
+
+        self.assertEqual(
+            n_trains_keep_demos, n_trains_remove_demos + n_demos_remove_demos
+        )
+        self.assertEqual(n_demos_keep_demos, n_demos_remove_demos)
+
     def test_empty_template(self):
         recipe = StandardRecipeWithIndexes(
             card="cards.wnli",

--- a/tests/library/test_splitters.py
+++ b/tests/library/test_splitters.py
@@ -1,3 +1,5 @@
+import copy
+
 from src.unitxt.splitters import DiverseLabelsSampler
 from tests.utils import UnitxtTestCase
 
@@ -100,3 +102,24 @@ class TestDiverseLabelsSampler(UnitxtTestCase):
     def test_examplar_repr_missing_fields(self):
         self._test_examplar_repr_missing_field(missing_field="inputs")
         self._test_examplar_repr_missing_field(missing_field="outputs")
+
+    def test_filter_with_bad_input(self):
+        sampler = DiverseLabelsSampler(3)
+        choices = ["dog", "cat"]
+        instances = [
+            self.new_examplar(choices, ["dog"], "Bark1"),
+            self.new_examplar(choices, ["dog"], "Bark2"),
+            self.new_examplar(choices, ["cat"], "Cat1"),
+        ]
+        instance = copy.deepcopy(instances[0])
+
+        filtered_instances = sampler.filter_source_by_instance(instances, instance)
+        self.assertEqual(len(filtered_instances), 2)
+
+        del instance["inputs"]
+        with self.assertRaises(ValueError) as cm:
+            sampler.filter_source_by_instance(instances, instance)
+        self.assertEqual(
+            f"'inputs' field is missing from '{instance}'.",
+            str(cm.exception),
+        )

--- a/tests/library/test_templates.py
+++ b/tests/library/test_templates.py
@@ -303,6 +303,11 @@ class TestTemplates(UnitxtTestCase):
 
         check_operator(template, inputs, targets, tester=self)
 
+        with self.assertRaises(KeyError):
+            template.outputs_to_target_and_references(
+                outputs={"label": "positive", "references": "1"}
+            )
+
         class ToCoverTemplate(Template):
             def inputs_to_source(self, inputs: Dict[str, object]) -> Tuple[str, str]:
                 ret = super().inputs_to_source(inputs)

--- a/tests/library/test_templates.py
+++ b/tests/library/test_templates.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Tuple
 
 from src.unitxt.templates import (
+    InputOutputReferenceTemplate,
     InputOutputTemplate,
     KeyValTemplate,
     MultiLabelTemplate,
@@ -271,6 +272,36 @@ class TestTemplates(UnitxtTestCase):
             "\"Available outputs are dict_keys(['label']) but output format requires a different one: {no_label}\"",
             str(ke.exception),
         )
+
+    def test_input_output_reference_template_and_standard_template(self):
+        template = InputOutputReferenceTemplate(
+            input_format="This is my text:'{text}'",
+            output_format="{label}",
+            instruction="Classify sentiment into: {labels}.\n",
+            target_prefix="Sentiment is: ",
+            reference="{reference}",
+        )
+
+        inputs = [
+            {
+                "inputs": {"labels": ["positive", "negative"], "text": "hello world"},
+                "outputs": {"label": "positive", "reference": "1"},
+            },
+        ]
+
+        targets = [
+            {
+                "inputs": {"labels": ["positive", "negative"], "text": "hello world"},
+                "outputs": {"label": "positive", "reference": "1"},
+                "source": "This is my text:'hello world'",
+                "target": "positive",
+                "references": ["1"],
+                "instruction": "Classify sentiment into: positive, negative.\n",
+                "target_prefix": "Sentiment is: ",
+            },
+        ]
+
+        check_operator(template, inputs, targets, tester=self)
 
         class ToCoverTemplate(Template):
             def inputs_to_source(self, inputs: Dict[str, object]) -> Tuple[str, str]:


### PR DESCRIPTION
Add items required for the eval metrics pipeline:
1. InputOutputReferenceTemplate: the template receives two separate output fields for target and reference - allows to map between the two in the dataset level.
2.  DiverseLabelsSamplerFromClasses: diverselabelssampler to choose only from certain classes (to be able to show only definitive answer in the demos). Also filters the demo pool to make sure the demo is different from the instance.
3. Fix takeFirstWord post-processor
4. A workaround to fix the issue where the metric pipelines modifies the input stream 
5. fix CopyFields: copy a deep copy of the value