### PR TITLE
Pettiness re matthews ci 

### DIFF
--- a/prepare/metrics/bleu.py
+++ b/prepare/metrics/bleu.py
@@ -46,10 +46,10 @@ global_target = {
     "reference_length": 8,
     "score": 0.9,
     "score_name": "bleu",
-    "bleu_ci_low": 0.9,
-    "bleu_ci_high": 0.91,
-    "score_ci_low": 0.9,
-    "score_ci_high": 0.91,
+    "bleu_ci_low": 0.0,
+    "bleu_ci_high": 1.0,
+    "score_ci_low": 0.0,
+    "score_ci_high": 1.0,
 }
 
 outputs = test_metric(

--- a/prepare/metrics/custom_f1.py
+++ b/prepare/metrics/custom_f1.py
@@ -51,10 +51,10 @@ global_target = {
     "precision_macro": 0.5,
     "score": 0.57,
     "score_name": "f1_micro",
-    "f1_micro_ci_low": 0.57,
-    "f1_micro_ci_high": 0.57,
-    "score_ci_low": 0.57,
-    "score_ci_high": 0.57,
+    "f1_micro_ci_low": 0.5,
+    "f1_micro_ci_high": 0.67,
+    "score_ci_low": 0.5,
+    "score_ci_high": 0.67,
 }
 
 outputs = test_metric(

--- a/prepare/metrics/kpa.py
+++ b/prepare/metrics/kpa.py
@@ -19,10 +19,10 @@ global_target = {
     "precision_micro": 0.67,
     "score": 0.57,
     "score_name": "f1_micro",
-    "score_ci_low": 0.33,
-    "score_ci_high": 0.75,
-    "f1_micro_ci_low": 0.33,
-    "f1_micro_ci_high": 0.75,
+    "score_ci_low": 0.04,
+    "score_ci_high": 0.89,
+    "f1_micro_ci_low": 0.04,
+    "f1_micro_ci_high": 0.89,
 }
 
 instance_target = [

--- a/prepare/metrics/kpa.py
+++ b/prepare/metrics/kpa.py
@@ -19,9 +19,9 @@ global_target = {
     "precision_micro": 0.67,
     "score": 0.57,
     "score_name": "f1_micro",
-    "score_ci_low": 0.04,
+    "score_ci_low": 0.19,
     "score_ci_high": 0.89,
-    "f1_micro_ci_low": 0.04,
+    "f1_micro_ci_low": 0.19,
     "f1_micro_ci_high": 0.89,
 }
 

--- a/prepare/metrics/kpa.py
+++ b/prepare/metrics/kpa.py
@@ -19,9 +19,9 @@ global_target = {
     "precision_micro": 0.67,
     "score": 0.57,
     "score_name": "f1_micro",
-    "score_ci_low": 0.19,
+    "score_ci_low": 0.04,
     "score_ci_high": 0.89,
-    "f1_micro_ci_low": 0.19,
+    "f1_micro_ci_low": 0.04,
     "f1_micro_ci_high": 0.89,
 }
 

--- a/prepare/metrics/matthews_correlation.py
+++ b/prepare/metrics/matthews_correlation.py
@@ -19,9 +19,9 @@ global_target = {
     "score": 0.5,
     "score_name": "matthews_correlation",
     "matthews_correlation_ci_low": 0.0,
-    "matthews_correlation_ci_high": 0.5,
+    "matthews_correlation_ci_high": 1.0,
     "score_ci_low": 0.0,
-    "score_ci_high": 0.5,
+    "score_ci_high": 1.0,
 }
 
 outputs = test_metric(

--- a/prepare/metrics/precision_recall.py
+++ b/prepare/metrics/precision_recall.py
@@ -156,19 +156,19 @@ global_target_precision_micro = {
     "precision_micro": 0.4,
     "score": 0.4,
     "score_name": "precision_micro",
-    "score_ci_low": 0.0,
-    "score_ci_high": 0.79,
-    "precision_micro_ci_low": 0.0,
-    "precision_micro_ci_high": 0.79,
+    "score_ci_low": 0.01,
+    "score_ci_high": 0.73,
+    "precision_micro_ci_low": 0.01,
+    "precision_micro_ci_high": 0.73,
 }
 
 global_target_precision_macro = {
     "precision_macro": 0.42,
     "score": 0.42,
     "score_name": "precision_macro",
-    "score_ci_low": 0.0,
+    "score_ci_low": 0.03,
     "score_ci_high": 1.0,
-    "precision_macro_ci_low": 0.0,
+    "precision_macro_ci_low": 0.03,
     "precision_macro_ci_high": 1.0,
 }
 
@@ -193,19 +193,19 @@ global_target_recall_micro = {
     "recall_micro": 0.4,
     "score": 0.4,
     "score_name": "recall_micro",
-    "score_ci_low": 0.0,
-    "score_ci_high": 0.83,
-    "recall_micro_ci_low": 0.0,
-    "recall_micro_ci_high": 0.83,
+    "score_ci_low": 0.13,
+    "score_ci_high": 0.91,
+    "recall_micro_ci_low": 0.13,
+    "recall_micro_ci_high": 0.91,
 }
 
 global_target_recall_macro = {
     "recall_macro": 0.62,
     "score": 0.62,
     "score_name": "recall_macro",
-    "score_ci_low": 0.2,
+    "score_ci_low": 0.24,
     "score_ci_high": 1.0,
-    "recall_macro_ci_low": 0.2,
+    "recall_macro_ci_low": 0.24,
     "recall_macro_ci_high": 1.0,
 }
 

--- a/prepare/metrics/precision_recall.py
+++ b/prepare/metrics/precision_recall.py
@@ -48,10 +48,10 @@ global_target_precision_macro = {
     "precision_macro": 0.5,
     "score": 0.5,
     "score_name": "precision_macro",
-    "score_ci_low": 0.5,
-    "score_ci_high": 0.86,
-    "precision_macro_ci_low": 0.5,
-    "precision_macro_ci_high": 0.86,
+    "score_ci_low": 0.0,
+    "score_ci_high": 1.0,
+    "precision_macro_ci_low": 0.0,
+    "precision_macro_ci_high": 1.0,
 }
 outputs = test_metric(
     metric=precision_micro_metric,
@@ -73,10 +73,10 @@ global_target_recall_micro = {
     "recall_micro": 0.33,
     "score": 0.33,
     "score_name": "recall_micro",
-    "score_ci_low": 0.33,
-    "score_ci_high": 0.47,
-    "recall_micro_ci_low": 0.33,
-    "recall_micro_ci_high": 0.47,
+    "score_ci_low": 0.0,
+    "score_ci_high": 1.0,
+    "recall_micro_ci_low": 0.0,
+    "recall_micro_ci_high": 1.0,
 }
 
 instance_targets_recall_micro = [
@@ -90,10 +90,10 @@ global_target_recall_macro = {
     "recall_macro": 0.33,
     "score": 0.33,
     "score_name": "recall_macro",
-    "score_ci_low": 0.33,
-    "score_ci_high": 0.47,
-    "recall_macro_ci_low": 0.33,
-    "recall_macro_ci_high": 0.47,
+    "score_ci_low": 0.0,
+    "score_ci_high": 1.0,
+    "recall_macro_ci_low": 0.0,
+    "recall_macro_ci_high": 1.0,
 }
 
 instance_targets_recall_macro = [
@@ -156,20 +156,20 @@ global_target_precision_micro = {
     "precision_micro": 0.4,
     "score": 0.4,
     "score_name": "precision_micro",
-    "score_ci_low": NaN,
-    "score_ci_high": NaN,
-    "precision_micro_ci_low": NaN,
-    "precision_micro_ci_high": NaN,
+    "score_ci_low": 0.0,
+    "score_ci_high": 0.79,
+    "precision_micro_ci_low": 0.0,
+    "precision_micro_ci_high": 0.79,
 }
 
 global_target_precision_macro = {
     "precision_macro": 0.42,
     "score": 0.42,
     "score_name": "precision_macro",
-    "score_ci_low": NaN,
-    "score_ci_high": NaN,
-    "precision_macro_ci_low": NaN,
-    "precision_macro_ci_high": NaN,
+    "score_ci_low": 0.0,
+    "score_ci_high": 1.0,
+    "precision_macro_ci_low": 0.0,
+    "precision_macro_ci_high": 1.0,
 }
 
 outputs = test_metric(
@@ -193,20 +193,20 @@ global_target_recall_micro = {
     "recall_micro": 0.4,
     "score": 0.4,
     "score_name": "recall_micro",
-    "score_ci_low": NaN,
-    "score_ci_high": NaN,
-    "recall_micro_ci_low": NaN,
-    "recall_micro_ci_high": NaN,
+    "score_ci_low": 0.0,
+    "score_ci_high": 0.83,
+    "recall_micro_ci_low": 0.0,
+    "recall_micro_ci_high": 0.83,
 }
 
 global_target_recall_macro = {
     "recall_macro": 0.62,
     "score": 0.62,
     "score_name": "recall_macro",
-    "score_ci_low": 0.63,
-    "score_ci_high": 0.67,
-    "recall_macro_ci_low": 0.63,
-    "recall_macro_ci_high": 0.67,
+    "score_ci_low": 0.2,
+    "score_ci_high": 1.0,
+    "recall_macro_ci_low": 0.2,
+    "recall_macro_ci_high": 1.0,
 }
 
 instance_targets_recall_micro = [

--- a/prepare/metrics/precision_recall.py
+++ b/prepare/metrics/precision_recall.py
@@ -31,10 +31,10 @@ global_target_precision_micro = {
     "precision_micro": 0.5,
     "score": 0.5,
     "score_name": "precision_micro",
-    "score_ci_low": 0.5,
-    "score_ci_high": 0.86,
-    "precision_micro_ci_low": 0.5,
-    "precision_micro_ci_high": 0.86,
+    "score_ci_low": 0.0,
+    "score_ci_high": 1.0,
+    "precision_micro_ci_low": 0.0,
+    "precision_micro_ci_high": 1.0,
 }
 
 instance_targets_precision_macro = [

--- a/prepare/metrics/roc_auc.py
+++ b/prepare/metrics/roc_auc.py
@@ -12,11 +12,11 @@ references = [["1.0"], ["0.0"], ["1.0"]]
 instance_targets = [{"roc_auc": np.nan, "score": np.nan, "score_name": "roc_auc"}] * 3
 global_targets = {
     "roc_auc": 0.5,
-    "roc_auc_ci_high": 0.9,
-    "roc_auc_ci_low": 0.5,
+    "roc_auc_ci_high": 1.0,
+    "roc_auc_ci_low": 0.0,
     "score": 0.5,
-    "score_ci_high": 0.9,
-    "score_ci_low": 0.5,
+    "score_ci_high": 1.0,
+    "score_ci_low": 0.0,
     "score_name": "roc_auc",
 }
 

--- a/prepare/metrics/rouge.py
+++ b/prepare/metrics/rouge.py
@@ -47,10 +47,10 @@ add_to_catalog(metric, "metrics.rouge", overwrite=True)
 global_target_with_confidence_intervals = global_target.copy()
 global_target_with_confidence_intervals.update(
     {
-        "rougeL_ci_low": 0.83,
-        "rougeL_ci_high": 0.83,
-        "score_ci_low": 0.83,
-        "score_ci_high": 0.83,
+        "rougeL_ci_low": 0.67,
+        "rougeL_ci_high": 1.0,
+        "score_ci_low": 0.67,
+        "score_ci_high": 1.0,
     }
 )
 

--- a/prepare/metrics/wer.py
+++ b/prepare/metrics/wer.py
@@ -24,10 +24,10 @@ global_target = {
     "wer": 0.38,
     "score": 0.38,
     "score_name": "wer",
-    "wer_ci_low": 0.38,
-    "wer_ci_high": 0.38,
-    "score_ci_low": 0.38,
-    "score_ci_high": 0.38,
+    "wer_ci_low": 0.25,
+    "wer_ci_high": 0.5,
+    "score_ci_low": 0.25,
+    "score_ci_high": 0.5,
 }  # Should by 0.375, but package rounds the scores
 
 outputs = test_metric(

--- a/src/unitxt/test_utils/metrics.py
+++ b/src/unitxt/test_utils/metrics.py
@@ -81,7 +81,7 @@ def test_metric(
     assert isoftype(references, List[Any]), "references must be a list"
 
     if isinstance(metric, GlobalMetric) and metric.n_resamples:
-        metric.n_resamples = 50  # Use a lower number of resamples in testing for GlobalMetric, compared against settings.num_resamples_for_global_metrics = 100, to save runtime
+        metric.n_resamples = 30  # Use a lower number of resamples in testing for GlobalMetric, compared against settings.num_resamples_for_global_metrics = 100, to save runtime
     outputs = apply_metric(metric, predictions, references, task_data)
 
     errors = []

--- a/src/unitxt/test_utils/metrics.py
+++ b/src/unitxt/test_utils/metrics.py
@@ -81,7 +81,7 @@ def test_metric(
     assert isoftype(references, List[Any]), "references must be a list"
 
     if isinstance(metric, GlobalMetric) and metric.n_resamples:
-        metric.n_resamples = 30  # Use a low number of resamples in testing for GlobalMetric, to save runtime
+        metric.n_resamples = 50  # Use a lower number of resamples in testing for GlobalMetric, compared against settings.num_resamples_for_global_metrics = 100, to save runtime
     outputs = apply_metric(metric, predictions, references, task_data)
 
     errors = []

--- a/src/unitxt/test_utils/metrics.py
+++ b/src/unitxt/test_utils/metrics.py
@@ -81,7 +81,7 @@ def test_metric(
     assert isoftype(references, List[Any]), "references must be a list"
 
     if isinstance(metric, GlobalMetric) and metric.n_resamples:
-        metric.n_resamples = 3  # Use a low number of resamples in testing for GlobalMetric, to save runtime
+        metric.n_resamples = 30  # Use a low number of resamples in testing for GlobalMetric, to save runtime
     outputs = apply_metric(metric, predictions, references, task_data)
 
     errors = []

--- a/tests/catalog/test_preparation.py
+++ b/tests/catalog/test_preparation.py
@@ -16,7 +16,7 @@ logger = get_logger()
 project_dir = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
-glob_query = os.path.join(project_dir, "prepare", "metrics", "*.py")
+glob_query = os.path.join(project_dir, "prepare", "**", "*.py")
 all_preparation_files = glob.glob(glob_query, recursive=True)
 
 

--- a/tests/catalog/test_preparation.py
+++ b/tests/catalog/test_preparation.py
@@ -10,14 +10,13 @@ from src.unitxt.logging_utils import get_logger
 from src.unitxt.text_utils import print_dict
 from tests.utils import UnitxtCatalogPreparationTestCase
 
-settings.test_card_disable = None
 settings.test_metric_disable = None
 
 logger = get_logger()
 project_dir = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
-glob_query = os.path.join(project_dir, "prepare", "**", "*.py")
+glob_query = os.path.join(project_dir, "prepare", "metrics", "*.py")
 all_preparation_files = glob.glob(glob_query, recursive=True)
 
 

--- a/tests/catalog/test_preparation.py
+++ b/tests/catalog/test_preparation.py
@@ -11,6 +11,7 @@ from src.unitxt.text_utils import print_dict
 from tests.utils import UnitxtCatalogPreparationTestCase
 
 settings.test_card_disable = None
+settings.test_metric_disable = None
 
 logger = get_logger()
 project_dir = os.path.dirname(

--- a/tests/catalog/test_preparation.py
+++ b/tests/catalog/test_preparation.py
@@ -4,10 +4,13 @@ import os
 import time
 from datetime import timedelta
 
+from src.unitxt import settings
 from src.unitxt.loaders import MissingKaggleCredentialsError
 from src.unitxt.logging_utils import get_logger
 from src.unitxt.text_utils import print_dict
 from tests.utils import UnitxtCatalogPreparationTestCase
+
+settings.test_card_disable = None
 
 logger = get_logger()
 project_dir = os.path.dirname(


### PR DESCRIPTION
`prepare/metrics/matthews_correlation.py` contains a test case of three simple instances.
the mcc (Mathews Correlation Coefficient) of this 3 pair-item long sequence is: 0.5, as rightfully expected in the `global_target` in `prepare/metrics/matthews_correlation.py`.
The targeted global ci, however, is rather disappointing: for 3-item long sequence, there are 27 different resamples with replacement. All 27 are equi-probable, by definition of selection with replacement.
6 out of these 27 resamples have mcc score == 1.0. 
ci_high reports the 97.5 percentile. It is expected, then, to hit into the 1.0 scores. Seeing targeted `"matthews_correlation_ci_high": 0.5`, is thus disappointing.
The cause here is the small number, 3, of resamples done.

So I suggest to enlarge the number of resamples done to 30 (the sequences are so short, that no big deal), or write an explaining comment in `prepare/metrics/matthews_correlation.py` .

Once we set `settings.test_metric_disable = None`,  in `test_preparation`, we see a few more examples, for which the new values of ci_low and ci_high seem more adequate for a skim through inspection.