### PR TITLE
Fix handling of boolean environment variables

### DIFF
--- a/src/unitxt/settings_utils.py
+++ b/src/unitxt/settings_utils.py
@@ -67,9 +67,16 @@ class Settings:
             actual_key = key[:-4]  # Remove the "_key" suffix
             return self.environment_variable_key_name(actual_key)
 
-        env_value = os.getenv(self.environment_variable_key_name(key))
+        key_name = self.environment_variable_key_name(key)
+        env_value = os.getenv(key_name)
 
         if env_value is not None:
+            if key in self._types and self._types[key] == bool:
+                assert env_value in {"True", "False"}, (
+                    f"unitxt boolean environment variables must be set to either 'True' or 'False', "
+                    f"current value: {key_name}={env_value}"
+                )
+                env_value = env_value == "True"
             return env_value
 
         if key in self._settings:

--- a/tests/library/test_settings.py
+++ b/tests/library/test_settings.py
@@ -61,3 +61,13 @@ class TestSettings(UnitxtTestCase):
         settings.test_env = "text_env"
         os.environ[settings.test_env_key] = "not_text_env"
         self.assertEqual(settings.test_env, "not_text_env")
+
+    def test_bool_env_var(self):
+        settings = Settings()
+        settings.test_bool_var = (bool, True)
+        os.environ[settings.test_bool_var_key] = "False"
+        self.assertEqual(settings.test_bool_var, False)
+
+        os.environ[settings.test_bool_var_key] = "TRUE"
+        with self.assertRaises(AssertionError):
+            _ = settings.test_bool_var


### PR DESCRIPTION
Currently when unitxt settings are set via environment variables, boolean parameters are processed as strings, and thus a value of "False" can be evaluated as True by unitxt. This change casts the relevant setting values to boolean