### PR TITLE
Eval metrics

### DIFF
--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -182,6 +182,7 @@ class DiverseLabelsSampler(Sampler):
 
     choices: str = "choices"
     labels: str = "labels"
+    include_empty_label: bool = True
 
     def prepare(self):
         super().prepare()
@@ -217,6 +218,8 @@ class DiverseLabelsSampler(Sampler):
         labels = {}
         for examplar in examplars_pool:
             label_repr = self.examplar_repr(examplar)
+            if label_repr == "[]" and not self.include_empty_label:
+                continue
             if label_repr not in labels:
                 labels[label_repr] = []
             labels[label_repr].append(examplar)

--- a/tests/library/test_splitters.py
+++ b/tests/library/test_splitters.py
@@ -45,6 +45,28 @@ class TestDiverseLabelsSampler(UnitxtTestCase):
             self.assertEqual(counts["cat"], 1)
             self.assertEqual(len(counts.keys()), 3)
 
+    def test_sample_no_empty_labels(self):
+        for i in range(3):
+            num_samples = 3
+            sampler = DiverseLabelsSampler(num_samples, include_empty_label=False)
+            choices = ["dog", "cat"]
+            instances = [
+                self.new_examplar(choices, ["dog"], "Bark1"),
+                self.new_examplar(choices, ["dog"], "Bark2"),
+                self.new_examplar(choices, ["cat"], "Cat1"),
+                self.new_examplar(choices, ["dog"], "Bark3"),
+                self.new_examplar(choices, ["cow"], "Moo1"),
+                self.new_examplar(choices, ["duck"], "Quack"),
+            ]
+            result = sampler.sample(instances)
+
+            from collections import Counter
+
+            counts = Counter()
+            for i in range(0, num_samples):
+                counts[result[i]["outputs"]["labels"][0]] += 1
+            self.assertEqual(set(counts.keys()), {"dog", "cat"})
+
     def test_sample_list(self):
         for _ in range(10):
             num_samples = 2


### PR DESCRIPTION
@elronbandel 
add option "include_empty_label" to DiverseLabelsSampler, to allow excluding empty labels from the sample. 

By default, the sampler balances on every combination of the "choices" classes, including the empty group. This causes examples with no desired label to be included in the sample.

Setting include_empty_label=True avoids this, and assures only examples whose labels intersect with choices are sampled.