### PR TITLE
Added new metric for unsorted_list_exact_math

### DIFF
--- a/prepare/metrics/unsorted_list_exact_match.py
+++ b/prepare/metrics/unsorted_list_exact_match.py
@@ -1,0 +1,6 @@
+from src.unitxt import add_to_catalog
+from src.unitxt.metrics import UnsortedListExactMatch
+
+metric = UnsortedListExactMatch()
+
+add_to_catalog(metric, "metrics.unsorted_list_exact_match", overwrite=True)

--- a/src/unitxt/catalog/metrics/unsorted_list_exact_match.json
+++ b/src/unitxt/catalog/metrics/unsorted_list_exact_match.json
@@ -1,0 +1,3 @@
+{
+    "type": "unsorted_list_exact_match"
+}

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -885,6 +885,20 @@ class Accuracy(InstanceMetric):
         return result
 
 
+class UnsortedListExactMatch(InstanceMetric):
+    reduction_map = {"mean": ["unsorted_list_exact_match"]}
+    main_score = "unsorted_list_exact_match"
+    ci_scores = ["unsorted_list_exact_match"]
+
+    def compute(
+        self, references: List[Any], prediction: Any, task_data: List[Dict]
+    ) -> dict:
+        result = {self.main_score: float(sorted(prediction) == sorted(references[0]))}
+        result["score"] = result[self.main_score]
+        result["score_name"] = self.main_score
+        return result
+
+
 class StringContainment(InstanceMetric):
     reduction_map = {"mean": ["string_containment"]}
     main_score = "string_containment"

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -39,6 +39,7 @@ from src.unitxt.metrics import (
     Rouge,
     Squad,
     TokenOverlap,
+    UnsortedListExactMatch,
 )
 from src.unitxt.test_utils.metrics import apply_metric
 from tests.utils import UnitxtTestCase
@@ -105,6 +106,51 @@ GROUPED_INSTANCE_ADDL_INPUTS = [
 
 
 class TestMetrics(UnitxtTestCase):
+    def test_unsorted_list_exact_match(self):
+        metric = UnsortedListExactMatch()
+
+        predictions = [["A", "B"], ["B", "A"], ["A", "B", "C"]]
+        references = [[["A", "B"]], [["A", "B"]], [["A", "B", "D"]]]
+
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+
+        expected_global_result = {
+            "unsorted_list_exact_match": 2 / 3,
+            "score": 2 / 3,
+            "score_name": "unsorted_list_exact_match",
+        }
+
+        global_result = outputs[0]["score"]["global"].copy()
+        # Only check the keys that are expected, i.e. exist in expected_global_result
+        global_result = {
+            key: value
+            for key, value in global_result.items()
+            if key in expected_global_result
+        }
+        self.assertDictEqual(global_result, expected_global_result)
+
+        instance_targets = [
+            {
+                "unsorted_list_exact_match": 1.0,
+                "score": 1.0,
+                "score_name": "unsorted_list_exact_match",
+            },
+            {
+                "unsorted_list_exact_match": 1.0,
+                "score": 1.0,
+                "score_name": "unsorted_list_exact_match",
+            },
+            {
+                "unsorted_list_exact_match": 0.0,
+                "score": 0.0,
+                "score_name": "unsorted_list_exact_match",
+            },
+        ]
+        for output, target in zip(outputs, instance_targets):
+            self.assertDictEqual(output["score"]["instance"], target)
+
     def test_accuracy(self):
         metric = Accuracy()
 


### PR DESCRIPTION
The new metrics sorts the predictions and references (which are both assumed to be list) and compares them return '1' if exact match or '0' otherwise.