### PR TITLE
Group shuffle

### DIFF
--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1751,7 +1751,7 @@ class FeatureGroupedShuffle(Shuffle):
 
         # now flatten the list so it consists of individual dicts, but in (randomized) block order
         return list(itertools.chain(*page_blocks))
-
+        
 
 class EncodeLabels(StreamInstanceOperator):
     """Encode each value encountered in any field in 'fields' into the integers 0,1,...

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1730,6 +1730,9 @@ class FeatureGroupedShuffle(Shuffle):
             See outputs_2features_bigpage and outputs_2features_smallpage in test_grouped_shuffle.
     """
 
+    grouping_features: List[str] = None
+    shuffle_within_group: bool = False
+
     def process(self, page: List[Dict], stream_name: Optional[str] = None) -> Generator:
         if self.grouping_features is None:
             super().process(page, stream_name)

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -32,8 +32,10 @@ The rest of this section is dedicated for general operators.
 General Operaotrs List:
 ------------------------
 """
+import collections
 import copy
 import operator
+import os
 import uuid
 import zipfile
 from abc import abstractmethod
@@ -1749,7 +1751,7 @@ class FeatureGroupedShuffle(Shuffle):
 
         # now flatten the list so it consists of individual dicts, but in (randomized) block order
         return list(itertools.chain(*page_blocks))
-        
+
 
 class EncodeLabels(StreamInstanceOperator):
     """Encode each value encountered in any field in 'fields' into the integers 0,1,...

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1709,15 +1709,27 @@ class FeatureGroupedShuffle(Shuffle):
 
     Example is if the dataset consists of questions with paraphrases of it, and each question falls into a topic.
     All paraphrases have the same ID value as the original.
-    In this case, we may want to shuffle on grouping_features = ['question iD'],
+    In this case, we may want to shuffle on grouping_features = ['question ID'],
     to keep the paraphrases and original question together.
     We may also want to group by both 'question ID' and 'topic', if the question IDs are repeated between topics.
-    """
+    In this case, grouping_features = ['question ID', 'topic']
 
-    # list of feature names to use to define the groups
-    # a group is defined by each unique observed combination of data values for features in grouping_features
+    Args:
+        grouping_features (list of strings): list of feature names to use to define the groups.
+            a group is defined by each unique observed combination of data values for features in grouping_features
+        shuffle_within_group (bool): whether to further shuffle the instances within each group block, keeping the block order
+
+    Args (of superclass):
+        page_size (int): The size of each page in the stream. Defaults to 1000.
+            Note: shuffle_by_grouping_features determines the unique groups (unique combinations of values of grouping_features)
+            separately by page (determined by page_size).  If a block of instances in the same group are split
+            into separate pages (either by a page break falling in the group, or the dataset was not sorted by
+            grouping_features), these instances will be shuffled separately and thus the grouping may be
+            broken up by pages.  If the user wants to ensure the shuffle does the grouping and shuffling
+            across all pages, set the page_size to be larger than the dataset size.
+            See outputs_2features_bigpage and outputs_2features_smallpage in test_grouped_shuffle.
+    """
     grouping_features: List[str] = None
-    # whether to further shuffle the instances within each group block, keeping the block order
     shuffle_within_group: bool = False
 
     def process(self, page: List[Dict], stream_name: Optional[str] = None) -> Generator:

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1729,8 +1729,6 @@ class FeatureGroupedShuffle(Shuffle):
             across all pages, set the page_size to be larger than the dataset size.
             See outputs_2features_bigpage and outputs_2features_smallpage in test_grouped_shuffle.
     """
-    grouping_features: List[str] = None
-    shuffle_within_group: bool = False
 
     def process(self, page: List[Dict], stream_name: Optional[str] = None) -> Generator:
         if self.grouping_features is None:

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -32,10 +32,8 @@ The rest of this section is dedicated for general operators.
 General Operaotrs List:
 ------------------------
 """
-import collections
 import copy
 import operator
-import os
 import uuid
 import zipfile
 from abc import abstractmethod
@@ -1751,7 +1749,7 @@ class FeatureGroupedShuffle(Shuffle):
 
         # now flatten the list so it consists of individual dicts, but in (randomized) block order
         return list(itertools.chain(*page_blocks))
-        
+
 
 class EncodeLabels(StreamInstanceOperator):
     """Encode each value encountered in any field in 'fields' into the integers 0,1,...


### PR DESCRIPTION
Add a sub-class of Shuffle operator that, rather than shuffling all the instances individually, first groups instances within a page by desired grouping features, then shuffles the groups as a block.  This is necessary for our robustness metric work, where we want a test dataset to contain complete-blocks of question paraphrases (the groups).