### PR TITLE
fix: LoadFromIBMCloud empty data_dir breaks processing

### DIFF
--- a/src/unitxt/loaders.py
+++ b/src/unitxt/loaders.py
@@ -405,7 +405,7 @@ class LoadFromIBMCloud(Loader):
         local_dir = os.path.join(
             self.cache_dir,
             self.bucket_name,
-            self.data_dir,
+            self.data_dir or "",  # data_dir can be None
             f"loader_limit_{self.get_limit()}",
         )
         if not os.path.exists(local_dir):


### PR DESCRIPTION
`os.path` does not allow `None`