### PR TITLE
Avoid RuntimeWarning in confidence interval computation

### DIFF
--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -199,7 +199,7 @@ class MetricWithConfidenceInterval(Metric):
         for score_name in score_names:
             # If all computed instance level scores are the same, there is no point in computing
             # confidence intervals. So skip to the next score.
-            if self._all_instance_scores_equal(instances):
+            if self._all_instance_scores_equal(instances, score_name):
                 continue
 
             # need to redefine the statistic function within the loop because score_name is a loop variable


### PR DESCRIPTION
Closes https://github.com/IBM/unitxt/issues/606

- For score based confidence interval computation, skip the computation if all instance-based scores have the same value (as suggested by @yoavkatz [here](https://github.com/IBM/unitxt/issues/482)).
- For global metric based confidence internal computation, filter out `RuntimeWarning` during the computation. This is for the case that the same metric value is computed over all resamplings. Since the metric computation per resampling is done in a callback used by scify's `bootsrtap` method, the computation cannot be simply aborted.