### PR TITLE
pettiness re matthews.ci

### DIFF
--- a/src/unitxt/test_utils/metrics.py
+++ b/src/unitxt/test_utils/metrics.py
@@ -81,7 +81,7 @@ def test_metric(
     assert isoftype(references, List[Any]), "references must be a list"
 
     if isinstance(metric, GlobalMetric) and metric.n_resamples:
-        metric.n_resamples = 3  # Use a low number of resamples in testing for GlobalMetric, to save runtime
+        metric.n_resamples = 30  # Use a low number of resamples in testing for GlobalMetric, to save runtime
     outputs = apply_metric(metric, predictions, references, task_data)
 
     errors = []

--- a/tests/catalog/test_preparation.py
+++ b/tests/catalog/test_preparation.py
@@ -11,6 +11,7 @@ from src.unitxt.text_utils import print_dict
 from tests.utils import UnitxtCatalogPreparationTestCase
 
 settings.test_card_disable = None
+settings.test_metric_disable = None
 
 logger = get_logger()
 project_dir = os.path.dirname(

--- a/tests/catalog/test_preparation.py
+++ b/tests/catalog/test_preparation.py
@@ -4,10 +4,13 @@ import os
 import time
 from datetime import timedelta
 
+from src.unitxt import settings
 from src.unitxt.loaders import MissingKaggleCredentialsError
 from src.unitxt.logging_utils import get_logger
 from src.unitxt.text_utils import print_dict
 from tests.utils import UnitxtCatalogPreparationTestCase
+
+settings.test_card_disable = None
 
 logger = get_logger()
 project_dir = os.path.dirname(


### PR DESCRIPTION
`prepare/metrics/matthews_correlation.py` contains a test case of three simple instances.
the mcc (Mathews Correlation Coefficient) of this 3 pair-item long sequence is: 0.5, as rightfully expected in the `global_target` in `prepare/metrics/matthews_correlation.py`.
The targeted global ci, however, is rather disappointing: for 3-item long sequence, there are 27 different resamples with replacement. All 27 are equi-probable, by definition of selection with replacement.
6 out of these 27 resamples have mcc score == 1.0.   see attached notebook.
ci_high reports the 97.5 percentile. It is expected, then, to hit into the 1.0 scores. Seeing targeted  `"matthews_correlation_ci_high": 0.5,`   is disappointing. 
The cause here is the small number, 3, of resamples done.

So I suggest to enlarge the number of resamples done to 30 (the sequences are so short, that no big deal), or write a comment in `prepare/metrics/matthews_correlation.py`  explaining that it serves mostly as a SHA code, 

[ci_for_matthews.pdf](https://github.com/IBM/unitxt/files/14623242/ci_for_matthews.pdf)
