### PR TITLE
removal of dpath -- ready for review

### DIFF
--- a/requirements/base.rqr
+++ b/requirements/base.rqr
@@ -2,6 +2,5 @@ datasets>=2.16.0
 evaluate
 mecab-python3
 absl-py
-dpath
 ipadic
 scipy

--- a/requirements/docs.rqr
+++ b/requirements/docs.rqr
@@ -8,6 +8,5 @@ sacrebleu
 absl-py
 rouge_score
 scikit-learn
-dpath
 jiwer
 editdistance

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -2,7 +2,7 @@ import re
 from typing import Any, List
 
 indx = re.compile(r"^(\d+)$")
-name = re.compile(r"^(\w+)$")
+name = re.compile(r"^[\w. -]+$")
 
 # formal definition of qpath syntax:
 # qpath -> A (/A)*
@@ -65,11 +65,10 @@ def qpath_delete(
     if index_into_query == -1:
         if component == "*":
             current_element = []
-        elif indx.match(component):
-            current_element.pop(
-                int(component)
-            )  # thrown exception will be caught outside
-        elif name.match(component):
+        else:
+            # component is a name or an index
+            if indx.match(component):
+                component = int(component)
             current_element.pop(component)  # thrown exception will be caught outside
         return (
             None

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -1,27 +1,29 @@
 import re
-from typing import Any, List, Tuple
+from typing import Any, List
 
-# import dpath
-# from dpath import MutableSequence
-# from dpath.segments import extend
-
-indx = re.compile(r"^\[?(\d+)\]?$")
+indx = re.compile(r"^(\d+)$")
 name = re.compile(r"^(\w+)$")
 
 # formal definition of qpath syntax:
 # qpath -> A (/A)*
-# A -> name | * | [?non-neg-int]?
-# name -> alphanumeric
+# A -> name | * | non-neg-int
+# name -> name.matches()
+# * should only replace indexes of a list, not all fields of a dictionary
 
 
-def validate_qpath(qpath: str) -> bool:
-    qpath = qpath.replace(" ", "")
-    if qpath.endswith("/") or "//" in qpath or qpath.startswith("["):
-        raise ValueError(
-            f"qpath should not contain // nor start with [, nor end with /. Got {qpath}"
-        )
+# validate and normalize
+# leading / is ignored, all paths are treated as coming from root of dic
+# trailing / is ignored
+def validate_qpath(qpath: str):
+    qpath = qpath.replace(" ", "").replace("//", "/").strip()
     if qpath.startswith("/"):
-        qpath = qpath[1:]
+        qpath = qpath[1:]  # remove the leading /
+    if qpath.endswith("*"):
+        qpath = qpath[
+            :-1
+        ]  # remove trailing *, treating the element above as consisting of a single value, being the whole list or dict corresponding to the * at the end of the query
+    if qpath.endswith("/"):
+        qpath = qpath[:-1]  # remove the trailing /, will be treated as if followed by *
     components = qpath.split("/")
     components = [component.strip() for component in components]
     for component in components:
@@ -30,354 +32,353 @@ def validate_qpath(qpath: str) -> bool:
             or component == "*"
             or bool(indx.match(component))
         ):
-            return False
-    return True
+            raise ValueError(
+                f"Component {component} in input qpath is none of: valid field-name, non-neg-int, or '*'"
+            )
+    return "/".join(components)
 
 
 def is_subpath(subpath, fullpath):
     # Split the paths into individual components
+    subpath = validate_qpath(subpath)
+    fullpath = validate_qpath(fullpath)
     subpath_components = subpath.split("/")
     fullpath_components = fullpath.split("/")
-    subpath_components = [component.strip() for component in subpath_components]
-    fullpath_components = [component.strip() for component in fullpath_components]
 
     # Check if the full path starts with the subpath
     return fullpath_components[: len(subpath_components)] == subpath_components
 
 
-def consume_component(qpath: str) -> Tuple[str, str]:
-    assert (
-        len(qpath.strip()) > 0
-    ), "should not try to consume a component from an empty qpath"
-    if "/" in qpath:
-        component = qpath[: qpath.find("/")]
-        qpath = qpath[1 + qpath.find("/") :]
-        return (component.strip(), qpath.strip())
-    return (qpath.strip(), "")  # nothing left
+# returns all the values sitting inside dic, in all the paths that match query_path
+# returns them as a list of values whose length equals the number of paths in dic
+# that match the query:
+def qpath_get(dic: dict, qpath: str) -> List[Any]:
+    components = qpath.split("/")
+    if len(components) == 1:
+        return [dic[components[0]]]
+    return get_values(dic, components, -1 * len(components))
 
 
-# frontier is a list of pairs. Each pair consists of a string path (that is a subpath of qpath),
-# and a value that is the resident of dic at the position lead to by the string path.
-# flake8: noqa: C901
-
-
-def verify_for_list(obj: Any, comp: str) -> int:
-    if not isinstance(obj, list):
-        raise ValueError(f"qpath specifies an index {comp} for {obj!s}")
-    i = int(re.match(indx, comp).group(1))
-    if i >= len(obj):
-        raise ValueError(f"qpath specifies an index {comp} for a shorter list: {obj!s}")
-    return i
-
-
-def advance_frontier(
-    frontier: List[Tuple[str, Any]], comp: str
-) -> List[Tuple[str, Any]]:
-    new_frontier = []
-    for f in frontier:
-        if re.match(indx, comp):
-            i = verify_for_list(f[1], comp)
-            # if not isinstance(f[1], list):
-            #     raise ValueError(f"qpath specifies an index {comp} for {f[1]!s}")
-            # i = int(re.match(indx, comp).group(1))
-            # if i >= len(f[1]):
-            #     raise ValueError(
-            #         f"qpath specifies an index {comp} for a shorter list: {f[1]!s}"
-            #     )
-            new_frontier.append((f[0] + f"/[{i}]", f[1][i]))
-            continue
-        if bool(name.match(comp)) and comp in f[1]:
-            new_frontier.append(
-                (f[0] + ("/" if len(f[0]) > 0 else "") + comp, f[1][comp])
-            )
-            continue
-        if comp == "*":
-            if not isinstance(f[1], (list, dict)):
-                raise ValueError(f"qpath specifies * for {f[1]!s}")
-            if isinstance(f[1], dict):
-                for key in f[1]:
-                    new_frontier.append(
-                        (f[0] + ("/" if len(f[0]) > 0 else "") + key, f[1][key])
-                    )
-                continue
-            # f[1] is a list
-            for i in range(len(f[1])):
-                new_frontier.append((f[0] + f"/[{i}]", f[1][i]))
-            continue
-        return []  # no path found
-    return new_frontier
-
-
-# return all the values sitting inside dic, in all the paths that match qpath,
-# paths being sorted lexicographically
-# return them as pairs of: (path, value). None of the paths contains *: these are all
-# elaborated and listed out
-
-
-def qpath_get(dic: dict, query_path: str) -> List[Tuple[str, Any]]:
-    if not validate_qpath(query_path):
-        raise ValueError(f"Received an invalid qpath: {query_path}")
-    if query_path.startswith("/"):
-        query_path = query_path[1:]
-    frontier = [("", dic)]
-    qp = query_path
-    while len(qp) > 0:
-        comp, qp = consume_component(qp)
-        frontier = advance_frontier(frontier, comp)
-
-    # now sort frontier by lexicographical order of its paths
-    frontier.sort(key=lambda front: front[0])
-    return frontier
-
-
-# def dpath_get(dic, query_path):
-#     return [v for _, v in dpath.search(dic, query_path, yielded=True)]
-
-
-def dpath_set_one(dic, query_path, value):
-    qpath_set(dic=dic, qpath=query_path, value=value)
-    # n = dpath.set(dic, query_path, value)
-    # if n != 1:
-    #     raise ValueError(f'query "{query_path}" matched multiple items in dict: {dic}')
-
-
-# qpath is fully specified, no *-s.
-def get_parent(
-    dic: dict, qpath: str
-) -> Tuple[
-    str, str, Any
-]:  # child_name, path to parent, element (list or dict) being the parent
-    if not validate_qpath(qpath) or "*" in qpath:
-        raise ValueError(
-            f"Received an invalid qpath, or a path that contains *, '{qpath}', and hence might specify more than one child. Parent can not be determined."
+def qpath_delete(
+    current_element: dict,
+    query: List[str],
+    index_into_query: int,
+    remove_empty_ancestors=False,
+):
+    component = query[index_into_query]
+    if index_into_query == -1:
+        if component == "*":
+            current_element = []
+        elif indx.match(component) and int(component) < len(current_element):
+            current_element.pop(int(component))
+        elif name.match(component) and component in current_element:
+            current_element.pop(component)
+        return (
+            None
+            if remove_empty_ancestors and len(current_element) == 0
+            else current_element
         )
-    if qpath.startswith("/"):
-        qpath = qpath[1:]
-    if "/" not in qpath:
-        return (qpath, "", dic)
-    parent_path = qpath[: qpath.rfind("/")]
-    child_name = qpath[1 + qpath.rfind("/") :]
-    parents = qpath_get(dic, parent_path)
-    if len(parents) != 1:
-        raise ValueError(f"More than one parent found to {qpath}. Check this error")
-    return (child_name, parents[0][0], parents[0][1])
+
+    # index_into_query < -1
+    if component == "*":
+        current_element = [
+            qpath_delete(
+                current_element=sub_element,
+                query=query,
+                index_into_query=index_into_query + 1,
+                remove_empty_ancestors=remove_empty_ancestors,
+            )
+            for sub_element in current_element
+        ]
+        current_element = [elem for elem in current_element if elem is not None]
+    elif indx.match(component) and int(component) < len(current_element):
+        current_element[int(component)] = qpath_delete(
+            current_element=current_element[int(component)],
+            query=query,
+            index_into_query=index_into_query + 1,
+            remove_empty_ancestors=remove_empty_ancestors,
+        )
+        if current_element[int(component)] is None:
+            current_element.pop(int(component))
+    elif name.match(component) and component in current_element:
+        current_element[component] = qpath_delete(
+            current_element=current_element[component],
+            query=query,
+            index_into_query=index_into_query + 1,
+            remove_empty_ancestors=remove_empty_ancestors,
+        )
+        if current_element[component] is None:
+            current_element.pop(component)
+    return (
+        None
+        if remove_empty_ancestors and len(current_element) == 0
+        else current_element
+    )
 
 
-def dict_delete(dic: dict, qpath: str):
+def dict_delete(dic: dict, qpath: str, remove_empty_ancestors=False):
     # we remove from dic all the elements lead to by the path.
-    # If the removal of any such element leaves its parent (list or dict) within dic empty -- remove that parent as well.
-
+    # If remove_empty_ancestors=True, and the removal of any such element leaves its parent (list or dict)
+    # within dic empty -- remove that parent as well, and continue recursively
+    qpath = validate_qpath(qpath)
     if "/" not in qpath:
         if qpath not in dic:
             raise ValueError(
-                f"And attempt to delete from dictionary {dic}, an element {qpath}, that does not exist in the dictionary"
+                f"An attempt to delete from dictionary {dic}, an element {qpath}, that does not exist in the dictionary"
             )
         dic.pop(qpath)
         return
-    to_deletes = qpath_get(dic, qpath)
-    for to_delete in to_deletes:
-        dict_delete_one_element(dic, to_delete[0])
+    dic = qpath_delete(
+        current_element=dic,
+        query=qpath.split("/"),
+        index_into_query=(-1) * len(qpath.split("/")),
+        remove_empty_ancestors=remove_empty_ancestors,
+    )
 
 
-# here qpath does not contain any *. it leads to only one element in dic, potentially, a list element.
-# If the removal of the element element leaves its parent (list or dict) within dic empty -- remove that parent as well.
-#
-def dict_delete_one_element(dic: dict, qpath: str):
-    if not validate_qpath(qpath) or "*" in qpath:
-        raise ValueError(
-            "invalid query, or a query that might lead to more than one element"
-        )
-    if qpath.startswith("/"):
-        qpath = qpath[1:]
-    checking = qpath_get(dic, qpath)
-    if len(checking) != 1:
-        raise ValueError(
-            f"qpath '{qpath}' does not specify a single path in dictionary '{dic}'. It specifies {len(checking)} paths."
-        )
-    qp = qpath
-    while True:
-        child_name, path_to_parent, parent = get_parent(dic, qp)
-        if bool(name.match(child_name)):
-            parent.pop(child_name)
-        else:  # parent is a list, and child name is an index:
-            i = int(child_name[1:-1])
-            if not isinstance(parent, list) or i >= len(parent):
-                raise ValueError(
-                    f"An attempt to remove the {i}-th element from a shorter list {parent}"
-                )
-            parent.pop(i)
-        if parent or len(path_to_parent) == 0:
-            break
-        # need to delete parent too
-        qp = path_to_parent
-
-
-# def dict_creator(current, segments, i, hints=()):
-#     """Create missing path components. If the segment is an int, then it will create a list. Otherwise a dictionary is created.
-#
-#     set(obj, segments, value) -> obj
-#     """
-#     segment = segments[i]
-#     length = len(segments)
-#
-#     if isinstance(current, Sequence):
-#         segment = int(segment)
-#
-#     if isinstance(current, MutableSequence):
-#         extend(current, segment)
-#
-#     # Infer the type from the hints provided.
-#     if i < len(hints):
-#         current[segment] = hints[i][1]()
-#     else:
-#         # Peek at the next segment to determine if we should be
-#         # creating an array for it to access or dictionary.
-#         if i + 1 < length:
-#             segment_next = segments[i + 1]
-#         else:
-#             segment_next = None
-#
-#         if isinstance(segment_next, int) or (
-#             isinstance(segment_next, str) and segment_next.isdecimal()
-#         ):
-#             current[segment] = []
-#         else:
-#             current[segment] = {}
-
-
-def build_bottom_up(components: List[str], value: Any) -> Any:
-    pointer = value
-    for i in range(len(components) - 1, -1, -1):
-        component = components[i]
-        if bool(name.match(component)):
-            pointer = {component: pointer}
-        else:  # an index,  * is not allowed here
-            j = int(component[1:-1])
-            if j > 0:
-                raise ValueError(
-                    "trying to generate a new list node, with a given element to be assigned, but the position given to it is not 0."
-                )
-            pointer = [pointer]
-    return pointer
-
-
-# sets a single values (that each by itself could be a list or dict) into dic,
-# at the position lead to by qpath.
-# qpath should lead to a single position (or multiple, if the last one
-# if these positions are not yet born, and not_exist_ok == True: these positions are enerated inside dic
 # flake8: noqa: C901
-def qpath_set(dic: dict, qpath: str, value: Any, not_exist_ok: bool = True):
-    if not validate_qpath(qpath) or "*" in qpath:
-        raise ValueError(
-            f"Invalid query, {qpath}, or a query that might lead to more than one position in dic"
-        )
-    if qpath.startswith("/"):
-        qpath = qpath[1:]
-    components = qpath.split("/")
-    components = [component.strip() for component in components]
-    pointer = dic
-    for i, component in enumerate(components):
-        if bool(name.match(component)):
-            if not isinstance(pointer, dict):
-                raise ValueError(
-                    f"path {qpath} leads down into {component}, but from a position that is not a dictionary"
-                )
-            if component in pointer:
-                if i == len(components) - 1:
-                    pointer[component] = value
-                    return
-                pointer = pointer[component]
-            else:
-                if not_exist_ok:
-                    pointer[component] = build_bottom_up(components[i + 1 :], value)
-                    return
-                raise ValueError(
-                    f"not_exist_ok == False, but can not get down to component {component}, in dic: {dic}, along qpath {qpath}"
-                )
-        else:  # an index, * is not allowed here
-            if not isinstance(pointer, list):
-                raise ValueError(
-                    f"path {qpath} leads down into position {component}, but from a position that is not a list"
-                )
-            j = int(component[1:-1])
-            if j < len(pointer):
-                if i == len(components) - 1:
-                    pointer[j] = value
-                    return
-                pointer = pointer[j]
-            else:
-                if not_exist_ok and j == len(pointer):
-                    pointer.append(build_bottom_up(components[i + 1 :], value))
-                    return
-                raise ValueError(
-                    f"not_exist_ok == False, but can not get down to index {component}, in dic: {dic}, along qpath {qpath}"
-                )
-
-
-# def dpath_set(dic, query_path, value, not_exist_ok=True):
-#     paths = [p for p, _ in dpath.search(dic, query_path, yielded=True)]
-#     if len(paths) == 0 and not_exist_ok:
-#         dpath.new(dic, query_path, value, creator=dict_creator)
-#     else:
-#         if len(paths) != 1:
-#             raise ValueError(
-#                 f'query "{query_path}" matched {len(paths)} items in dict: {dic}. should match only one.'
-#             )
-#         for path in paths:
-#             dpath_set_one(dic, path, value)
-#
-#
-# def qpath_set_multiple(dic, query_path, values, not_exist_ok=True):
-#     pass
-
-
-def dpath_set_multiple(dic, query_path, values, not_exist_ok=True):
-    # paths = [p for p, _ in dpath.search(dic, query_path, yielded=True)]
-    paths = qpath_get(dic, query_path)
-    if len(paths) == 0:
-        if not_exist_ok:
+def get_values(
+    current_element: Any, query: List[str], index_into_query: int
+) -> List[Any]:
+    # going down from current_element through query[index_into_query].
+    if index_into_query == 0:
+        return [current_element]
+    component = query[index_into_query]
+    # index_into_query < 0
+    if component == "*":  # current_element must be a list or a dictionary
+        if not isinstance(current_element, (list, dict)):
             raise ValueError(
-                f"Cannot set multiple values to non-existing path: {query_path}"
+                f"* in query {query}, when evaluated over the input dictionary, does not correspond to a dict nor a list"
             )
-        raise ValueError(f'query "{query_path}" did not match any item in dict: {dic}')
-
-    if len(paths) != len(values):
-        raise ValueError(
-            f'query "{query_path}" matched {len(paths)} items in dict: {dic} but {len(values)} values are provided. should match only one.'
+        to_ret = []
+        for sub_element in current_element:
+            if isinstance(current_element, dict):
+                to_ret.extend(
+                    get_values(
+                        current_element[sub_element], query, index_into_query + 1
+                    )
+                )
+            else:
+                to_ret.extend(get_values(sub_element, query, index_into_query + 1))
+        return to_ret
+    # next_component is indx or name
+    if indx.match(component):
+        component = int(component)
+        return (
+            []
+            if component >= len(current_element)
+            else get_values(current_element[component], query, index_into_query + 1)
         )
-    paths = [path[0] for path in paths]  # from list of frontiers to a list of paths
-    for path, value in zip(paths, values):
-        dpath_set_one(dic, path, value)
+    # next_component is a name
+    return (
+        []
+        if (component not in current_element)
+        else get_values(current_element[component], query, index_into_query + 1)
+    )
+
+
+# going down from current_element via query[index_into_query]
+# returns the updated current_element
+def qpath_set_values(
+    current_element: Any,
+    value: Any,
+    index_into_query: int,
+    fixed_parameters: dict,
+    set_individual_already_used: bool = False,
+):
+    assert (
+        current_element or fixed_parameters["generate_if_not_exists"]
+    ), "Current_element == None, and yet not generate_if_not_exists. Check who sent us here"
+    component = fixed_parameters["query"][index_into_query]
+    if component == "*":
+        # it is not a trailing * of the original query, that one, if there was any, was removed on starting of processing
+        if set_individual_already_used:
+            # set_individual_already_used indicates that generate_if_not_exists == True and current_element == None
+            assert (
+                not current_element and fixed_parameters["generate_if_not_exists"]
+            ), "Should not happen. Dafna to check"
+            raise ValueError(
+                "Can not respect * more than once along the path for generation of new list of length determined by the length of the input value"
+            )
+        if not current_element and not fixed_parameters["set_individual"]:
+            raise ValueError(
+                "Can not tell the length of the list to generate for a * that does not end the input query, when set_multiple == False"
+            )
+
+    if component == "*":
+        if current_element:
+            if fixed_parameters["set_individual"] and len(current_element) != len(
+                value
+            ):
+                raise ValueError(
+                    "set_multiple == True, while an existing element matching a * has a different len than values. dic: {dic}, query: {query}, value: {value}"
+                )
+            for i in range(len(current_element)):
+                current_element[i] = (
+                    value
+                    if index_into_query == -1
+                    else qpath_set_values(
+                        current_element=current_element[i],
+                        value=value[i] if fixed_parameters["set_individual"] else value,
+                        index_into_query=index_into_query + 1,
+                        fixed_parameters=fixed_parameters,
+                        set_individual_already_used=set_individual_already_used,
+                    )
+                )
+            return current_element
+        a_list = [None] * len(value)
+        # not current_element, and we are now using set_individual:
+        for i in range(len(a_list)):
+            a_list[i] = (
+                (value if not fixed_parameters["set_individual"] else value[i])
+                if index_into_query == -1
+                else qpath_set_values(
+                    current_element=None,
+                    value=value[i],
+                    index_into_query=index_into_query + 1,
+                    fixed_parameters=fixed_parameters,
+                    set_individual_already_used=True,
+                )
+            )
+        return a_list
+    if indx.match(component):
+        component = int(component)
+        if current_element and component < len(current_element):
+            current_element[component] = (
+                value
+                if index_into_query == -1
+                else qpath_set_values(
+                    current_element=current_element[component]
+                    if isinstance(current_element[component], (dict, list))
+                    else None,
+                    value=value,
+                    index_into_query=index_into_query + 1,
+                    fixed_parameters=fixed_parameters,
+                    set_individual_already_used=set_individual_already_used,
+                )
+            )
+            return current_element
+        if not fixed_parameters["generate_if_not_exists"]:
+            raise ValueError(
+                "Trying to set a value into dic {dic} via a query {query} that matches no path, while not_exist_ok=False"
+            )
+        a_list = [None] * (
+            (1 + component)
+            if not current_element
+            else (1 + component - len(current_element))
+        )
+        a_list[component - (0 if not current_element else len(current_element))] = (
+            value
+            if index_into_query == -1
+            else qpath_set_values(
+                current_element=None,
+                value=value,
+                index_into_query=index_into_query + 1,
+                fixed_parameters=fixed_parameters,
+                set_individual_already_used=set_individual_already_used,
+            )
+        )
+
+        if not current_element:
+            return a_list  # the updated value of current_element:
+        current_element.extend(a_list)
+        return current_element
+
+    # query[index_into_query] must be a name
+    if (
+        not current_element or component not in current_element
+    ) and not fixed_parameters["generate_if_not_exists"]:
+        raise ValueError(
+            "Trying to set a value into dic {dic} via a query {query} that matches no path, while not_exist_ok=False"
+        )
+
+    a_dict = current_element if current_element else {}
+    a_dict[component] = (
+        value
+        if index_into_query == -1
+        else qpath_set_values(
+            current_element=a_dict[component]
+            if component in a_dict and isinstance(a_dict[component], (dict, list))
+            else None,
+            value=value,
+            index_into_query=index_into_query + 1,
+            fixed_parameters=fixed_parameters,
+            set_individual_already_used=set_individual_already_used,
+        )
+    )
+    return a_dict
 
 
 # the returned values are ordered by the lexicographic order of the paths leading to them
-def dict_get(dic, query, use_dpath=True, not_exist_ok=False, default=None):
-    if use_dpath:
-        values = qpath_get(dic, query)  # a list of tuples (path to value, value)
-        if len(values) == 0 and not_exist_ok:
-            return default
+def dict_get(
+    dic: dict,
+    query: str,
+    use_dpath: bool = True,
+    not_exist_ok: bool = False,
+    default: Any = None,
+):
+    query = validate_qpath(query)  # validate and normalize
+    if use_dpath and "/" in query:
+        values = qpath_get(
+            dic, query
+        )  # list of values, whose length == number of paths that match the query
         if len(values) == 0:
+            if not_exist_ok:
+                return default
             raise ValueError(f'query "{query}" did not match any item in dict: {dic}')
 
-        to_ret = [v[1] for v in values]
-        if len(to_ret) == 1:
-            return to_ret[0]
-        return to_ret
-
-    if not_exist_ok:
-        return dic.get(query, default)
+        if len(values) == 1:
+            return values[0]
+        return values
 
     if query in dic:
         return dic[query]
 
+    if not_exist_ok:
+        return default
+
     raise ValueError(f'query "{query}" did not match any item in dict: {dic}')
 
 
-def dict_set(dic, query, value, use_dpath=True, not_exist_ok=True, set_multiple=False):
-    if use_dpath:
-        if set_multiple:
-            dpath_set_multiple(dic, query, value, not_exist_ok=not_exist_ok)
-        else:
-            qpath_set(dic, query, value, not_exist_ok=not_exist_ok)
+# dict_set sets value, which by itself, can be a dict or list or scalar, into dic, in the element specified by query.
+# if not_exist_ok = True, and such a path does not exist in dic, this function also builds that path inside dic, and then
+# assigns the value.
+# if two or more (existing in input dic, or newly generated per not_exist_ok = True) paths in dic match the query
+# all these paths are assigned copies of value.
+# if set_multiple=True, value must be a list, and there should be exactly len(values) paths matching of query,
+# and in this case, function assigns one member of list value to each path.
+# the matching paths are sorted alphabetically toward the above assignment
+def dict_set(
+    dic: dict,
+    query: str,
+    value: Any,
+    use_dpath=True,
+    not_exist_ok=True,
+    set_multiple=False,
+):
+    if set_multiple and (not isinstance(value, list)):
+        raise ValueError(f"set_multiple == True, but value, {value}, is not a list")
+    if use_dpath and "/" in query:
+        query = validate_qpath(query)
+        components = query.split("/")
+        fixed_parameters = {
+            "query": components,
+            "generate_if_not_exists": not_exist_ok,
+            "set_individual": set_multiple,
+        }
+        try:
+            dic = qpath_set_values(
+                current_element=dic,
+                value=value,
+                index_into_query=(-1) * len(components),
+                fixed_parameters=fixed_parameters,
+                set_individual_already_used=False,
+            )
+        except ValueError as ve:
+            raise ValueError(str(ve).format(query=query, dic=dic, value=value)) from ve
     else:
+        if query not in dic and not not_exist_ok:
+            raise ValueError(
+                f"not_exist_ok=False and query {query} matches no path in dic {dic}, still was trying to set a value into dic by the query"
+            )
         dic[query] = value

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -334,8 +334,8 @@ def dict_get(
 
         return values
 
-    if query in dic:
-        return dic[query]
+    if qpath in dic:
+        return dic[qpath]
 
     if not_exist_ok:
         return default

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -152,7 +152,8 @@ def get_values(
         return current_element
     component = query[index_into_query]
     # index_into_query < 0
-    if component == "*":  # current_element must be a list or a dictionary
+    if component == "*":
+        # current_element must be a list or a dictionary, otherwise, an exception will be thrown, and cuaght outside
         if not isinstance(current_element, (list, dict)):
             raise ValueError(
                 f"* in query {query}, when evaluated over the input dictionary, does not correspond to a dict nor a list"

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -378,8 +378,8 @@ def dict_set(
     if set_multiple and (not isinstance(value, list)):
         raise ValueError(f"set_multiple == True, but value, {value}, is not a list")
     if use_dpath and "/" in query:
-        query = validate_qpath(query)
-        components = query.split("/")
+        qpath = validate_qpath(query)
+        components = qpath.split("/")
         fixed_parameters = {
             "query": components,
             "generate_if_not_exists": not_exist_ok,

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -364,14 +364,6 @@ def dict_get(
 ):
     if use_dpath and "/" in query:
         components = validate_query_and_break_to_components(query)
-        if len(components) == 1:
-            if components[0] in dic:
-                return dic[components[0]]
-            if not_exist_ok:
-                return default
-            raise ValueError(
-                f'query "{query}" did not match any item in dict: {dic}, and not_exist_ok==False'
-            )
         try:
             success, values = get_values(dic, components, -1 * len(components))
             if not success:

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -1,86 +1,339 @@
-import os
-from typing import Sequence
+import re
+from typing import Any, List, Tuple
 
-import dpath
-from dpath import MutableSequence
-from dpath.segments import extend
+# import dpath
+# from dpath import MutableSequence
+# from dpath.segments import extend
+
+indx = re.compile(r"^\[?(\d+)\]?$")
+name = re.compile(r"^(\w+)$")
+
+# formal definition of qpath syntax:
+# qpath -> A (/A)*
+# A -> name | * | [?non-neg-int]?
+# name -> alphanumeric
+
+
+def validate_qpath(qpath: str) -> bool:
+    qpath = qpath.replace(" ", "")
+    if qpath.endswith("/") or "//" in qpath or qpath.startswith("["):
+        raise ValueError(
+            f"qpath should not contain // nor start with [, nor end with /. Got {qpath}"
+        )
+    if qpath.startswith("/"):
+        qpath = qpath[1:]
+    components = qpath.split("/")
+    components = [component.strip() for component in components]
+    for component in components:
+        if not (
+            bool(name.match(component))
+            or component == "*"
+            or bool(indx.match(component))
+        ):
+            return False
+    return True
 
 
 def is_subpath(subpath, fullpath):
-    # Normalize the paths to handle different formats and separators
-    subpath = os.path.normpath(subpath)
-    fullpath = os.path.normpath(fullpath)
-
     # Split the paths into individual components
-    subpath_components = subpath.split(os.path.sep)
-    fullpath_components = fullpath.split(os.path.sep)
+    subpath_components = subpath.split("/")
+    fullpath_components = fullpath.split("/")
+    subpath_components = [component.strip() for component in subpath_components]
+    fullpath_components = [component.strip() for component in fullpath_components]
 
     # Check if the full path starts with the subpath
     return fullpath_components[: len(subpath_components)] == subpath_components
 
 
-def dpath_get(dic, query_path):
-    return [v for _, v in dpath.search(dic, query_path, yielded=True)]
+def consume_component(qpath: str) -> Tuple[str, str]:
+    assert (
+        len(qpath.strip()) > 0
+    ), "should not try to consume a component from an empty qpath"
+    if "/" in qpath:
+        component = qpath[: qpath.find("/")]
+        qpath = qpath[1 + qpath.find("/") :]
+        return (component.strip(), qpath.strip())
+    return (qpath.strip(), "")  # nothing left
+
+
+# frontier is a list of pairs. Each pair consists of a string path (that is a subpath of qpath),
+# and a value that is the resident of dic at the position lead to by the string path.
+# flake8: noqa: C901
+
+
+def verify_for_list(obj: Any, comp: str) -> int:
+    if not isinstance(obj, list):
+        raise ValueError(f"qpath specifies an index {comp} for {obj!s}")
+    i = int(re.match(indx, comp).group(1))
+    if i >= len(obj):
+        raise ValueError(f"qpath specifies an index {comp} for a shorter list: {obj!s}")
+    return i
+
+
+def advance_frontier(
+    frontier: List[Tuple[str, Any]], comp: str
+) -> List[Tuple[str, Any]]:
+    new_frontier = []
+    for f in frontier:
+        if re.match(indx, comp):
+            i = verify_for_list(f[1], comp)
+            # if not isinstance(f[1], list):
+            #     raise ValueError(f"qpath specifies an index {comp} for {f[1]!s}")
+            # i = int(re.match(indx, comp).group(1))
+            # if i >= len(f[1]):
+            #     raise ValueError(
+            #         f"qpath specifies an index {comp} for a shorter list: {f[1]!s}"
+            #     )
+            new_frontier.append((f[0] + f"/[{i}]", f[1][i]))
+            continue
+        if bool(name.match(comp)) and comp in f[1]:
+            new_frontier.append(
+                (f[0] + ("/" if len(f[0]) > 0 else "") + comp, f[1][comp])
+            )
+            continue
+        if comp == "*":
+            if not isinstance(f[1], (list, dict)):
+                raise ValueError(f"qpath specifies * for {f[1]!s}")
+            if isinstance(f[1], dict):
+                for key in f[1]:
+                    new_frontier.append(
+                        (f[0] + ("/" if len(f[0]) > 0 else "") + key, f[1][key])
+                    )
+                continue
+            # f[1] is a list
+            for i in range(len(f[1])):
+                new_frontier.append((f[0] + f"/[{i}]", f[1][i]))
+            continue
+        return []  # no path found
+    return new_frontier
+
+
+# return all the values sitting inside dic, in all the paths that match qpath,
+# paths being sorted lexicographically
+# return them as pairs of: (path, value). None of the paths contains *: these are all
+# elaborated and listed out
+
+
+def qpath_get(dic: dict, query_path: str) -> List[Tuple[str, Any]]:
+    if not validate_qpath(query_path):
+        raise ValueError(f"Received an invalid qpath: {query_path}")
+    if query_path.startswith("/"):
+        query_path = query_path[1:]
+    frontier = [("", dic)]
+    qp = query_path
+    while len(qp) > 0:
+        comp, qp = consume_component(qp)
+        frontier = advance_frontier(frontier, comp)
+
+    # now sort frontier by lexicographical order of its paths
+    frontier.sort(key=lambda front: front[0])
+    return frontier
+
+
+# def dpath_get(dic, query_path):
+#     return [v for _, v in dpath.search(dic, query_path, yielded=True)]
 
 
 def dpath_set_one(dic, query_path, value):
-    n = dpath.set(dic, query_path, value)
-    if n != 1:
-        raise ValueError(f'query "{query_path}" matched multiple items in dict: {dic}')
+    qpath_set(dic=dic, qpath=query_path, value=value)
+    # n = dpath.set(dic, query_path, value)
+    # if n != 1:
+    #     raise ValueError(f'query "{query_path}" matched multiple items in dict: {dic}')
 
 
-def dict_delete(dic, query_path):
-    dpath.delete(dic, query_path)
+# qpath is fully specified, no *-s.
+def get_parent(
+    dic: dict, qpath: str
+) -> Tuple[
+    str, str, Any
+]:  # child_name, path to parent, element (list or dict) being the parent
+    if not validate_qpath(qpath) or "*" in qpath:
+        raise ValueError(
+            f"Received an invalid qpath, or a path that contains *, '{qpath}', and hence might specify more than one child. Parent can not be determined."
+        )
+    if qpath.startswith("/"):
+        qpath = qpath[1:]
+    if "/" not in qpath:
+        return (qpath, "", dic)
+    parent_path = qpath[: qpath.rfind("/")]
+    child_name = qpath[1 + qpath.rfind("/") :]
+    parents = qpath_get(dic, parent_path)
+    if len(parents) != 1:
+        raise ValueError(f"More than one parent found to {qpath}. Check this error")
+    return (child_name, parents[0][0], parents[0][1])
 
 
-def dict_creator(current, segments, i, hints=()):
-    """Create missing path components. If the segment is an int, then it will create a list. Otherwise a dictionary is created.
+def dict_delete(dic: dict, qpath: str):
+    # we remove from dic all the elements lead to by the path.
+    # If the removal of any such element leaves its parent (list or dict) within dic empty -- remove that parent as well.
 
-    set(obj, segments, value) -> obj
-    """
-    segment = segments[i]
-    length = len(segments)
-
-    if isinstance(current, Sequence):
-        segment = int(segment)
-
-    if isinstance(current, MutableSequence):
-        extend(current, segment)
-
-    # Infer the type from the hints provided.
-    if i < len(hints):
-        current[segment] = hints[i][1]()
-    else:
-        # Peek at the next segment to determine if we should be
-        # creating an array for it to access or dictionary.
-        if i + 1 < length:
-            segment_next = segments[i + 1]
-        else:
-            segment_next = None
-
-        if isinstance(segment_next, int) or (
-            isinstance(segment_next, str) and segment_next.isdecimal()
-        ):
-            current[segment] = []
-        else:
-            current[segment] = {}
-
-
-def dpath_set(dic, query_path, value, not_exist_ok=True):
-    paths = [p for p, _ in dpath.search(dic, query_path, yielded=True)]
-    if len(paths) == 0 and not_exist_ok:
-        dpath.new(dic, query_path, value, creator=dict_creator)
-    else:
-        if len(paths) != 1:
+    if "/" not in qpath:
+        if qpath not in dic:
             raise ValueError(
-                f'query "{query_path}" matched {len(paths)} items in dict: {dic}. should match only one.'
+                f"And attempt to delete from dictionary {dic}, an element {qpath}, that does not exist in the dictionary"
             )
-        for path in paths:
-            dpath_set_one(dic, path, value)
+        dic.pop(qpath)
+        return
+    to_deletes = qpath_get(dic, qpath)
+    for to_delete in to_deletes:
+        dict_delete_one_element(dic, to_delete[0])
+
+
+# here qpath does not contain any *. it leads to only one element in dic, potentially, a list element.
+# If the removal of the element element leaves its parent (list or dict) within dic empty -- remove that parent as well.
+#
+def dict_delete_one_element(dic: dict, qpath: str):
+    if not validate_qpath(qpath) or "*" in qpath:
+        raise ValueError(
+            "invalid query, or a query that might lead to more than one element"
+        )
+    if qpath.startswith("/"):
+        qpath = qpath[1:]
+    checking = qpath_get(dic, qpath)
+    if len(checking) != 1:
+        raise ValueError(
+            f"qpath '{qpath}' does not specify a single path in dictionary '{dic}'. It specifies {len(checking)} paths."
+        )
+    qp = qpath
+    while True:
+        child_name, path_to_parent, parent = get_parent(dic, qp)
+        if bool(name.match(child_name)):
+            parent.pop(child_name)
+        else:  # parent is a list, and child name is an index:
+            i = int(child_name[1:-1])
+            if not isinstance(parent, list) or i >= len(parent):
+                raise ValueError(
+                    f"An attempt to remove the {i}-th element from a shorter list {parent}"
+                )
+            parent.pop(i)
+        if parent or len(path_to_parent) == 0:
+            break
+        # need to delete parent too
+        qp = path_to_parent
+
+
+# def dict_creator(current, segments, i, hints=()):
+#     """Create missing path components. If the segment is an int, then it will create a list. Otherwise a dictionary is created.
+#
+#     set(obj, segments, value) -> obj
+#     """
+#     segment = segments[i]
+#     length = len(segments)
+#
+#     if isinstance(current, Sequence):
+#         segment = int(segment)
+#
+#     if isinstance(current, MutableSequence):
+#         extend(current, segment)
+#
+#     # Infer the type from the hints provided.
+#     if i < len(hints):
+#         current[segment] = hints[i][1]()
+#     else:
+#         # Peek at the next segment to determine if we should be
+#         # creating an array for it to access or dictionary.
+#         if i + 1 < length:
+#             segment_next = segments[i + 1]
+#         else:
+#             segment_next = None
+#
+#         if isinstance(segment_next, int) or (
+#             isinstance(segment_next, str) and segment_next.isdecimal()
+#         ):
+#             current[segment] = []
+#         else:
+#             current[segment] = {}
+
+
+def build_bottom_up(components: List[str], value: Any) -> Any:
+    pointer = value
+    for i in range(len(components) - 1, -1, -1):
+        component = components[i]
+        if bool(name.match(component)):
+            pointer = {component: pointer}
+        else:  # an index,  * is not allowed here
+            j = int(component[1:-1])
+            if j > 0:
+                raise ValueError(
+                    "trying to generate a new list node, with a given element to be assigned, but the position given to it is not 0."
+                )
+            pointer = [pointer]
+    return pointer
+
+
+# sets a single values (that each by itself could be a list or dict) into dic,
+# at the position lead to by qpath.
+# qpath should lead to a single position (or multiple, if the last one
+# if these positions are not yet born, and not_exist_ok == True: these positions are enerated inside dic
+# flake8: noqa: C901
+def qpath_set(dic: dict, qpath: str, value: Any, not_exist_ok: bool = True):
+    if not validate_qpath(qpath) or "*" in qpath:
+        raise ValueError(
+            f"Invalid query, {qpath}, or a query that might lead to more than one position in dic"
+        )
+    if qpath.startswith("/"):
+        qpath = qpath[1:]
+    components = qpath.split("/")
+    components = [component.strip() for component in components]
+    pointer = dic
+    for i, component in enumerate(components):
+        if bool(name.match(component)):
+            if not isinstance(pointer, dict):
+                raise ValueError(
+                    f"path {qpath} leads down into {component}, but from a position that is not a dictionary"
+                )
+            if component in pointer:
+                if i == len(components) - 1:
+                    pointer[component] = value
+                    return
+                pointer = pointer[component]
+            else:
+                if not_exist_ok:
+                    pointer[component] = build_bottom_up(components[i + 1 :], value)
+                    return
+                raise ValueError(
+                    f"not_exist_ok == False, but can not get down to component {component}, in dic: {dic}, along qpath {qpath}"
+                )
+        else:  # an index, * is not allowed here
+            if not isinstance(pointer, list):
+                raise ValueError(
+                    f"path {qpath} leads down into position {component}, but from a position that is not a list"
+                )
+            j = int(component[1:-1])
+            if j < len(pointer):
+                if i == len(components) - 1:
+                    pointer[j] = value
+                    return
+                pointer = pointer[j]
+            else:
+                if not_exist_ok and j == len(pointer):
+                    pointer.append(build_bottom_up(components[i + 1 :], value))
+                    return
+                raise ValueError(
+                    f"not_exist_ok == False, but can not get down to index {component}, in dic: {dic}, along qpath {qpath}"
+                )
+
+
+# def dpath_set(dic, query_path, value, not_exist_ok=True):
+#     paths = [p for p, _ in dpath.search(dic, query_path, yielded=True)]
+#     if len(paths) == 0 and not_exist_ok:
+#         dpath.new(dic, query_path, value, creator=dict_creator)
+#     else:
+#         if len(paths) != 1:
+#             raise ValueError(
+#                 f'query "{query_path}" matched {len(paths)} items in dict: {dic}. should match only one.'
+#             )
+#         for path in paths:
+#             dpath_set_one(dic, path, value)
+#
+#
+# def qpath_set_multiple(dic, query_path, values, not_exist_ok=True):
+#     pass
 
 
 def dpath_set_multiple(dic, query_path, values, not_exist_ok=True):
-    paths = [p for p, _ in dpath.search(dic, query_path, yielded=True)]
+    # paths = [p for p, _ in dpath.search(dic, query_path, yielded=True)]
+    paths = qpath_get(dic, query_path)
     if len(paths) == 0:
         if not_exist_ok:
             raise ValueError(
@@ -92,22 +345,24 @@ def dpath_set_multiple(dic, query_path, values, not_exist_ok=True):
         raise ValueError(
             f'query "{query_path}" matched {len(paths)} items in dict: {dic} but {len(values)} values are provided. should match only one.'
         )
+    paths = [path[0] for path in paths]  # from list of frontiers to a list of paths
     for path, value in zip(paths, values):
         dpath_set_one(dic, path, value)
 
 
+# the returned values are ordered by the lexicographic order of the paths leading to them
 def dict_get(dic, query, use_dpath=True, not_exist_ok=False, default=None):
     if use_dpath:
-        values = dpath_get(dic, query)
+        values = qpath_get(dic, query)  # a list of tuples (path to value, value)
         if len(values) == 0 and not_exist_ok:
             return default
         if len(values) == 0:
             raise ValueError(f'query "{query}" did not match any item in dict: {dic}')
 
-        if len(values) == 1 and "*" not in query and "," not in query:
-            return values[0]
-
-        return values
+        to_ret = [v[1] for v in values]
+        if len(to_ret) == 1:
+            return to_ret[0]
+        return to_ret
 
     if not_exist_ok:
         return dic.get(query, default)
@@ -123,6 +378,6 @@ def dict_set(dic, query, value, use_dpath=True, not_exist_ok=True, set_multiple=
         if set_multiple:
             dpath_set_multiple(dic, query, value, not_exist_ok=not_exist_ok)
         else:
-            dpath_set(dic, query, value, not_exist_ok=not_exist_ok)
+            qpath_set(dic, query, value, not_exist_ok=not_exist_ok)
     else:
         dic[query] = value

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -35,7 +35,6 @@ General Operaotrs List:
 import collections
 import copy
 import operator
-import os
 import uuid
 import zipfile
 from abc import abstractmethod
@@ -472,17 +471,17 @@ class RenameFields(FieldOperator):
                 not is_subpath(to_field, from_field)
             ):
                 dict_delete(res, from_field)
-                if self.use_query:
-                    from_field_components = list(
-                        os.path.normpath(from_field).split(os.path.sep)
-                    )
-                    while len(from_field_components) > 1:
-                        from_field_components.pop()
-                        parent = dict_get(res, os.path.sep.join(from_field_components))
-                        if isinstance(parent, dict) and not parent:
-                            dict_delete(res, os.path.sep.join(from_field_components))
-                        else:
-                            break
+                # if self.use_query:
+                #     from_field_components = list(
+                #         os.path.normpath(from_field).split(os.path.sep)
+                #     )
+                #     while len(from_field_components) > 1:
+                #         from_field_components.pop()
+                #         parent = dict_get(res, os.path.sep.join(from_field_components))
+                #         if isinstance(parent, dict) and not parent:
+                #             dict_delete(res, os.path.sep.join(from_field_components))
+                #         else:
+                #             break
 
         return res
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1683,62 +1683,38 @@ class Shuffle(PagedStreamOperator):
         yield from page
 
 
-class EncodeLabels(StreamInstanceOperator):
+class EncodeLabels(InstanceFieldOperator):
     """Encode each value encountered in any field in 'fields' into the integers 0,1,...
 
     Encoding is determined by a str->int map that is built on the go, as different values are
     first encountered in the stream, either as list members or as values in single-value fields.
 
-    Args:
-        fields (List[str]): The fields to encode together.
+    Args (of super class):
+
+        field_to_field: a list of pair of field names: (to encode from, to store result in)
+        process_every_value: boolean, should be set to True for fields whose values are lists
 
     Example: applying
-        EncodeLabels(fields = ["a", "b/*"])
+        EncodeLabels(field_to_field = ["a", "a"])
         on input stream = [{"a": "red", "b": ["red", "blue"], "c":"bread"},
         {"a": "blue", "b": ["green"], "c":"water"}]   will yield the
+        output stream = [{'a': 0, 'b': ["red", "blue"], 'c': 'bread'},
+        {'a': 1, 'b': ["green"], 'c': 'water'}]
+        feeding that output stream through
+        EncoderLabels(field_to_field = ["b", "b"], process_every_value=True)
+        will yield the output:
         output stream = [{'a': 0, 'b': [0, 1], 'c': 'bread'}, {'a': 1, 'b': [2], 'c': 'water'}]
 
-        Note: dpath is applied here, and hence, fields that are lists, should be included in
-        input 'fields' with the appendix "/*"  as in the above example.
-
     """
-
-    fields: List[str]
 
     def _process_multi_stream(self, multi_stream: MultiStream) -> MultiStream:
         self.encoder = {}
         return super()._process_multi_stream(multi_stream)
 
-    def encode_values(self, values) -> Any:
-        assert isoftype(values, List[str]) or isinstance(
-            values, str
-        ), "expected a string or a list of strings, received {values}"
-        old_values_was_a_list = isinstance(values, list)
-        if not isinstance(values, list):
-            values = [values]
-        for value in values:
-            if value not in self.encoder:
-                self.encoder[value] = len(self.encoder)
-        new_values = [self.encoder[value] for value in values]
-        if not old_values_was_a_list:
-            new_values = new_values[0]
-        return new_values
-
-    def process(
-        self, instance: Dict[str, Any], stream_name: Optional[str] = None
-    ) -> Dict[str, Any]:
-        for field_name in self.fields:
-            new_values = []
-            original_values = dict_get(instance, field_name, use_dpath=True)
-            if isoftype(original_values, List[List[str]]):  # as for classic references
-                for values in original_values:
-                    new_values.append(self.encode_values(values))
-            else:
-                new_values = self.encode_values(original_values)
-
-            dict_set(instance, field_name, new_values, use_dpath=True)
-
-        return instance
+    def process_instance_value(self, value: Any, instance: Dict[str, Any]) -> Any:
+        if value not in self.encoder:
+            self.encoder[value] = len(self.encoder)
+        return self.encoder[value]
 
 
 class StreamRefiner(SingleStreamOperator):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1696,12 +1696,14 @@ class EncodeLabels(InstanceFieldOperator):
 
     Example: applying
         EncodeLabels(field_to_field = ["a", "a"])
+        ( or: EncodeLabels(field="a") , in this simple case of single field that serves as source and target)
         on input stream = [{"a": "red", "b": ["red", "blue"], "c":"bread"},
         {"a": "blue", "b": ["green"], "c":"water"}]   will yield the
         output stream = [{'a': 0, 'b': ["red", "blue"], 'c': 'bread'},
         {'a': 1, 'b': ["green"], 'c': 'water'}]
         feeding that output stream through
         EncoderLabels(field_to_field = ["b", "b"], process_every_value=True)
+        ( or: EncodeLabels(field="b", process_every_value=True), in this simple case)
         will yield the output:
         output stream = [{'a': 0, 'b': [0, 1], 'c': 'bread'}, {'a': 1, 'b': [2], 'c': 'water'}]
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1710,20 +1710,22 @@ class EncodeLabels(StreamInstanceOperator):
     ) -> Dict[str, Any]:
         for field_name in self.fields:
             values = dict_get(instance, field_name, use_dpath=True)
-            assert isoftype(values, List[str]) or isinstance(
-                values, str
-            ), "expected a string or a list of strings, received {values}"
-            old_values_was_a_list = isinstance(values, list)
+            values_was_a_list = isinstance(values, list)
             if not isinstance(values, list):
                 values = [values]
             for value in values:
                 if value not in self.encoder:
                     self.encoder[value] = len(self.encoder)
             new_values = [self.encoder[value] for value in values]
-            if not old_values_was_a_list:
+            if not values_was_a_list:
                 new_values = new_values[0]
-
-            dict_set(instance, field_name, new_values, use_dpath=True)
+            dict_set(
+                instance,
+                field_name,
+                new_values,
+                use_dpath=True,
+                set_multiple="*" in field_name,
+            )
 
         return instance
 

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -68,8 +68,17 @@ class TestDictUtils(UnitxtTestCase):
         dic = {"references": ["r1", "r2", "r3"]}
         dict_delete(dic, "references", remove_empty_ancestors=True)
         self.assertEqual({}, dic)
+        dic = {"references": [{"r11": 1, "r12": 2}, "r2", "r3"]}
+        with self.assertRaises(ValueError):
+            dict_delete(dic, "refrefs/1", remove_empty_ancestors=True)
+        dict_delete(dic, "references/0/*", remove_empty_ancestors=False)
+        self.assertEqual({"references": [{}, "r2", "r3"]}, dic)
+        dict_delete(dic, "references/0/*", remove_empty_ancestors=True)
+        self.assertEqual({"references": ["r2", "r3"]}, dic)
         with self.assertRaises(ValueError):
             dict_delete(dic, "references+#/^!", remove_empty_ancestors=True)
+        with self.assertRaises(ValueError):
+            dict_delete(dic, "", remove_empty_ancestors=True)
 
         dic = {"a": [[["i1", "i2"], ["i3", "i4"]], [["i5", "i6"], ["i7", "i8"]]]}
         dict_delete(dic, "a/1/0/1")
@@ -146,6 +155,16 @@ class TestDictUtils(UnitxtTestCase):
         self.assertDictEqual(
             dic, {"a": [{"b": 1}, {"b": 5}], "c": [{"b": 3}, {"b": 6}]}
         )
+        with self.assertRaises(ValueError):
+            # lengths do not match for set_multiple
+            dict_set(
+                dic,
+                "*/1/b",
+                [5, 6, 7],
+                use_dpath=True,
+                set_multiple=True,
+                not_exist_ok=False,
+            )
 
         dic = {"a": {"b": []}}
         dict_set(dic, "a/b/2/c", [3, 4], use_dpath=True)

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -129,7 +129,6 @@ class TestDictUtils(UnitxtTestCase):
 
     def test_query_set_with_multiple_non_existing(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}
-        # with self.assertRaises(ValueError):
         dict_set(dic, "a/*/c", [3, 4], use_dpath=True, set_multiple=True)
         self.assertDictEqual({"a": [{"b": 1, "c": 3}, {"b": 2, "c": 4}]}, dic)
         dict_set(
@@ -141,6 +140,10 @@ class TestDictUtils(UnitxtTestCase):
             not_exist_ok=True,
         )
         self.assertEqual({"a": [{"b": 1, "c": [3, 4]}, {"b": 2, "c": [3, 4]}]}, dic)
+
+        dic = {"a": [{"b": 1}, {"b": 2}]}
+        with self.assertRaises(ValueError):
+            dict_set(dic, "a/*/d", [3, 4, 5], use_dpath=True, set_multiple=True)
 
     def test_adding_one_new_field(self):
         dic = {"a": {"b": {"c": 0}}}

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -59,11 +59,36 @@ class TestDictUtils(UnitxtTestCase):
         self.assertEqual({"references": []}, dic)
 
         dic = {"references": ["r1", "r2", "r3"]}
+        dict_delete(dic, "references/1")
+        self.assertEqual({"references": ["r1", "r3"]}, dic)
+
+        dic = {"references": ["r1", "r2", "r3"]}
         dict_delete(dic, "references", remove_empty_ancestors=True)
         self.assertEqual({}, dic)
-
         with self.assertRaises(ValueError):
             dict_delete(dic, "references+#/^!", remove_empty_ancestors=True)
+
+        dic = {"a": [[["i1", "i2"], ["i3", "i4"]], [["i5", "i6"], ["i7", "i8"]]]}
+        dict_delete(dic, "a/1/0/1")
+        self.assertEqual(
+            {"a": [[["i1", "i2"], ["i3", "i4"]], [["i5"], ["i7", "i8"]]]}, dic
+        )
+        dict_delete(dic, "a/1/0/0")
+        self.assertEqual({"a": [[["i1", "i2"], ["i3", "i4"]], [[], ["i7", "i8"]]]}, dic)
+        dict_delete(dic, "a/1/1")
+        self.assertEqual({"a": [[["i1", "i2"], ["i3", "i4"]], [[]]]}, dic)
+        dict_delete(dic, "a/1/0", remove_empty_ancestors=True)
+        self.assertEqual({"a": [[["i1", "i2"], ["i3", "i4"]]]}, dic)
+
+        with self.assertRaises(ValueError):
+            dict_delete(dic, "aaa")
+        with self.assertRaises(ValueError):
+            dict_delete(dic, "a/2/3")
+
+        self.assertEqual("i", dict_get(dic, "a/0/0/0/0", use_dpath=True))
+        self.assertEqual("i", dict_get(dic, "a/0/0/0/0/0/0/0", use_dpath=True))
+        with self.assertRaises(ValueError):
+            dict_get(dic, "a/0/0/0/*/0")
 
     def test_simple_set(self):
         dic = {"a": 1, "b": 2}
@@ -91,7 +116,12 @@ class TestDictUtils(UnitxtTestCase):
         dic = {"a": [{"b": 1}, {"b": 2}]}
         dict_set(dic, "a/*/b", [3, 4], use_dpath=True, set_multiple=True)
         self.assertDictEqual(dic, {"a": [{"b": 3}, {"b": 4}]})
-        dic = {"a": [{"b": 1}, {"b": 2}], "c": [{"b": 3}, {"b": 4}]}
+        with self.assertRaises(ValueError):
+            dict_set(dic, "a/0/b/c/*/d/*/e", [3, 4], use_dpath=True, set_multiple=True)
+        with self.assertRaises(ValueError):
+            dict_set(dic, "a/0/b/c/*/d", [3, 4], use_dpath=True, set_multiple=False)
+
+        # dic = {"a": [{"b": 1}, {"b": 2}], "c": [{"b": 3}, {"b": 4}]}
         # dict_set(dic, "*/1/b", [5, 6], use_dpath=True, set_multiple=True)
         # self.assertDictEqual(
         #     dic, {"a": [{"b": 1}, {"b": 5}], "c": [{"b": 3}, {"b": 6}]}

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -4,12 +4,15 @@ from tests.utils import UnitxtTestCase
 
 class TestDictUtils(UnitxtTestCase):
     def test_simple_get(self):
-        dic = {"a": 1, "b": 2}
+        dic = {"a": 1, "b": 2, "d": [3, 4]}
         self.assertEqual(dict_get(dic, "a"), 1)
         self.assertEqual(dict_get(dic, "b"), 2)
         self.assertEqual(dict_get(dic, "c", not_exist_ok=True), None)
         with self.assertRaises(ValueError):
             dict_get(dic, "c")
+        self.assertEqual(dict_get(dic, "d/1"), 4)
+        with self.assertRaises(ValueError):
+            dict_get(dic, "d/2")
 
     def test_nested_get(self):
         dic = {"a": {"b": 1, "c": 2}}
@@ -126,6 +129,14 @@ class TestDictUtils(UnitxtTestCase):
         # self.assertDictEqual(
         #     dic, {"a": [{"b": 1}, {"b": 5}], "c": [{"b": 3}, {"b": 6}]}
         # )
+
+        dic = {"a": {"b": []}}
+        dict_set(dic, "a/b/2/c", [3, 4], use_dpath=True)
+        self.assertDictEqual(dic, {"a": {"b": [None, None, {"c": [3, 4]}]}})
+
+        dic = {"a": {"b": []}}
+        with self.assertRaises(ValueError):
+            dict_set(dic, "a/b/2/c", [3, 4], use_dpath=True, not_exist_ok=False)
 
     def test_query_set_with_multiple_non_existing(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -24,6 +24,18 @@ class TestDictUtils(UnitxtTestCase):
         self.assertEqual(dict_get(dic, "a/*/b", use_dpath=True), [1, 2])
         dic = {"a": [{"b": 1}, {"b": 2}], "c": [{"b": 3}, {"b": 4}]}
         self.assertEqual(dict_get(dic, "*/1/b", use_dpath=True), [2, 4])
+        dic = {"references": ["r1", "r2", "r3"]}
+        self.assertEqual(
+            dict_get(dic, "references/*", use_dpath=True), ["r1", "r2", "r3"]
+        )
+        self.assertEqual(
+            dict_get(dic, "references/", use_dpath=True), ["r1", "r2", "r3"]
+        )
+        self.assertEqual(
+            dict_get(dic, "references", use_dpath=True), ["r1", "r2", "r3"]
+        )
+        with self.assertRaises(ValueError):
+            dict_get(dic, "references+#/^!", use_dpath=True)
 
     def test_simple_set(self):
         dic = {"a": 1, "b": 2}

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -52,24 +52,25 @@ class TestDictUtils(UnitxtTestCase):
         dict_set(dic, "a/*/b", [3, 4], use_dpath=True, set_multiple=True)
         self.assertDictEqual(dic, {"a": [{"b": 3}, {"b": 4}]})
         dic = {"a": [{"b": 1}, {"b": 2}], "c": [{"b": 3}, {"b": 4}]}
-        dict_set(dic, "*/1/b", [5, 6], use_dpath=True, set_multiple=True)
-        self.assertDictEqual(
-            dic, {"a": [{"b": 1}, {"b": 5}], "c": [{"b": 3}, {"b": 6}]}
-        )
+        # dict_set(dic, "*/1/b", [5, 6], use_dpath=True, set_multiple=True)
+        # self.assertDictEqual(
+        #     dic, {"a": [{"b": 1}, {"b": 5}], "c": [{"b": 3}, {"b": 6}]}
+        # )
 
     def test_query_set_with_multiple_non_existing(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}
-        with self.assertRaises(ValueError):
-            dict_set(dic, "a/*/c", [3, 4], use_dpath=True, set_multiple=True)
-        with self.assertRaises(ValueError):
-            dict_set(
-                dic,
-                "a/*/c",
-                [3, 4],
-                use_dpath=True,
-                set_multiple=False,
-                not_exist_ok=True,
-            )
+        # with self.assertRaises(ValueError):
+        dict_set(dic, "a/*/c", [3, 4], use_dpath=True, set_multiple=True)
+        self.assertDictEqual({"a": [{"b": 1, "c": 3}, {"b": 2, "c": 4}]}, dic)
+        dict_set(
+            dic,
+            "a/*/c",
+            [3, 4],
+            use_dpath=True,
+            set_multiple=False,
+            not_exist_ok=True,
+        )
+        self.assertEqual({"a": [{"b": 1, "c": [3, 4]}, {"b": 2, "c": [3, 4]}]}, dic)
 
     def test_adding_one_new_field(self):
         dic = {"a": {"b": {"c": 0}}}

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -1,4 +1,4 @@
-from src.unitxt.dict_utils import dict_get, dict_set
+from src.unitxt.dict_utils import dict_delete, dict_get, dict_set
 from tests.utils import UnitxtTestCase
 
 
@@ -36,6 +36,34 @@ class TestDictUtils(UnitxtTestCase):
         )
         with self.assertRaises(ValueError):
             dict_get(dic, "references+#/^!", use_dpath=True)
+
+    def test_query_delete(self):
+        dic = {"a": [{"b": 1}, {"b": 2, "c": 3}]}
+        dict_delete(dic, "a/*/b", remove_empty_ancestors=True)
+        self.assertEqual({"a": [{"c": 3}]}, dic)
+
+        dic = {"references": ["r1", "r2", "r3"]}
+        dict_delete(dic, "references/*")
+        self.assertEqual({"references": []}, dic)
+
+        dic = {"references": ["r1", "r2", "r3"]}
+        dict_delete(dic, "references/*", remove_empty_ancestors=True)
+        self.assertEqual({}, dic)
+
+        dic = {"references": ["r1", "r2", "r3"]}
+        dict_delete(dic, "references/*")
+        self.assertEqual({"references": []}, dic)
+
+        dic = {"references": ["r1", "r2", "r3"]}
+        dict_delete(dic, "references/")
+        self.assertEqual({"references": []}, dic)
+
+        dic = {"references": ["r1", "r2", "r3"]}
+        dict_delete(dic, "references", remove_empty_ancestors=True)
+        self.assertEqual({}, dic)
+
+        with self.assertRaises(ValueError):
+            dict_delete(dic, "references+#/^!", remove_empty_ancestors=True)
 
     def test_simple_set(self):
         dic = {"a": 1, "b": 2}

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -575,27 +575,27 @@ class TestOperators(UnitxtTestCase):
 
     def test_remove_none(self):
         inputs = [
-            {"references": [["none"]]},
-            {"references": [["news", "games"]]},
+            {"references": [["none"], ["none"]]},
+            {"references": [["news", "games"], ["none"]]},
         ]
 
         targets = [
-            {"references": [[]]},
-            {"references": [["news", "games"]]},
+            {"references": [[], ["none"]]},
+            {"references": [["news", "games"], ["none"]]},
         ]
 
-        with self.assertRaises(ValueError):
-            check_operator(
-                operator=RemoveValues(
-                    field="references/*",
-                    unallowed_values=["none"],
-                    process_every_value=False,
-                    use_query=True,
-                ),
-                inputs=inputs,
-                targets=targets,
-                tester=self,
-            )
+        # with self.assertRaises(ValueError):
+        #     check_operator(
+        #         operator=RemoveValues(
+        #             field="references",
+        #             unallowed_values=["none"],
+        #             process_every_value=True,
+        #             use_query=True,
+        #         ),
+        #         inputs=inputs,
+        #         targets=targets,
+        #         tester=self,
+        #     )
 
         check_operator(
             operator=RemoveValues(
@@ -606,6 +606,36 @@ class TestOperators(UnitxtTestCase):
             ),
             inputs=inputs,
             targets=targets,
+            tester=self,
+        )
+
+        check_operator(
+            operator=RemoveValues(
+                field="references/1",
+                unallowed_values=["none"],
+                process_every_value=False,
+                use_query=True,
+            ),
+            inputs=inputs,
+            targets=[
+                {"references": [["none"], []]},
+                {"references": [["news", "games"], []]},
+            ],
+            tester=self,
+        )
+
+        check_operator(
+            operator=RemoveValues(
+                field="references",
+                unallowed_values=["none"],
+                use_query=True,
+                process_every_value=True,
+            ),
+            inputs=inputs,
+            targets=[
+                {"references": [[], []]},
+                {"references": [["news", "games"], []]},
+            ],
             tester=self,
         )
 
@@ -639,19 +669,19 @@ class TestOperators(UnitxtTestCase):
             str(cm.exception), "The unallowed_values is not a list but '3'"
         )
 
-        with self.assertRaises(ValueError) as cm:
-            check_operator(
-                operator=RemoveValues(
-                    field="label", unallowed_values=["3"], process_every_value=True
-                ),
-                inputs=inputs,
-                targets=targets,
-                tester=self,
-            )
-        self.assertEqual(
-            str(cm.exception),
-            "'process_every_value=True' is not supported in RemoveValues operator",
-        )
+        # with self.assertRaises(ValueError) as cm:
+        #     check_operator(
+        #         operator=RemoveValues(
+        #             field="label", unallowed_values=["3"], process_every_value=True
+        #         ),
+        #         inputs=inputs,
+        #         targets=targets,
+        #         tester=self,
+        #     )
+        # self.assertEqual(
+        #     str(cm.exception),
+        #     "'process_every_value=True' is not supported in RemoveValues operator",
+        # )
 
         inputs = [
             {"label": "b"},
@@ -2037,7 +2067,7 @@ class TestOperators(UnitxtTestCase):
         ]
 
         check_operator(
-            operator=EncodeLabels(fields=["prediction", "references/*"]),
+            operator=EncodeLabels(fields=["prediction", "references"]),
             inputs=inputs,
             targets=targets,
             tester=self,

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -584,18 +584,20 @@ class TestOperators(UnitxtTestCase):
             {"references": [["news", "games"], ["none"]]},
         ]
 
-        # with self.assertRaises(ValueError):
-        #     check_operator(
-        #         operator=RemoveValues(
-        #             field="references",
-        #             unallowed_values=["none"],
-        #             process_every_value=True,
-        #             use_query=True,
-        #         ),
-        #         inputs=inputs,
-        #         targets=targets,
-        #         tester=self,
-        #     )
+        check_operator(
+            operator=RemoveValues(
+                field="references/*",
+                unallowed_values=["none"],
+                use_query=True,
+                process_every_value=True,
+            ),
+            inputs=inputs,
+            targets=[
+                {"references": [[], []]},
+                {"references": [["news", "games"], []]},
+            ],
+            tester=self,
+        )
 
         check_operator(
             operator=RemoveValues(
@@ -2066,13 +2068,9 @@ class TestOperators(UnitxtTestCase):
             {"prediction": 2, "references": [0]},
         ]
 
-        operator_pred = EncodeLabels(field="prediction")
-        inputs1 = list(
-            operator_pred(MultiStream.from_iterables({"tmp": inputs}))["tmp"]
-        )
         check_operator(
-            operator=EncodeLabels(field="references", process_every_value=True),
-            inputs=inputs1,
+            operator=EncodeLabels(fields=["prediction", "references/*"]),
+            inputs=inputs,
             targets=targets,
             tester=self,
         )

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -2066,9 +2066,13 @@ class TestOperators(UnitxtTestCase):
             {"prediction": 2, "references": [0]},
         ]
 
+        operator_pred = EncodeLabels(field="prediction")
+        inputs1 = list(
+            operator_pred(MultiStream.from_iterables({"tmp": inputs}))["tmp"]
+        )
         check_operator(
-            operator=EncodeLabels(fields=["prediction", "references"]),
-            inputs=inputs,
+            operator=EncodeLabels(field="references", process_every_value=True),
+            inputs=inputs1,
             targets=targets,
             tester=self,
         )

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -586,21 +586,6 @@ class TestOperators(UnitxtTestCase):
 
         check_operator(
             operator=RemoveValues(
-                field="references/*",
-                unallowed_values=["none"],
-                use_query=True,
-                process_every_value=True,
-            ),
-            inputs=inputs,
-            targets=[
-                {"references": [[], []]},
-                {"references": [["news", "games"], []]},
-            ],
-            tester=self,
-        )
-
-        check_operator(
-            operator=RemoveValues(
                 field="references/0",
                 unallowed_values=["none"],
                 process_every_value=False,
@@ -696,7 +681,7 @@ class TestOperators(UnitxtTestCase):
             tester=self,
         )
 
-        exception_text = "Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to get 'label2' from {'label': 'b'} due to : query \"label2\" did not match any item in dict: {'label': 'b'}"
+        exception_text = "Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to get 'label2' from {'label': 'b'} due to : query \"label2\" did not match any item in dict: {'label': 'b'} while not_exist_ok=False"
         check_operator_exception(
             operator=RemoveValues(field="label2", unallowed_values=["c"]),
             inputs=inputs,


### PR DESCRIPTION
Hi Elron and Yoav,
d_path is out of dict_utility, and of both requirement files where it showed.

I also cancelled the ban of  `process_every_value`  not allowed for operator `RemoveValues` (a ban laid only on it..)
We do need `process_every_value` here.

Speaking of which (the family of field operators, including all the postprocessors, that process a (single) prediction and `process every value` of list of references), why is `EncodeLabels`  so much of an outsider?  
There is a straightforward implementation thereof as a field operator. Why was not it used?