### PR TITLE
Fix split in mmlu which was removed in huggingface

### DIFF
--- a/prepare/cards/mmlu.py
+++ b/prepare/cards/mmlu.py
@@ -69,7 +69,7 @@ def main():
         card = TaskCard(
             loader=LoadHF(path="cais/mmlu", name=subtask),
             preprocess_steps=[
-                RenameSplits({"auxiliary_train": "train"}),
+                RenameSplits({"dev": "train"}),
                 AddFields({"topic": subtask.replace("_", " ")}),
             ],
             task="tasks.qa.multiple_choice.with_topic",

--- a/src/unitxt/catalog/cards/mmlu/abstract_algebra.json
+++ b/src/unitxt/catalog/cards/mmlu/abstract_algebra.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/anatomy.json
+++ b/src/unitxt/catalog/cards/mmlu/anatomy.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/astronomy.json
+++ b/src/unitxt/catalog/cards/mmlu/astronomy.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/business_ethics.json
+++ b/src/unitxt/catalog/cards/mmlu/business_ethics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/clinical_knowledge.json
+++ b/src/unitxt/catalog/cards/mmlu/clinical_knowledge.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/college_biology.json
+++ b/src/unitxt/catalog/cards/mmlu/college_biology.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/college_chemistry.json
+++ b/src/unitxt/catalog/cards/mmlu/college_chemistry.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/college_computer_science.json
+++ b/src/unitxt/catalog/cards/mmlu/college_computer_science.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/college_mathematics.json
+++ b/src/unitxt/catalog/cards/mmlu/college_mathematics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/college_medicine.json
+++ b/src/unitxt/catalog/cards/mmlu/college_medicine.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/college_physics.json
+++ b/src/unitxt/catalog/cards/mmlu/college_physics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/computer_security.json
+++ b/src/unitxt/catalog/cards/mmlu/computer_security.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/conceptual_physics.json
+++ b/src/unitxt/catalog/cards/mmlu/conceptual_physics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/econometrics.json
+++ b/src/unitxt/catalog/cards/mmlu/econometrics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/electrical_engineering.json
+++ b/src/unitxt/catalog/cards/mmlu/electrical_engineering.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/elementary_mathematics.json
+++ b/src/unitxt/catalog/cards/mmlu/elementary_mathematics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/formal_logic.json
+++ b/src/unitxt/catalog/cards/mmlu/formal_logic.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/global_facts.json
+++ b/src/unitxt/catalog/cards/mmlu/global_facts.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_biology.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_biology.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_chemistry.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_chemistry.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_computer_science.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_computer_science.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_european_history.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_european_history.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_geography.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_geography.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_government_and_politics.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_government_and_politics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_macroeconomics.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_macroeconomics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_mathematics.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_mathematics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_microeconomics.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_microeconomics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_physics.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_physics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_psychology.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_psychology.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_statistics.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_statistics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_us_history.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_us_history.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/high_school_world_history.json
+++ b/src/unitxt/catalog/cards/mmlu/high_school_world_history.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/human_aging.json
+++ b/src/unitxt/catalog/cards/mmlu/human_aging.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/human_sexuality.json
+++ b/src/unitxt/catalog/cards/mmlu/human_sexuality.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/international_law.json
+++ b/src/unitxt/catalog/cards/mmlu/international_law.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/jurisprudence.json
+++ b/src/unitxt/catalog/cards/mmlu/jurisprudence.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/logical_fallacies.json
+++ b/src/unitxt/catalog/cards/mmlu/logical_fallacies.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/machine_learning.json
+++ b/src/unitxt/catalog/cards/mmlu/machine_learning.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/management.json
+++ b/src/unitxt/catalog/cards/mmlu/management.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/marketing.json
+++ b/src/unitxt/catalog/cards/mmlu/marketing.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/medical_genetics.json
+++ b/src/unitxt/catalog/cards/mmlu/medical_genetics.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/miscellaneous.json
+++ b/src/unitxt/catalog/cards/mmlu/miscellaneous.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/moral_disputes.json
+++ b/src/unitxt/catalog/cards/mmlu/moral_disputes.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/moral_scenarios.json
+++ b/src/unitxt/catalog/cards/mmlu/moral_scenarios.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/nutrition.json
+++ b/src/unitxt/catalog/cards/mmlu/nutrition.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/philosophy.json
+++ b/src/unitxt/catalog/cards/mmlu/philosophy.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/prehistory.json
+++ b/src/unitxt/catalog/cards/mmlu/prehistory.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/professional_accounting.json
+++ b/src/unitxt/catalog/cards/mmlu/professional_accounting.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/professional_law.json
+++ b/src/unitxt/catalog/cards/mmlu/professional_law.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/professional_medicine.json
+++ b/src/unitxt/catalog/cards/mmlu/professional_medicine.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/professional_psychology.json
+++ b/src/unitxt/catalog/cards/mmlu/professional_psychology.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/public_relations.json
+++ b/src/unitxt/catalog/cards/mmlu/public_relations.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/security_studies.json
+++ b/src/unitxt/catalog/cards/mmlu/security_studies.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/sociology.json
+++ b/src/unitxt/catalog/cards/mmlu/sociology.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/us_foreign_policy.json
+++ b/src/unitxt/catalog/cards/mmlu/us_foreign_policy.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/virology.json
+++ b/src/unitxt/catalog/cards/mmlu/virology.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/src/unitxt/catalog/cards/mmlu/world_religions.json
+++ b/src/unitxt/catalog/cards/mmlu/world_religions.json
@@ -9,7 +9,7 @@
         {
             "type": "rename_splits",
             "mapper": {
-                "auxiliary_train": "train"
+                "dev": "train"
             }
         },
         {

--- a/tests/library/test_recipe.py
+++ b/tests/library/test_recipe.py
@@ -53,13 +53,13 @@ class TestRecipes(UnitxtTestCase):
             system_prompt="system_prompts.models.llama",
             template="templates.qa.multiple_choice.with_topic.lm_eval_harness",
             format="formats.user_agent",
-            demos_pool_size=100,
+            demos_pool_size=5,
             num_demos=3,
         )
 
         stream = recipe()
 
-        for instance in stream["train"]:
+        for instance in stream["test"]:
             print_dict(instance)
             break
 


### PR DESCRIPTION
mmlu used to have "auxiliary_train: auxiliary multiple-choice training questions from ARC, MC_TEST, OBQA, RACE, etc." which was removed by dataset owner on huggingface hub as it was not part of the original mmlu dataset