### PR TITLE
encode labels for single-value, and for all levels of nestings of containing lists

### DIFF
--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -2040,7 +2040,7 @@ class TestOperators(UnitxtTestCase):
         ]
 
         check_operator(
-            operator=EncodeLabels(fields=["prediction", "references/*"]),
+            operator=EncodeLabels(fields=["prediction", "references"]),
             inputs=inputs,
             targets=targets,
             tester=self,


### PR DESCRIPTION
Now, with multi-labeling, field references may become a "deep" (!) list.
`EncodeLabel `tried to chase the depth via specifying * and `set_multiple`  features of `dict_set`.
Basing on the fact that `EncodeLable` expects either a str or a list of str -s (and I understand that imminently -- a list of lists of str-s), suggested here is a simple `EncodeLabel` that needs no *, and no `set_multiple`, and is ready for the new references, no matter how deep their lists are.