### PR TITLE
Ready for review: remove use_dpath parameter from dict_get and dict_set

### DIFF
--- a/docs/docs/adding_dataset.rst
+++ b/docs/docs/adding_dataset.rst
@@ -71,7 +71,6 @@ For example, prepare the dataset for translation task:
                 ["translation/en", "text"],
                 ["translation/de", "translation"],
             ],
-            use_query=True,
         ),
         AddFields( # add new fields required by the task schema
             fields={
@@ -131,7 +130,6 @@ Once your card is ready you can test it:
                         ["translation/en", "text"],
                         ["translation/de", "translation"],
                     ],
-                    use_query=True,
                 ),
                 AddFields( # add new fields required by the task schema
                     fields={

--- a/prepare/cards/almost_evil_ml_qa_mulitlingual.py
+++ b/prepare/cards/almost_evil_ml_qa_mulitlingual.py
@@ -19,10 +19,7 @@ for lang in langs:
         loader=LoadHF(path="0x22almostEvil/multilingual-wikihow-qa-16k"),
         preprocess_steps=[
             Apply("METADATA", function=json.loads, to_field="metadata"),
-            CopyFields(
-                field_to_field=[("metadata/language", "extracted_language")],
-                use_query=True,
-            ),
+            CopyFields(field_to_field=[("metadata/language", "extracted_language")]),
             FilterByCondition(values={"extracted_language": lang}, condition="eq"),
             RemoveFields(fields=["extracted_language", "metadata"]),
             SplitRandomMix(

--- a/prepare/cards/arc.py
+++ b/prepare/cards/arc.py
@@ -12,8 +12,7 @@ for subtask in subtasks:
             AddFields({"topic": "science"}),
             RenameFields(field_to_field={"answerKey": "label", "choices": "_choices"}),
             CopyFields(
-                field_to_field={"_choices/text": "choices", "_choices/label": "labels"},
-                use_query=True,
+                field_to_field={"_choices/text": "choices", "_choices/label": "labels"}
             ),
             IndexOf(search_in="labels", index_of="label", to_field="answer"),
         ],

--- a/prepare/cards/atis.py
+++ b/prepare/cards/atis.py
@@ -114,7 +114,6 @@ card = TaskCard(
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels",
             },
-            use_query=True,
             get_default=[],
             not_exist_ok=True,
         ),

--- a/prepare/cards/atta_q.py
+++ b/prepare/cards/atta_q.py
@@ -19,8 +19,7 @@ card = TaskCard(
         Shuffle(page_size=2800),
         AddFields({"input_label": {}}),
         CopyFields(
-            field_to_field={"input": "input_label/input", "label": "input_label/label"},
-            use_query=True,
+            field_to_field={"input": "input_label/input", "label": "input_label/label"}
         ),
         Apply("input_label", function=json.dumps, to_field="input_label"),
     ],

--- a/prepare/cards/bold.py
+++ b/prepare/cards/bold.py
@@ -23,8 +23,8 @@ card = TaskCard(
     preprocess_steps=[
         RenameSplits(mapper={"train": "test"}),
         AddFields({"input_label": {}}),
-        CopyFields(field_to_field=[("prompts/0", "first_prompt")], use_query=True),
-        CopyFields(field_to_field=[("wikipedia/0", "first_wiki")], use_query=True),
+        CopyFields(field_to_field=[("prompts/0", "first_prompt")]),
+        CopyFields(field_to_field=[("wikipedia/0", "first_wiki")]),
         FilterByCondition(values={"domain": ["race", "gender"]}, condition="in"),
         Shuffle(page_size=10000),
         CopyFields(
@@ -33,7 +33,6 @@ card = TaskCard(
                 "category": "input_label/category",
                 "first_wiki": "input_label/wiki",
             },
-            use_query=True,
         ),
         Apply("input_label", function=json.dumps, to_field="input_label"),
     ],

--- a/prepare/cards/coqa.py
+++ b/prepare/cards/coqa.py
@@ -13,14 +13,12 @@ card = TaskCard(
         ZipFieldValues(
             fields=["questions", "answers/input_text"],
             to_field="dialog",
-            use_query=True,
         ),
         Dictify(field="dialog", with_keys=["user", "system"], process_every_value=True),
         DuplicateBySubLists(field="dialog"),
         Get(field="dialog", item=-1, to_field="last_turn"),
         CopyFields(
             field_to_field={"last_turn/user": "question", "last_turn/system": "answer"},
-            use_query=True,
         ),
         Wrap(
             field="answer",
@@ -48,7 +46,6 @@ card = TaskCard(
         ZipFieldValues(
             fields=["questions", "answers/input_text"],
             to_field="dialog",
-            use_query=True,
         ),
         Dictify(field="dialog", with_keys=["user", "system"], process_every_value=True),
         DuplicateBySubLists(field="dialog"),

--- a/prepare/cards/dart.py
+++ b/prepare/cards/dart.py
@@ -17,7 +17,6 @@ card = TaskCard(
         RenameFields(field_to_field={"serialized_triples": "input"}),
         CopyFields(
             field_to_field={"annotations/text/0": "output"},
-            use_query=True,
         ),
         AddFields(fields={"type_of_input": "Triples", "type_of_output": "Text"}),
     ],

--- a/prepare/cards/ffqa_filtered.py
+++ b/prepare/cards/ffqa_filtered.py
@@ -86,7 +86,6 @@ def add_card(split: str):
                     "conversations/0/tok_len": "inputs_len",
                     "conversations/1/value": "answer",
                 },
-                use_query=True,
             ),
             ListFieldValues(fields=["answer"], to_field="answers"),
             FilterByCondition(

--- a/prepare/cards/multidoc2dial.py
+++ b/prepare/cards/multidoc2dial.py
@@ -18,7 +18,6 @@ card_abstractive = TaskCard(
     preprocess_steps=[
         RenameFields(
             field_to_field={"answers/text/0": "relevant_context"},
-            use_query=True,
         ),
         ListFieldValues(fields=["utterance"], to_field="answers"),
         ExecuteExpression(expression="question.split('[SEP]')[0]", to_field="question"),
@@ -33,7 +32,6 @@ card_extractive = TaskCard(
     preprocess_steps=[
         RenameFields(
             field_to_field={"answers/text/0": "relevant_context"},
-            use_query=True,
         ),
         ListFieldValues(fields=["relevant_context"], to_field="answers"),
         ExecuteExpression(expression="question.split('[SEP]')[0]", to_field="question"),

--- a/prepare/cards/openbookqa.py
+++ b/prepare/cards/openbookqa.py
@@ -8,7 +8,6 @@ card = TaskCard(
     preprocess_steps=[
         RenameFields(
             field_to_field={"choices/text": "choices_text", "choices/label": "labels"},
-            use_query=True,
         ),
         RenameFields(
             field_to_field={"choices_text": "choices", "question_stem": "question"},

--- a/prepare/cards/squad.py
+++ b/prepare/cards/squad.py
@@ -6,7 +6,7 @@ card = TaskCard(
     loader=LoadHF(path="squad"),
     preprocess_steps=[
         "splitters.small_no_test",
-        CopyFields(field_to_field=[["answers/text", "answers"]], use_query=True),
+        CopyFields(field_to_field=[["answers/text", "answers"]]),
         AddFields({"context_type": "passage"}),
     ],
     task="tasks.qa.with_context.extractive",

--- a/prepare/cards/universal_ner.py
+++ b/prepare/cards/universal_ner.py
@@ -66,7 +66,6 @@ for sub_task in sub_tasks:
                     "spans/*/end": "spans_ends",
                     "spans/*/label": "labels",
                 },
-                use_query=True,
                 get_default=[],
                 not_exist_ok=True,
             ),

--- a/prepare/cards/wiki_bio.py
+++ b/prepare/cards/wiki_bio.py
@@ -17,7 +17,6 @@ card = TaskCard(
         ListToKeyValPairs(
             fields=["input_text/table/column_header", "input_text/table/content"],
             to_field="kvpairs",
-            use_query=True,
         ),
         SerializeKeyValPairs(field_to_field=[["kvpairs", "input"]]),
         RenameFields(field_to_field={"target_text": "output"}),

--- a/prepare/cards/wmt/en_de.py
+++ b/prepare/cards/wmt/en_de.py
@@ -10,7 +10,6 @@ card = TaskCard(
                 ["translation/en", "text"],
                 ["translation/de", "translation"],
             ],
-            use_query=True,
         ),
         AddFields(
             fields={

--- a/prepare/cards/wmt/en_fr.py
+++ b/prepare/cards/wmt/en_fr.py
@@ -10,7 +10,6 @@ card = TaskCard(
                 ["translation/en", "text"],
                 ["translation/fr", "translation"],
             ],
-            use_query=True,
         ),
         AddFields(
             fields={

--- a/prepare/cards/wmt/en_ro.py
+++ b/prepare/cards/wmt/en_ro.py
@@ -10,7 +10,6 @@ card = TaskCard(
                 ["translation/en", "text"],
                 ["translation/ro", "translation"],
             ],
-            use_query=True,
         ),
         AddFields(
             fields={

--- a/prepare/metrics/normalized_sacrebleu.py
+++ b/prepare/metrics/normalized_sacrebleu.py
@@ -31,14 +31,12 @@ metric = MetricPipeline(
     preprocess_steps=[
         CopyFields(
             field_to_field=[("task_data/target_language", "task_data/tokenize")],
-            use_query=True,
             not_exist_ok=True,
             get_default="en",
         ),
         MapInstanceValues(
             mappers={"task_data/tokenize": language_to_tokenizer},
             strict=True,
-            use_query=True,
         ),
     ],
     metric=NormalizedSacrebleu(),

--- a/prepare/metrics/rag.py
+++ b/prepare/metrics/rag.py
@@ -60,9 +60,7 @@ global_target = {
 metric = MetricPipeline(
     main_score="score",
     preprocess_steps=[
-        CopyFields(
-            field_to_field=[("task_data/context", "references")], use_query=True
-        ),
+        CopyFields(field_to_field=[("task_data/context", "references")]),
         ListFieldValues(fields=["references"], to_field="references"),
     ],
     metric=metrics["metrics.token_overlap"],
@@ -76,7 +74,6 @@ metric = MetricPipeline(
                     "score/global/precision_overlap_with_context",
                 ),
             ],
-            use_query=True,
         ),
     ],
 )
@@ -244,10 +241,9 @@ for metric_name, catalog_name in [
     metric = MetricPipeline(
         main_score="score",
         preprocess_steps=[
-            CopyFields(field_to_field=[("context_ids", "prediction")], use_query=True),
+            CopyFields(field_to_field=[("context_ids", "prediction")]),
             CopyFields(
                 field_to_field=[("ground_truths_context_ids", "references")],
-                use_query=True,
             ),
         ],
         metric=f"metrics.{metric_name}",
@@ -258,10 +254,9 @@ for metric_name, catalog_name in [
 context_relevance = MetricPipeline(
     main_score="perplexity",
     preprocess_steps=[
-        CopyFields(field_to_field=[("contexts", "references")], use_query=True),
+        CopyFields(field_to_field=[("contexts", "references")]),
         CopyFields(
             field_to_field=[("question", "prediction")],
-            use_query=True,
         ),
     ],
     metric="metrics.perplexity_q.flan_t5_small",
@@ -271,10 +266,9 @@ add_to_catalog(context_relevance, "metrics.rag.context_relevance", overwrite=Tru
 context_perplexity = MetricPipeline(
     main_score="score",
     preprocess_steps=[
-        CopyFields(field_to_field=[("contexts", "references")], use_query=True),
+        CopyFields(field_to_field=[("contexts", "references")]),
         CopyFields(
             field_to_field=[("question", "prediction")],
-            use_query=True,
         ),
     ],
     metric="metrics.perplexity_q.flan_t5_small",
@@ -283,7 +277,6 @@ context_perplexity = MetricPipeline(
             field_to_field=[
                 ("score/instance/reference_scores", "score/instance/score")
             ],
-            use_query=True,
         )
     ],
 )
@@ -298,10 +291,9 @@ for new_catalog_name, base_catalog_name in [
     metric = MetricPipeline(
         main_score="precision",
         preprocess_steps=[
-            CopyFields(field_to_field=[("contexts", "references")], use_query=True),
+            CopyFields(field_to_field=[("contexts", "references")]),
             CopyFields(
                 field_to_field=[("answer", "prediction")],
-                use_query=True,
             ),
         ],
         metric=base_catalog_name,
@@ -316,12 +308,9 @@ for new_catalog_name, base_catalog_name in [
     metric = MetricPipeline(
         main_score="recall",
         preprocess_steps=[
-            CopyFields(
-                field_to_field=[("ground_truths", "references")], use_query=True
-            ),
+            CopyFields(field_to_field=[("ground_truths", "references")]),
             CopyFields(
                 field_to_field=[("answer", "prediction")],
-                use_query=True,
             ),
         ],
         metric=base_catalog_name,
@@ -331,10 +320,9 @@ for new_catalog_name, base_catalog_name in [
 answer_reward = MetricPipeline(
     main_score="score",
     preprocess_steps=[
-        CopyFields(field_to_field=[("question", "references")], use_query=True),
+        CopyFields(field_to_field=[("question", "references")]),
         CopyFields(
             field_to_field=[("answer", "prediction")],
-            use_query=True,
         ),
         # This metric compares the answer (as the prediction) to the question (as the reference).
         # We have to wrap the question by a list (otherwise it will be a string),

--- a/prepare/metrics/spearman.py
+++ b/prepare/metrics/spearman.py
@@ -8,7 +8,7 @@ from src.unitxt.test_utils.metrics import test_metric
 metric = MetricPipeline(
     main_score="spearmanr",
     preprocess_steps=[
-        CopyFields(field_to_field=[("references/0", "references")], use_query=True),
+        CopyFields(field_to_field=[("references/0", "references")]),
         CastFields(
             fields={"prediction": "float", "references": "float"},
             failure_defaults={"prediction": 0.0},

--- a/prepare/metrics/squad.py
+++ b/prepare/metrics/squad.py
@@ -24,14 +24,12 @@ metric = MetricPipeline(
                 ["id", "prediction_template/id"],
                 ["id", "reference_template/id"],
             ],
-            use_query=True,
         ),
         CopyFields(
             field_to_field=[
                 ["reference_template", "references"],
                 ["prediction_template", "prediction"],
             ],
-            use_query=True,
         ),
     ],
     metric=Squad(),

--- a/prepare/metrics/unnormalized_sacrebleu.py
+++ b/prepare/metrics/unnormalized_sacrebleu.py
@@ -8,14 +8,12 @@ metric = MetricPipeline(
     preprocess_steps=[
         CopyFields(
             field_to_field=[("task_data/target_language", "task_data/tokenize")],
-            use_query=True,
             not_exist_ok=True,
             get_default="en",
         ),
         MapInstanceValues(
             mappers={"task_data/tokenize": {"en": "", "ja": "ja-mecab"}},
             strict=True,
-            use_query=True,
         ),
     ],
     metric=HuggingfaceMetric(

--- a/prepare/processors/processors.py
+++ b/prepare/processors/processors.py
@@ -231,7 +231,6 @@ add_to_catalog(
                 field="references/0",
                 unallowed_values=["none"],
                 process_every_value=False,
-                use_query=True,
             ),
         ]
     ),

--- a/src/unitxt/catalog/cards/ai2_arc/arc_challenge.json
+++ b/src/unitxt/catalog/cards/ai2_arc/arc_challenge.json
@@ -24,8 +24,7 @@
             "field_to_field": {
                 "_choices/text": "choices",
                 "_choices/label": "labels"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "index_of",

--- a/src/unitxt/catalog/cards/ai2_arc/arc_easy.json
+++ b/src/unitxt/catalog/cards/ai2_arc/arc_easy.json
@@ -24,8 +24,7 @@
             "field_to_field": {
                 "_choices/text": "choices",
                 "_choices/label": "labels"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "index_of",

--- a/src/unitxt/catalog/cards/almost_evil/de.json
+++ b/src/unitxt/catalog/cards/almost_evil/de.json
@@ -20,8 +20,7 @@
                     "metadata/language",
                     "extracted_language"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "filter_by_condition",

--- a/src/unitxt/catalog/cards/almost_evil/en.json
+++ b/src/unitxt/catalog/cards/almost_evil/en.json
@@ -20,8 +20,7 @@
                     "metadata/language",
                     "extracted_language"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "filter_by_condition",

--- a/src/unitxt/catalog/cards/almost_evil/es.json
+++ b/src/unitxt/catalog/cards/almost_evil/es.json
@@ -20,8 +20,7 @@
                     "metadata/language",
                     "extracted_language"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "filter_by_condition",

--- a/src/unitxt/catalog/cards/almost_evil/fr.json
+++ b/src/unitxt/catalog/cards/almost_evil/fr.json
@@ -20,8 +20,7 @@
                     "metadata/language",
                     "extracted_language"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "filter_by_condition",

--- a/src/unitxt/catalog/cards/almost_evil/it.json
+++ b/src/unitxt/catalog/cards/almost_evil/it.json
@@ -20,8 +20,7 @@
                     "metadata/language",
                     "extracted_language"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "filter_by_condition",

--- a/src/unitxt/catalog/cards/almost_evil/nl.json
+++ b/src/unitxt/catalog/cards/almost_evil/nl.json
@@ -20,8 +20,7 @@
                     "metadata/language",
                     "extracted_language"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "filter_by_condition",

--- a/src/unitxt/catalog/cards/almost_evil/pt.json
+++ b/src/unitxt/catalog/cards/almost_evil/pt.json
@@ -20,8 +20,7 @@
                     "metadata/language",
                     "extracted_language"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "filter_by_condition",

--- a/src/unitxt/catalog/cards/almost_evil/ru.json
+++ b/src/unitxt/catalog/cards/almost_evil/ru.json
@@ -20,8 +20,7 @@
                     "metadata/language",
                     "extracted_language"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "filter_by_condition",

--- a/src/unitxt/catalog/cards/atis.json
+++ b/src/unitxt/catalog/cards/atis.json
@@ -267,7 +267,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/atta_q.json
+++ b/src/unitxt/catalog/cards/atta_q.json
@@ -26,8 +26,7 @@
             "field_to_field": {
                 "input": "input_label/input",
                 "label": "input_label/label"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "apply",

--- a/src/unitxt/catalog/cards/bold.json
+++ b/src/unitxt/catalog/cards/bold.json
@@ -24,8 +24,7 @@
                     "prompts/0",
                     "first_prompt"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -34,8 +33,7 @@
                     "wikipedia/0",
                     "first_wiki"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "filter_by_condition",
@@ -57,8 +55,7 @@
                 "first_prompt": "input_label/input",
                 "category": "input_label/category",
                 "first_wiki": "input_label/wiki"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "apply",

--- a/src/unitxt/catalog/cards/coqa/completion.json
+++ b/src/unitxt/catalog/cards/coqa/completion.json
@@ -19,8 +19,7 @@
                 "questions",
                 "answers/input_text"
             ],
-            "to_field": "dialog",
-            "use_query": true
+            "to_field": "dialog"
         },
         {
             "type": "dictify",

--- a/src/unitxt/catalog/cards/coqa/qa.json
+++ b/src/unitxt/catalog/cards/coqa/qa.json
@@ -18,8 +18,7 @@
                 "questions",
                 "answers/input_text"
             ],
-            "to_field": "dialog",
-            "use_query": true
+            "to_field": "dialog"
         },
         {
             "type": "dictify",
@@ -45,8 +44,7 @@
             "field_to_field": {
                 "last_turn/user": "question",
                 "last_turn/system": "answer"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "wrap",

--- a/src/unitxt/catalog/cards/dart.json
+++ b/src/unitxt/catalog/cards/dart.json
@@ -25,8 +25,7 @@
             "type": "copy_fields",
             "field_to_field": {
                 "annotations/text/0": "output"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "add_fields",

--- a/src/unitxt/catalog/cards/ffqa_filtered/16k.json
+++ b/src/unitxt/catalog/cards/ffqa_filtered/16k.json
@@ -11,8 +11,7 @@
                 "conversations/0/value": "inputs",
                 "conversations/0/tok_len": "inputs_len",
                 "conversations/1/value": "answer"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "list_field_values",

--- a/src/unitxt/catalog/cards/ffqa_filtered/2k.json
+++ b/src/unitxt/catalog/cards/ffqa_filtered/2k.json
@@ -11,8 +11,7 @@
                 "conversations/0/value": "inputs",
                 "conversations/0/tok_len": "inputs_len",
                 "conversations/1/value": "answer"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "list_field_values",

--- a/src/unitxt/catalog/cards/ffqa_filtered/4k.json
+++ b/src/unitxt/catalog/cards/ffqa_filtered/4k.json
@@ -11,8 +11,7 @@
                 "conversations/0/value": "inputs",
                 "conversations/0/tok_len": "inputs_len",
                 "conversations/1/value": "answer"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "list_field_values",

--- a/src/unitxt/catalog/cards/ffqa_filtered/8k.json
+++ b/src/unitxt/catalog/cards/ffqa_filtered/8k.json
@@ -11,8 +11,7 @@
                 "conversations/0/value": "inputs",
                 "conversations/0/tok_len": "inputs_len",
                 "conversations/1/value": "answer"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "list_field_values",

--- a/src/unitxt/catalog/cards/multidoc2dial/abstractive.json
+++ b/src/unitxt/catalog/cards/multidoc2dial/abstractive.json
@@ -9,8 +9,7 @@
             "type": "rename_fields",
             "field_to_field": {
                 "answers/text/0": "relevant_context"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "list_field_values",

--- a/src/unitxt/catalog/cards/multidoc2dial/extractive.json
+++ b/src/unitxt/catalog/cards/multidoc2dial/extractive.json
@@ -9,8 +9,7 @@
             "type": "rename_fields",
             "field_to_field": {
                 "answers/text/0": "relevant_context"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "list_field_values",

--- a/src/unitxt/catalog/cards/openbook_qa.json
+++ b/src/unitxt/catalog/cards/openbook_qa.json
@@ -10,8 +10,7 @@
             "field_to_field": {
                 "choices/text": "choices_text",
                 "choices/label": "labels"
-            },
-            "use_query": true
+            }
         },
         {
             "type": "rename_fields",

--- a/src/unitxt/catalog/cards/squad.json
+++ b/src/unitxt/catalog/cards/squad.json
@@ -13,8 +13,7 @@
                     "answers/text",
                     "answers"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "add_fields",

--- a/src/unitxt/catalog/cards/universal_ner/ceb/gja.json
+++ b/src/unitxt/catalog/cards/universal_ner/ceb/gja.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/da/ddt.json
+++ b/src/unitxt/catalog/cards/universal_ner/da/ddt.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/de/pud.json
+++ b/src/unitxt/catalog/cards/universal_ner/de/pud.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/en/ewt.json
+++ b/src/unitxt/catalog/cards/universal_ner/en/ewt.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/en/pud.json
+++ b/src/unitxt/catalog/cards/universal_ner/en/pud.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/hr/set.json
+++ b/src/unitxt/catalog/cards/universal_ner/hr/set.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/pt/bosque.json
+++ b/src/unitxt/catalog/cards/universal_ner/pt/bosque.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/pt/pud.json
+++ b/src/unitxt/catalog/cards/universal_ner/pt/pud.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/ru/pud.json
+++ b/src/unitxt/catalog/cards/universal_ner/ru/pud.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/sk/snk.json
+++ b/src/unitxt/catalog/cards/universal_ner/sk/snk.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/sr/set.json
+++ b/src/unitxt/catalog/cards/universal_ner/sr/set.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/sv/pud.json
+++ b/src/unitxt/catalog/cards/universal_ner/sv/pud.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/sv/talbanken.json
+++ b/src/unitxt/catalog/cards/universal_ner/sv/talbanken.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/tl/trg.json
+++ b/src/unitxt/catalog/cards/universal_ner/tl/trg.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/tl/ugnayan.json
+++ b/src/unitxt/catalog/cards/universal_ner/tl/ugnayan.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/zh/gsd.json
+++ b/src/unitxt/catalog/cards/universal_ner/zh/gsd.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/zh/gsdsimp.json
+++ b/src/unitxt/catalog/cards/universal_ner/zh/gsdsimp.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/universal_ner/zh/pud.json
+++ b/src/unitxt/catalog/cards/universal_ner/zh/pud.json
@@ -55,7 +55,6 @@
                 "spans/*/end": "spans_ends",
                 "spans/*/label": "labels"
             },
-            "use_query": true,
             "get_default": [],
             "not_exist_ok": true
         },

--- a/src/unitxt/catalog/cards/wiki_bio.json
+++ b/src/unitxt/catalog/cards/wiki_bio.json
@@ -19,8 +19,7 @@
                 "input_text/table/column_header",
                 "input_text/table/content"
             ],
-            "to_field": "kvpairs",
-            "use_query": true
+            "to_field": "kvpairs"
         },
         {
             "type": "serialize_key_val_pairs",

--- a/src/unitxt/catalog/cards/wmt/en_de.json
+++ b/src/unitxt/catalog/cards/wmt/en_de.json
@@ -18,8 +18,7 @@
                     "translation/de",
                     "translation"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "add_fields",

--- a/src/unitxt/catalog/cards/wmt/en_fr.json
+++ b/src/unitxt/catalog/cards/wmt/en_fr.json
@@ -18,8 +18,7 @@
                     "translation/fr",
                     "translation"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "add_fields",

--- a/src/unitxt/catalog/cards/wmt/en_ro.json
+++ b/src/unitxt/catalog/cards/wmt/en_ro.json
@@ -18,8 +18,7 @@
                     "translation/ro",
                     "translation"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "add_fields",

--- a/src/unitxt/catalog/metrics/normalized_sacrebleu.json
+++ b/src/unitxt/catalog/metrics/normalized_sacrebleu.json
@@ -10,7 +10,6 @@
                     "task_data/tokenize"
                 ]
             ],
-            "use_query": true,
             "not_exist_ok": true,
             "get_default": "en"
         },
@@ -40,8 +39,7 @@
                     "ja": "ja-mecab"
                 }
             },
-            "strict": true,
-            "use_query": true
+            "strict": true
         }
     ],
     "metric": {

--- a/src/unitxt/catalog/metrics/rag/answer_correctness.json
+++ b/src/unitxt/catalog/metrics/rag/answer_correctness.json
@@ -9,8 +9,7 @@
                     "ground_truths",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "answer",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.token_overlap"

--- a/src/unitxt/catalog/metrics/rag/answer_reward.json
+++ b/src/unitxt/catalog/metrics/rag/answer_reward.json
@@ -9,8 +9,7 @@
                     "question",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "answer",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "list_field_values",

--- a/src/unitxt/catalog/metrics/rag/bert_k_precision.json
+++ b/src/unitxt/catalog/metrics/rag/bert_k_precision.json
@@ -9,8 +9,7 @@
                     "contexts",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "answer",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.bert_score.deberta_xlarge_mnli"

--- a/src/unitxt/catalog/metrics/rag/bert_recall.json
+++ b/src/unitxt/catalog/metrics/rag/bert_recall.json
@@ -9,8 +9,7 @@
                     "ground_truths",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "answer",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.bert_score.deberta_xlarge_mnli"

--- a/src/unitxt/catalog/metrics/rag/context_correctness.json
+++ b/src/unitxt/catalog/metrics/rag/context_correctness.json
@@ -9,8 +9,7 @@
                     "context_ids",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "ground_truths_context_ids",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.mrr"

--- a/src/unitxt/catalog/metrics/rag/context_perplexity.json
+++ b/src/unitxt/catalog/metrics/rag/context_perplexity.json
@@ -9,8 +9,7 @@
                     "contexts",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "question",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.perplexity_q.flan_t5_small",
@@ -32,8 +30,7 @@
                     "score/instance/reference_scores",
                     "score/instance/score"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ]
 }

--- a/src/unitxt/catalog/metrics/rag/context_relevance.json
+++ b/src/unitxt/catalog/metrics/rag/context_relevance.json
@@ -9,8 +9,7 @@
                     "contexts",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "question",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.perplexity_q.flan_t5_small"

--- a/src/unitxt/catalog/metrics/rag/faithfulness.json
+++ b/src/unitxt/catalog/metrics/rag/faithfulness.json
@@ -9,8 +9,7 @@
                     "contexts",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "answer",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.token_overlap"

--- a/src/unitxt/catalog/metrics/rag/k_precision.json
+++ b/src/unitxt/catalog/metrics/rag/k_precision.json
@@ -9,8 +9,7 @@
                     "contexts",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "answer",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.token_overlap"

--- a/src/unitxt/catalog/metrics/rag/map.json
+++ b/src/unitxt/catalog/metrics/rag/map.json
@@ -9,8 +9,7 @@
                     "context_ids",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "ground_truths_context_ids",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.map"

--- a/src/unitxt/catalog/metrics/rag/mrr.json
+++ b/src/unitxt/catalog/metrics/rag/mrr.json
@@ -9,8 +9,7 @@
                     "context_ids",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "ground_truths_context_ids",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.mrr"

--- a/src/unitxt/catalog/metrics/rag/recall.json
+++ b/src/unitxt/catalog/metrics/rag/recall.json
@@ -9,8 +9,7 @@
                     "ground_truths",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -19,8 +18,7 @@
                     "answer",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": "metrics.token_overlap"

--- a/src/unitxt/catalog/metrics/sacrebleu.json
+++ b/src/unitxt/catalog/metrics/sacrebleu.json
@@ -10,7 +10,6 @@
                     "task_data/tokenize"
                 ]
             ],
-            "use_query": true,
             "not_exist_ok": true,
             "get_default": "en"
         },
@@ -22,8 +21,7 @@
                     "ja": "ja-mecab"
                 }
             },
-            "strict": true,
-            "use_query": true
+            "strict": true
         }
     ],
     "metric": {

--- a/src/unitxt/catalog/metrics/spearman.json
+++ b/src/unitxt/catalog/metrics/spearman.json
@@ -9,8 +9,7 @@
                     "references/0",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "cast_fields",

--- a/src/unitxt/catalog/metrics/squad.json
+++ b/src/unitxt/catalog/metrics/squad.json
@@ -43,8 +43,7 @@
                     "id",
                     "reference_template/id"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "copy_fields",
@@ -57,8 +56,7 @@
                     "prediction_template",
                     "prediction"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ],
     "metric": {

--- a/src/unitxt/catalog/metrics/token_overlap_with_context.json
+++ b/src/unitxt/catalog/metrics/token_overlap_with_context.json
@@ -9,8 +9,7 @@
                     "task_data/context",
                     "references"
                 ]
-            ],
-            "use_query": true
+            ]
         },
         {
             "type": "list_field_values",
@@ -39,8 +38,7 @@
                     "score/global/precision",
                     "score/global/precision_overlap_with_context"
                 ]
-            ],
-            "use_query": true
+            ]
         }
     ]
 }

--- a/src/unitxt/catalog/processors/remove_none_from_list.json
+++ b/src/unitxt/catalog/processors/remove_none_from_list.json
@@ -15,8 +15,7 @@
             "unallowed_values": [
                 "none"
             ],
-            "process_every_value": false,
-            "use_query": true
+            "process_every_value": false
         }
     ]
 }

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -191,6 +191,10 @@ def dict_delete(
             "Query is an empty string, implying the deletion of dic as a whole. This can not be done via this function call."
         )
 
+    if isinstance(dic, dict) and query.strip() in dic:
+        dic.pop(query.strip())
+        return
+
     qpath = validate_query_and_break_to_components(query)
 
     try:
@@ -381,6 +385,9 @@ def dict_get(
     if len(query.strip()) == 0:
         return dic
 
+    if dic is not None and isinstance(dic, dict) and query.strip() in dic:
+        return dic[query.strip()]
+
     components = validate_query_and_break_to_components(query)
     if len(components) > 1:
         try:
@@ -465,7 +472,7 @@ def dict_set(
 ):  # sets dic to its new value
     if dic is None or not isinstance(dic, (list, dict)):
         raise ValueError(
-            f"Can not change dic that is either None or not a dict nor list. Got dic = {dic}"
+            f"Can not change dic that is either None or not a dict nor a list. Got dic = {dic}"
         )
 
     if query.strip() == "":
@@ -487,6 +494,10 @@ def dict_set(
             dic.clear()
             dic.extend(value)
             return
+
+    if isinstance(dic, dict) and query.strip() in dic:
+        dic[query.strip()] = value
+        return
 
     if set_multiple:
         if value is None or not isinstance(value, list) or len(value) == 0:

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -442,7 +442,6 @@ def dict_set(
     dic: dict,
     query: str,
     value: Any,
-    use_dpath=True,
     not_exist_ok=True,
     set_multiple=False,
 ):
@@ -452,7 +451,7 @@ def dict_set(
         raise ValueError(
             f"set_multiple == True, and yet value, {value}, is not a list or '*' is not in query '{query}'"
         )
-    if not use_dpath or "/" not in query:
+    if "/" not in query:
         if query.strip() in dic or not_exist_ok:
             dic[query] = value
             return
@@ -460,7 +459,7 @@ def dict_set(
             f"not_exist_ok=False and the single component query '{query}' is not a key in dic {dic}"
         )
 
-    # use_dpath and "/" in query
+    # "/" in query
     components = validate_query_and_break_to_components(query)
     fixed_parameters = {
         "query": components,

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -358,12 +358,13 @@ def set_values(
 def dict_get(
     dic: dict,
     query: str,
-    use_dpath: bool = True,
     not_exist_ok: bool = False,
     default: Any = None,
 ):
-    if use_dpath and "/" in query:
-        components = validate_query_and_break_to_components(query)
+    if len(query.strip()) == 0:
+        raise ValueError(f"Can not process the empty query received: '{query}'.")
+    components = validate_query_and_break_to_components(query)
+    if len(components) > 1:
         try:
             success, values = get_values(dic, components, -1 * len(components))
             if not success:
@@ -382,8 +383,9 @@ def dict_get(
                 f'query "{query}" did not match any item in dict: {dic}'
             ) from e
 
-    if query.strip() in dic:
-        return dic[query.strip()]
+    # len(components) == 1
+    if components[0] in dic:
+        return dic[components[0]]
 
     if not_exist_ok:
         return default

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -178,16 +178,20 @@ def dict_delete(
 ):
     # We remove from dic the value from each and every element lead to by a path matching the query.
     # If remove_empty_ancestors=True, and the removal of any such value leaves its containing element (list or dict)
-    # within dic empty -- remove that element as well, and continue recursively
+    # within dic empty -- remove that element as well, and continue recursively, but stop one step before deleting dic
+    # altogether, even if became {}. If successful, changes dic into its new shape
+
+    if dic is None or not isinstance(dic, (list, dict)):
+        raise ValueError(
+            f"dic {dic} is either None or not a list nor a dict. Can not delete from it."
+        )
+
+    if len(query) == 0:
+        raise ValueError(
+            "Query is an empty string, implying the deletion of dic as a whole. This can not be done via this function call."
+        )
+
     qpath = validate_query_and_break_to_components(query)
-    if len(qpath) == 1:
-        if qpath[0] in dic:
-            dic.pop(qpath[0])
-            return
-        if not not_exist_ok:
-            raise ValueError(
-                f"An attempt to delete from dictionary {dic}, an element {query}, that does not exist in the dictionary"
-            )
 
     try:
         success, new_val = delete_values(
@@ -196,10 +200,17 @@ def dict_delete(
             index_into_query=(-1) * len(qpath),
             remove_empty_ancestors=remove_empty_ancestors,
         )
-        if not success and not not_exist_ok:
+
+        if success:
+            if new_val == {}:
+                dic.clear()
+            return
+
+        if not not_exist_ok:
             raise ValueError(
-                f"An attempt to delete from dictionary {dic}, an element {query}, that does not exist in the dictionary"
+                f"An attempt to delete from dictionary {dic}, an element {query}, that does not exist in the dictionary, while not_exist_ok=False"
             )
+
     except Exception as e:
         raise ValueError(f"query {query} matches no path in dictionary {dic}") from e
 
@@ -262,15 +273,15 @@ def set_values(
         return (True, value)  # matched query all along!
 
     # current_element should be a list or dict: a containing element
-    if current_element and not isinstance(current_element, (list, dict)):
+    if current_element is not None and not isinstance(current_element, (list, dict)):
         current_element = None  # give it a chance to become what is needed, if allowed
 
-    if not current_element and not fixed_parameters["generate_if_not_exists"]:
+    if current_element is None and not fixed_parameters["generate_if_not_exists"]:
         return (False, None)
     component = fixed_parameters["query"][index_into_query]
 
     if component == "*":
-        if current_element and set_multiple:
+        if current_element is not None and set_multiple:
             if isinstance(current_element, dict) and len(current_element) != len(value):
                 return (False, None)
             if isinstance(current_element, list) and len(current_element) > len(value):
@@ -280,8 +291,14 @@ def set_values(
                     return (False, None)
                 # current_element must be a list, extend current_element to the length needed
                 current_element.extend([None] * (len(value) - len(current_element)))
-        if not current_element:
-            current_element = [None] * (len(value) if set_multiple else 1)
+        if current_element is None:
+            current_element = [None] * (
+                len(value)
+                if set_multiple
+                else 1
+                if (not isinstance(value, list) or len(value) > 0)
+                else 0
+            )
         # now current_element is of size suiting value
         if isinstance(current_element, dict):
             keys = sorted(current_element.keys())
@@ -305,31 +322,26 @@ def set_values(
 
             except:
                 continue
-        return (any_success, current_element)
+        return (any_success or len(keys) == 0, current_element)
 
     # component is an index into a list or a key into a dictionary
     if indx.match(component):
-        if current_element and not isinstance(current_element, list):
+        if current_element is None or not isinstance(current_element, list):
             if not fixed_parameters["generate_if_not_exists"]:
                 return (False, None)
             current_element = []
+        # current_element is a list
         component = int(component)
-        if (
-            current_element and component >= len(current_element)
-        ) or not current_element:
+        if component >= len(current_element):
             if not fixed_parameters["generate_if_not_exists"]:
                 return (False, None)
             # extend current_element to the length needed
-            if not current_element:
-                current_element = []
             current_element.extend([None] * (component + 1 - len(current_element)))
         next_current_element = current_element[component]
     else:  # component is a key into a dictionary
-        if current_element and not isinstance(current_element, dict):
+        if current_element is None or not isinstance(current_element, dict):
             if not fixed_parameters["generate_if_not_exists"]:
                 return (False, None)
-            current_element = {}
-        if not current_element:
             current_element = {}
         if (
             component not in current_element
@@ -363,7 +375,8 @@ def dict_get(
     default: Any = None,
 ):
     if len(query.strip()) == 0:
-        raise ValueError(f"Can not process the empty query received: '{query}'.")
+        return dic
+
     components = validate_query_and_break_to_components(query)
     if len(components) > 1:
         try:
@@ -445,22 +458,38 @@ def dict_set(
     value: Any,
     not_exist_ok=True,
     set_multiple=False,
-):
-    if set_multiple and (
-        not isinstance(value, list) or len(value) == 0 or "*" not in query
-    ):
+):  # sets dic to its new value
+    if dic is None or not isinstance(dic, (list, dict)):
         raise ValueError(
-            f"set_multiple == True, but can not tell what or where to break up: either value, {value}, is not a list of len > 0, or '*' is not in query '{query}'"
-        )
-    if "/" not in query:
-        if query.strip() in dic or not_exist_ok:
-            dic[query] = value
-            return
-        raise ValueError(
-            f"not_exist_ok=False and the single component query '{query}' is not a key in dic {dic}"
+            f"Can not change dic that is either None or not a dict nor list. Got dic = {dic}"
         )
 
-    # "/" in query
+    if query.strip() == "":
+        # change the whole input dic, as dic indeed matches ""
+        if isinstance(dic, dict):
+            if not isinstance(value, dict):
+                raise ValueError(
+                    f"Through an empty query, trying to set a whole new value, {value}, to the whole of dic, {dic}, but value is not a dict"
+                )
+            dic.clear()
+            dic.update(value)
+            return
+
+        if isinstance(dic, list):
+            if not isinstance(value, list):
+                raise ValueError(
+                    f"Through an empty query, trying to set a whole new value, {value}, to the whole of dic, {dic}, but value is not a list"
+                )
+            dic.clear()
+            dic.extend(value)
+            return
+
+    if set_multiple:
+        if not isinstance(value, list) or len(value) == 0:
+            raise ValueError(
+                f"set_multiple=True, but value, {value}, can not be broken up, as either it is not a list or it is an empty list"
+            )
+
     components = validate_query_and_break_to_components(query)
     fixed_parameters = {
         "query": components,

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -450,7 +450,7 @@ def dict_set(
         not isinstance(value, list) or len(value) == 0 or "*" not in query
     ):
         raise ValueError(
-            f"set_multiple == True, and yet value, {value}, is not a list or '*' is not in query '{query}'"
+            f"set_multiple == True, but can not tell what or where to break up: either value, {value}, is not a list of len > 0, or '*' is not in query '{query}'"
         )
     if "/" not in query:
         if query.strip() in dic or not_exist_ok:

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -233,7 +233,8 @@ def get_values(
             except:
                 continue
 
-        return (len(to_ret) > 0, to_ret)
+        return (len(to_ret) > 0 or index_into_query == -1, to_ret)
+        # when * is the last component, it refers to 'all the contents' of an empty list being current_element.
     # next_component is indx or name, current_element must be a list or a dict
     if indx.match(component):
         component = int(component)

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -278,8 +278,8 @@ def set_values(
 
     if current_element is None and not fixed_parameters["generate_if_not_exists"]:
         return (False, None)
-    component = fixed_parameters["query"][index_into_query]
 
+    component = fixed_parameters["query"][index_into_query]
     if component == "*":
         if current_element is not None and set_multiple:
             if isinstance(current_element, dict) and len(current_element) != len(value):
@@ -291,13 +291,14 @@ def set_values(
                     return (False, None)
                 # current_element must be a list, extend current_element to the length needed
                 current_element.extend([None] * (len(value) - len(current_element)))
-        if current_element is None:
+        if current_element is None or current_element == []:
             current_element = [None] * (
                 len(value)
                 if set_multiple
-                else 1
-                if (not isinstance(value, list) or len(value) > 0)
-                else 0
+                else value is None
+                or not isinstance(value, list)
+                or len(value) > 0
+                or index_into_query < -1
             )
         # now current_element is of size suiting value
         if isinstance(current_element, dict):
@@ -322,7 +323,10 @@ def set_values(
 
             except:
                 continue
-        return (any_success or len(keys) == 0, current_element)
+        return (
+            any_success or (len(keys) == 0 and index_into_query == -1),
+            current_element,
+        )
 
     # component is an index into a list or a key into a dictionary
     if indx.match(component):
@@ -467,7 +471,7 @@ def dict_set(
     if query.strip() == "":
         # change the whole input dic, as dic indeed matches ""
         if isinstance(dic, dict):
-            if not isinstance(value, dict):
+            if value is None or not isinstance(value, dict):
                 raise ValueError(
                     f"Through an empty query, trying to set a whole new value, {value}, to the whole of dic, {dic}, but value is not a dict"
                 )
@@ -476,7 +480,7 @@ def dict_set(
             return
 
         if isinstance(dic, list):
-            if not isinstance(value, list):
+            if value is None or not isinstance(value, list):
                 raise ValueError(
                     f"Through an empty query, trying to set a whole new value, {value}, to the whole of dic, {dic}, but value is not a list"
                 )
@@ -485,7 +489,7 @@ def dict_set(
             return
 
     if set_multiple:
-        if not isinstance(value, list) or len(value) == 0:
+        if value is None or not isinstance(value, list) or len(value) == 0:
             raise ValueError(
                 f"set_multiple=True, but value, {value}, can not be broken up, as either it is not a list or it is an empty list"
             )

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -1047,7 +1047,6 @@ class MetricPipeline(MultiStreamOperator, Metric):
                 [f"score/instance/{self.main_score}", "score/instance/score"],
                 [f"score/global/{self.main_score}", "score/global/score"],
             ],
-            use_query=True,
         )
 
     def process(self, multi_stream: MultiStream) -> MultiStream:

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -175,7 +175,7 @@ class MapInstanceValues(StreamInstanceOperator):
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
     ) -> Dict[str, Any]:
         for key, mapper in self.mappers.items():
-            value = dict_get(instance, key, use_dpath=self.use_query)
+            value = dict_get(instance, key)
             if value is not None:
                 if (self.process_every_value is True) and (not isinstance(value, list)):
                     raise ValueError(
@@ -397,7 +397,6 @@ class InstanceFieldOperator(StreamInstanceOperator):
                 old_value = dict_get(
                     instance,
                     from_field,
-                    use_dpath=self.use_query,
                     default=self.get_default,
                     not_exist_ok=self.not_exist_ok,
                 )
@@ -539,7 +538,6 @@ class Augmentor(StreamInstanceOperator):
                 old_value = dict_get(
                     instance,
                     field_name,
-                    use_dpath=True,
                     default="",
                     not_exist_ok=False,
                 )
@@ -816,7 +814,7 @@ class ListFieldValues(StreamInstanceOperator):
     ) -> Dict[str, Any]:
         values = []
         for field_name in self.fields:
-            values.append(dict_get(instance, field_name, use_dpath=self.use_query))
+            values.append(dict_get(instance, field_name))
         instance[self.to_field] = values
         return instance
 
@@ -843,7 +841,7 @@ class ZipFieldValues(StreamInstanceOperator):
     ) -> Dict[str, Any]:
         values = []
         for field_name in self.fields:
-            values.append(dict_get(instance, field_name, use_dpath=self.use_query))
+            values.append(dict_get(instance, field_name))
         if self.longest:
             zipped = zip_longest(*values)
         else:
@@ -863,8 +861,8 @@ class IndexOf(StreamInstanceOperator):
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
     ) -> Dict[str, Any]:
-        lst = dict_get(instance, self.search_in, use_dpath=self.use_query)
-        item = dict_get(instance, self.index_of, use_dpath=self.use_query)
+        lst = dict_get(instance, self.search_in)
+        item = dict_get(instance, self.index_of)
         instance[self.to_field] = lst.index(item)
         return instance
 
@@ -884,8 +882,8 @@ class TakeByField(StreamInstanceOperator):
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
     ) -> Dict[str, Any]:
-        value = dict_get(instance, self.field, use_dpath=self.use_query)
-        index_value = dict_get(instance, self.index, use_dpath=self.use_query)
+        value = dict_get(instance, self.field)
+        index_value = dict_get(instance, self.index)
         instance[self.to_field] = value[index_value]
         return instance
 
@@ -1031,7 +1029,7 @@ class CastFields(StreamInstanceOperator):
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
     ) -> Dict[str, Any]:
         for field_name, type in self.fields.items():
-            value = dict_get(instance, field_name, use_dpath=self.use_nested_query)
+            value = dict_get(instance, field_name)
             if self.process_every_value:
                 assert isinstance(
                     value, list
@@ -1709,7 +1707,7 @@ class EncodeLabels(StreamInstanceOperator):
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
     ) -> Dict[str, Any]:
         for field_name in self.fields:
-            values = dict_get(instance, field_name, use_dpath=True)
+            values = dict_get(instance, field_name)
             values_was_a_list = isinstance(values, list)
             if not isinstance(values, list):
                 values = [values]
@@ -1781,9 +1779,7 @@ class DeterministicBalancer(StreamRefiner):
     fields: List[str]
 
     def signature(self, instance):
-        return str(
-            tuple(dict_get(instance, field, use_dpath=True) for field in self.fields)
-        )
+        return str(tuple(dict_get(instance, field) for field in self.fields))
 
     def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
         counter = collections.Counter()
@@ -1837,7 +1833,7 @@ class LengthBalancer(DeterministicBalancer):
     def signature(self, instance):
         total_len = 0
         for field_name in self.fields:
-            total_len += len(dict_get(instance, field_name, use_dpath=True))
+            total_len += len(dict_get(instance, field_name))
         for i, val in enumerate(self.segments_boundaries):
             if total_len < val:
                 return i

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1703,7 +1703,10 @@ class EncodeLabels(StreamInstanceOperator):
                 instance,
                 field_name,
                 new_values,
-                set_multiple="*" in field_name,
+                not_exist_ok=False,  # the values to encode where just taken from there
+                set_multiple="*" in field_name
+                and isinstance(new_values, list)
+                and len(new_values) > 0,
             )
 
         return instance

--- a/src/unitxt/struct_data_operators.py
+++ b/src/unitxt/struct_data_operators.py
@@ -255,11 +255,11 @@ class TruncateTableCells(StreamInstanceOperator):
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
     ) -> Dict[str, Any]:
-        table = dict_get(instance, self.table, use_dpath=self.use_query)
+        table = dict_get(instance, self.table)
 
         answers = []
         if self.text_output is not None:
-            answers = dict_get(instance, self.text_output, use_dpath=self.use_query)
+            answers = dict_get(instance, self.text_output)
 
         self.truncate_table(table_content=table, answers=answers)
 
@@ -337,7 +337,7 @@ class SerializeTableRowAsText(StreamInstanceOperator):
     ) -> Dict[str, Any]:
         linearized_str = ""
         for field in self.fields:
-            value = dict_get(instance, field, use_dpath=False)
+            value = dict_get(instance, field)
             if self.max_cell_length is not None:
                 truncated_value = truncate_cell(value, self.max_cell_length)
                 if truncated_value is not None:
@@ -367,7 +367,7 @@ class SerializeTableRowAsList(StreamInstanceOperator):
     ) -> Dict[str, Any]:
         linearized_str = ""
         for field in self.fields:
-            value = dict_get(instance, field, use_dpath=False)
+            value = dict_get(instance, field)
             if self.max_cell_length is not None:
                 truncated_value = truncate_cell(value, self.max_cell_length)
                 if truncated_value is not None:
@@ -432,8 +432,8 @@ class ListToKeyValPairs(StreamInstanceOperator):
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
     ) -> Dict[str, Any]:
-        keylist = dict_get(instance, self.fields[0], use_dpath=self.use_query)
-        valuelist = dict_get(instance, self.fields[1], use_dpath=self.use_query)
+        keylist = dict_get(instance, self.fields[0])
+        valuelist = dict_get(instance, self.fields[1])
 
         output_dict = {}
         for key, value in zip(keylist, valuelist):

--- a/src/unitxt/struct_data_operators.py
+++ b/src/unitxt/struct_data_operators.py
@@ -250,7 +250,6 @@ class TruncateTableCells(StreamInstanceOperator):
     max_length: int = 15
     table: str = None
     text_output: Optional[str] = None
-    use_query: bool = False
 
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
@@ -427,7 +426,6 @@ class ListToKeyValPairs(StreamInstanceOperator):
 
     fields: List[str]
     to_field: str
-    use_query: bool = False
 
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -15,38 +15,32 @@ class TestDictUtils(UnitxtTestCase):
         self.assertEqual(dict_get(dic, "d/8", not_exist_ok=True), None)
         with self.assertRaises(ValueError):
             dict_get(dic, "d/2")
-        self.assertEqual(dict_get(dic, "f", use_dpath=True), [])
-        self.assertEqual(dict_get(dic, "f/0", use_dpath=True, not_exist_ok=True), None)
+        self.assertEqual(dict_get(dic, "f"), [])
+        self.assertEqual(dict_get(dic, "f/0", not_exist_ok=True), None)
         with self.assertRaises(ValueError):
             dict_get(dic, "f/0")
 
     def test_nested_get(self):
         dic = {"a": {"b": 1, "c": 2, "f": [3, 4], "g": []}}
-        self.assertEqual(dict_get(dic, "a/b", use_dpath=True), 1)
-        self.assertEqual(dict_get(dic, "a/c", use_dpath=True), 2)
-        self.assertEqual(dict_get(dic, "a/d", use_dpath=True, not_exist_ok=True), None)
+        self.assertEqual(dict_get(dic, "a/b"), 1)
+        self.assertEqual(dict_get(dic, "a/c"), 2)
+        self.assertEqual(dict_get(dic, "a/d", not_exist_ok=True), None)
         with self.assertRaises(ValueError):
-            dict_get(dic, "a/d", use_dpath=True)
-        self.assertEqual(dict_get(dic, "a/f", use_dpath=True), [3, 4])
-        self.assertEqual(dict_get(dic, "a/g", use_dpath=True), [])
+            dict_get(dic, "a/d")
+        self.assertEqual(dict_get(dic, "a/f"), [3, 4])
+        self.assertEqual(dict_get(dic, "a/g"), [])
 
     def test_query_get(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}
-        self.assertEqual(dict_get(dic, "a/*/b", use_dpath=True), [1, 2])
+        self.assertEqual(dict_get(dic, "a/*/b"), [1, 2])
         dic = {"a": [{"b": 1}, {"b": 2}], "c": [{"b": 3}, {"b": 4}]}
-        self.assertEqual(dict_get(dic, "*/1/b", use_dpath=True), [2, 4])
+        self.assertEqual(dict_get(dic, "*/1/b"), [2, 4])
         dic = {"references": ["r1", "r2", "r3"]}
-        self.assertEqual(
-            dict_get(dic, "references/*", use_dpath=True), ["r1", "r2", "r3"]
-        )
-        self.assertEqual(
-            dict_get(dic, "references/", use_dpath=True), ["r1", "r2", "r3"]
-        )
-        self.assertEqual(
-            dict_get(dic, "references", use_dpath=True), ["r1", "r2", "r3"]
-        )
+        self.assertEqual(dict_get(dic, "references/*"), ["r1", "r2", "r3"])
+        self.assertEqual(dict_get(dic, "references/"), ["r1", "r2", "r3"])
+        self.assertEqual(dict_get(dic, "references"), ["r1", "r2", "r3"])
         with self.assertRaises(ValueError):
-            dict_get(dic, "references+#/^!", use_dpath=True)
+            dict_get(dic, "references+#/^!")
 
     def test_query_delete(self):
         dic = {"a": [{"b": 1}, {"b": 2, "c": 3}]}
@@ -110,8 +104,8 @@ class TestDictUtils(UnitxtTestCase):
         with self.assertRaises(ValueError):
             dict_delete(dic, "a/2/3")
 
-        self.assertEqual("i", dict_get(dic, "a/0/0/0/0", use_dpath=True))
-        self.assertEqual("i", dict_get(dic, "a/0/0/0/0/0/0/0", use_dpath=True))
+        self.assertEqual("i", dict_get(dic, "a/0/0/0/0"))
+        self.assertEqual("i", dict_get(dic, "a/0/0/0/0/0/0/0"))
         with self.assertRaises(ValueError):
             dict_get(dic, "a/0/0/0/*/0")
 

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -28,7 +28,17 @@ class TestDictUtils(UnitxtTestCase):
         with self.assertRaises(ValueError):
             dict_get(dic, "a/d")
         self.assertEqual(dict_get(dic, "a/f"), [3, 4])
+        self.assertEqual(dict_get(dic, "a/f/0"), 3)
+        self.assertEqual(dict_get(dic, "a/f/1"), 4)
+        self.assertEqual(dict_get(dic, "a/f/*"), [3, 4])
+        with self.assertRaises(ValueError):
+            dict_get(dic, "a/f/2")
+        with self.assertRaises(ValueError):
+            dict_get(dic, "a/f/1/m")
         self.assertEqual(dict_get(dic, "a/g"), [])
+        self.assertEqual(dict_get(dic, "a/g/*"), [])
+        with self.assertRaises(ValueError):
+            dict_get(dic, "a/g/0")
 
     def test_query_get(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}
@@ -58,6 +68,8 @@ class TestDictUtils(UnitxtTestCase):
         dic = {"references": ["r1", "r2", "r3"]}
         dict_delete(dic, "references/*")
         self.assertEqual({"references": []}, dic)
+        dict_delete(dic, "references")
+        self.assertEqual({}, dic)
 
         dic = {"references": ["r1", "r2", "r3"]}
         dict_delete(dic, "references/")
@@ -150,9 +162,12 @@ class TestDictUtils(UnitxtTestCase):
         self.assertDictEqual(dic, {"a": [{"b": 3}, {"b": 4}]})
         dict_set(dic, "a/*/b", [3, 4], set_multiple=False)
         self.assertDictEqual(dic, {"a": [{"b": [3, 4]}, {"b": [3, 4]}]})
-
+        dict_set(dic, "a/0/c", [])
+        self.assertDictEqual({"a": [{"b": [3, 4], "c": []}, {"b": [3, 4]}]}, dic)
         dict_set(dic, "a/0/b/c/*/d", [5, 6], set_multiple=False)
-        self.assertDictEqual(dic, {"a": [{"b": {"c": [{"d": [5, 6]}]}}, {"b": [3, 4]}]})
+        self.assertDictEqual(
+            dic, {"a": [{"b": {"c": [{"d": [5, 6]}]}, "c": []}, {"b": [3, 4]}]}
+        )
 
         dict_set(dic, "a/0/c/d/*/e/*/f", [7, 8], set_multiple=True)
         # breaks up just one, smoothly

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -103,6 +103,11 @@ class TestDictUtils(UnitxtTestCase):
         self.assertEqual({"a": [{"c": 3}], "d": 4}, dic)
         dict_delete(dic, "a/*/c", remove_empty_ancestors=True)
         self.assertEqual({"d": 4}, dic)
+        dict_delete(dic, "d", remove_empty_ancestors=True)
+        self.assertEqual({}, dic)
+        dic = {"c": {"d": {"e": 4}}}
+        dict_delete(dic, "c/d/e", remove_empty_ancestors=True)
+        self.assertEqual({}, dic)
         dic = {
             "a": [
                 {"b": 1},
@@ -260,6 +265,19 @@ class TestDictUtils(UnitxtTestCase):
             dic,
         )
 
+        dict_set(dic, "a/1/c/d/*/e/*/f/*/h", [])
+        self.assertDictEqual(
+            {
+                "c": 30,
+                "a": [
+                    {"c": {"d": [{"e": [{"f": 7}]}, {"e": [{"f": 8}]}]}},
+                    {"c": {"d": [{"e": [{"f": [{"h": []}]}]}]}},
+                ],
+                "b": 20,
+            },
+            dic,
+        )
+
         dic = {"c": [{"b": 3}, {"b": 4}], "a": [{"b": 1}, {"b": 2}]}
         dict_set(dic, "*/1/b", [5, 6], set_multiple=True)
         # ordered paths alphabetically before assigning
@@ -311,6 +329,26 @@ class TestDictUtils(UnitxtTestCase):
         dic = {"a": {"b": []}}
         dict_set(dic, "a/b/2/c", [3, 4])
         self.assertDictEqual(dic, {"a": {"b": [None, None, {"c": [3, 4]}]}})
+
+        dic = {"a": {"b": []}}
+        dict_set(dic, "c", None)
+        self.assertDictEqual({"a": {"b": []}, "c": None}, dic)
+        dict_set(dic, "d/e/*/f/*", None)
+        self.assertDictEqual(
+            {"a": {"b": []}, "c": None, "d": {"e": [{"f": [None]}]}}, dic
+        )
+        dict_set(dic, "d/e/*/f/", None)
+        self.assertDictEqual(
+            {"a": {"b": []}, "c": None, "d": {"e": [{"f": [None]}]}}, dic
+        )
+        dict_set(dic, "d/e/*/f", None)
+        self.assertDictEqual(
+            {"a": {"b": []}, "c": None, "d": {"e": [{"f": None}]}}, dic
+        )
+        dict_set(dic, "a/b/*", 5)
+        self.assertDictEqual(
+            {"a": {"b": [5]}, "c": None, "d": {"e": [{"f": None}]}}, dic
+        )
 
         dic = {"a": {"b": []}}
         with self.assertRaises(ValueError):

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -54,6 +54,9 @@ class TestDictUtils(UnitxtTestCase):
             dict_get(dic, "l/*/*/*")
 
     def test_nested_get(self):
+        dic = {"x/y": 3}
+        self.assertEqual(dict_get(dic, "x/y"), 3)
+
         dic = {"a": {"b": 1, "c": 2, "f": [3, 4], "g": []}}
         self.assertEqual(dict_get(dic, "a/b"), 1)
         self.assertEqual(dict_get(dic, "a/c"), 2)
@@ -95,6 +98,10 @@ class TestDictUtils(UnitxtTestCase):
         dic = {"a": 1, "b": 2, "c": 3}
         dict_delete(dic, "a")
         self.assertDictEqual({"b": 2, "c": 3}, dic)
+        dic = {"x/y": 1, "b": 2, "c": 3}
+        dict_delete(dic, "x/y")
+        self.assertDictEqual({"b": 2, "c": 3}, dic)
+
         dic = {"a": [{"b": 1}, {"b": 2, "c": 3}]}
         dict_delete(dic, "a/*/b")
         self.assertEqual({"a": [{}, {"c": 3}]}, dic)
@@ -220,6 +227,10 @@ class TestDictUtils(UnitxtTestCase):
         self.assertDictEqual(dic, {"a": 3, "b": 4, "c": 5})
         dict_set(dic, "", {"a": 6, "b": 8})
         self.assertDictEqual({"a": 6, "b": 8}, dic)
+        dic = {"x/y": 1, "b": 2}
+        dict_set(dic, "x/y", 3)
+        self.assertDictEqual(dic, {"x/y": 3, "b": 2})
+
         dic = [1, 2, 3]
         dict_set(dic, "", [])
         self.assertEqual([], dic)

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -135,26 +135,26 @@ class TestDictUtils(UnitxtTestCase):
 
     def test_nested_set(self):
         dic = {"a": {"b": 1, "c": 2}}
-        dict_set(dic, "a/b", 3, use_dpath=True)
+        dict_set(dic, "a/b", 3)
         self.assertDictEqual(dic, {"a": {"b": 3, "c": 2}})
-        dict_set(dic, "a/c", 4, use_dpath=True)
+        dict_set(dic, "a/c", 4)
         self.assertDictEqual(dic, {"a": {"b": 3, "c": 4}})
         with self.assertRaises(ValueError):
-            dict_set(dic, "a/d", 5, use_dpath=True, not_exist_ok=False)
-        dict_set(dic, "a/d", 5, use_dpath=True)
+            dict_set(dic, "a/d", 5, not_exist_ok=False)
+        dict_set(dic, "a/d", 5)
         self.assertDictEqual(dic, {"a": {"b": 3, "c": 4, "d": 5}})
 
     def test_query_set(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}
-        dict_set(dic, "a/*/b", [3, 4], use_dpath=True, set_multiple=True)
+        dict_set(dic, "a/*/b", [3, 4], set_multiple=True)
         self.assertDictEqual(dic, {"a": [{"b": 3}, {"b": 4}]})
-        dict_set(dic, "a/*/b", [3, 4], use_dpath=True, set_multiple=False)
+        dict_set(dic, "a/*/b", [3, 4], set_multiple=False)
         self.assertDictEqual(dic, {"a": [{"b": [3, 4]}, {"b": [3, 4]}]})
 
-        dict_set(dic, "a/0/b/c/*/d", [5, 6], use_dpath=True, set_multiple=False)
+        dict_set(dic, "a/0/b/c/*/d", [5, 6], set_multiple=False)
         self.assertDictEqual(dic, {"a": [{"b": {"c": [{"d": [5, 6]}]}}, {"b": [3, 4]}]})
 
-        dict_set(dic, "a/0/c/d/*/e/*/f", [7, 8], use_dpath=True, set_multiple=True)
+        dict_set(dic, "a/0/c/d/*/e/*/f", [7, 8], set_multiple=True)
         # breaks up just one, smoothly
         self.assertDictEqual(
             dic,
@@ -170,7 +170,7 @@ class TestDictUtils(UnitxtTestCase):
         )
 
         dic = {"c": [{"b": 3}, {"b": 4}], "a": [{"b": 1}, {"b": 2}]}
-        dict_set(dic, "*/1/b", [5, 6], use_dpath=True, set_multiple=True)
+        dict_set(dic, "*/1/b", [5, 6], set_multiple=True)
         # ordered paths alphabetically before assigning
         self.assertDictEqual(
             dic, {"a": [{"b": 1}, {"b": 5}], "c": [{"b": 3}, {"b": 6}]}
@@ -181,7 +181,6 @@ class TestDictUtils(UnitxtTestCase):
                 dic,
                 "*/1/b",
                 [50, 60, 70],
-                use_dpath=True,
                 set_multiple=True,
                 not_exist_ok=False,
             )
@@ -193,7 +192,6 @@ class TestDictUtils(UnitxtTestCase):
                 dic,
                 "*/1/b",
                 [50, 60, 70],
-                use_dpath=True,
                 set_multiple=True,
                 not_exist_ok=False,
             )
@@ -203,7 +201,6 @@ class TestDictUtils(UnitxtTestCase):
                 dic,
                 "*/1/b",
                 [50],
-                use_dpath=True,
                 set_multiple=True,
                 not_exist_ok=False,
             )
@@ -212,7 +209,6 @@ class TestDictUtils(UnitxtTestCase):
             dic,
             "*/1/b",
             [50, 60, 70],
-            use_dpath=True,
             set_multiple=True,
         )
         # list extends to the length of value
@@ -221,22 +217,21 @@ class TestDictUtils(UnitxtTestCase):
         )
 
         dic = {"a": {"b": []}}
-        dict_set(dic, "a/b/2/c", [3, 4], use_dpath=True)
+        dict_set(dic, "a/b/2/c", [3, 4])
         self.assertDictEqual(dic, {"a": {"b": [None, None, {"c": [3, 4]}]}})
 
         dic = {"a": {"b": []}}
         with self.assertRaises(ValueError):
-            dict_set(dic, "a/b/2/c", [3, 4], use_dpath=True, not_exist_ok=False)
+            dict_set(dic, "a/b/2/c", [3, 4], not_exist_ok=False)
 
     def test_query_set_with_multiple_non_existing(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}
-        dict_set(dic, "a/*/c", [3, 4], use_dpath=True, set_multiple=True)
+        dict_set(dic, "a/*/c", [3, 4], set_multiple=True)
         self.assertDictEqual({"a": [{"b": 1, "c": 3}, {"b": 2, "c": 4}]}, dic)
         dict_set(
             dic,
             "a/*/c",
             [3, 4],
-            use_dpath=True,
             set_multiple=False,
             not_exist_ok=True,
         )
@@ -247,7 +242,6 @@ class TestDictUtils(UnitxtTestCase):
             dic,
             "a/*/d",
             [3, 4, 5],
-            use_dpath=True,
             set_multiple=True,
             not_exist_ok=True,
         )
@@ -255,10 +249,10 @@ class TestDictUtils(UnitxtTestCase):
 
     def test_adding_one_new_field(self):
         dic = {"a": {"b": {"c": 0}}}
-        dict_set(dic, "a/b/d", 1, use_dpath=True)
+        dict_set(dic, "a/b/d", 1)
         self.assertDictEqual(dic, {"a": {"b": {"c": 0, "d": 1}}})
 
     def test_adding_one_new_field_nested(self):
         dic = {"d": 0}
-        dict_set(dic, "/a/b/d", 1, use_dpath=True)
+        dict_set(dic, "/a/b/d", 1)
         self.assertDictEqual(dic, {"a": {"b": {"d": 1}}, "d": 0})

--- a/tests/library/test_function_operators.py
+++ b/tests/library/test_function_operators.py
@@ -26,7 +26,7 @@ class TestFunctionOperators(UnitxtTestCase):
         operator = SequentialOperator(
             [
                 Apply(function=dict, to_field="t"),
-                CopyFields(field_to_field={"a": "t/a", "b": "t/b"}, use_query=True),
+                CopyFields(field_to_field={"a": "t/a", "b": "t/b"}),
                 Apply("t", function=json.dumps, to_field="t"),
             ]
         )

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -589,7 +589,6 @@ class TestOperators(UnitxtTestCase):
                 field="references/0",
                 unallowed_values=["none"],
                 process_every_value=False,
-                use_query=True,
             ),
             inputs=inputs,
             targets=targets,
@@ -601,7 +600,6 @@ class TestOperators(UnitxtTestCase):
                 field="references/1",
                 unallowed_values=["none"],
                 process_every_value=False,
-                use_query=True,
             ),
             inputs=inputs,
             targets=[
@@ -615,7 +613,6 @@ class TestOperators(UnitxtTestCase):
             operator=RemoveValues(
                 field="references",
                 unallowed_values=["none"],
-                use_query=True,
                 process_every_value=True,
             ),
             inputs=inputs,
@@ -769,7 +766,7 @@ class TestOperators(UnitxtTestCase):
         ]
 
         check_operator(
-            operator=AddFields(fields={"a/c": 5}, use_query=True),
+            operator=AddFields(fields={"a/c": 5}),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -805,9 +802,7 @@ class TestOperators(UnitxtTestCase):
         ]
 
         outputs = check_operator(
-            operator=AddFields(
-                fields={"c/d": alist}, use_deepcopy=True, use_query=True
-            ),
+            operator=AddFields(fields={"c/d": alist}, use_deepcopy=True),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -1875,7 +1870,7 @@ class TestOperators(UnitxtTestCase):
 
         # to field is structured:
         check_operator(
-            operator=RenameFields(field_to_field={"b": "c/d"}, use_query=True),
+            operator=RenameFields(field_to_field={"b": "c/d"}),
             inputs=inputs,
             targets=[{"a": 1, "c": {"d": 2}}, {"a": 2, "c": {"d": 3}}],
             tester=self,
@@ -1883,7 +1878,7 @@ class TestOperators(UnitxtTestCase):
 
         # to field is structured, to stand in place of from field:
         check_operator(
-            operator=RenameFields(field_to_field={"b": "b/d"}, use_query=True),
+            operator=RenameFields(field_to_field={"b": "b/d"}),
             inputs=inputs,
             targets=[{"a": 1, "b": {"d": 2}}, {"a": 2, "b": {"d": 3}}],
             tester=self,
@@ -1891,7 +1886,7 @@ class TestOperators(UnitxtTestCase):
 
         # to field is structured, to stand in place of from field, from field is deeper:
         check_operator(
-            operator=RenameFields(field_to_field={"b/c/e": "b/d"}, use_query=True),
+            operator=RenameFields(field_to_field={"b/c/e": "b/d"}),
             inputs=[
                 {"a": 1, "b": {"c": {"e": 2, "f": 20}}},
                 {"a": 2, "b": {"c": {"e": 3, "f": 30}}},
@@ -1905,7 +1900,7 @@ class TestOperators(UnitxtTestCase):
 
         # to field is structured, from field is structured too, different fields:
         check_operator(
-            operator=RenameFields(field_to_field={"b/c/e": "g/h"}, use_query=True),
+            operator=RenameFields(field_to_field={"b/c/e": "g/h"}),
             inputs=[
                 {"a": 1, "b": {"c": {"e": 2, "f": 20}}},
                 {"a": 2, "b": {"c": {"e": 3, "f": 30}}},
@@ -1919,9 +1914,7 @@ class TestOperators(UnitxtTestCase):
 
         # both from and to field are structured, different only in the middle of the path:
         check_operator(
-            operator=RenameFields(
-                field_to_field={"a/b/c/d": "a/g/c/d"}, use_query=True
-            ),
+            operator=RenameFields(field_to_field={"a/b/c/d": "a/g/c/d"}),
             inputs=[
                 {"a": {"b": {"c": {"d": {"e": 1}}}}, "b": 2},
             ],
@@ -1933,9 +1926,7 @@ class TestOperators(UnitxtTestCase):
 
         # both from and to field are structured, different down the path:
         check_operator(
-            operator=RenameFields(
-                field_to_field={"a/b/c/d": "a/b/c/f"}, use_query=True
-            ),
+            operator=RenameFields(field_to_field={"a/b/c/d": "a/b/c/f"}),
             inputs=[
                 {"a": {"b": {"c": {"d": {"e": 1}}}}, "b": 2},
             ],
@@ -2005,7 +1996,7 @@ class TestOperators(UnitxtTestCase):
         targets = [{"a": 1}, {"a": 2}]
 
         check_operator(
-            operator=CopyFields(field_to_field={"a/0": "a"}, use_query=True),
+            operator=CopyFields(field_to_field={"a/0": "a"}),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -2020,7 +2011,7 @@ class TestOperators(UnitxtTestCase):
         targets = [{"a": {"x": "test"}}, {"a": {"x": "pest"}}]
 
         check_operator(
-            operator=CopyFields(field_to_field={"a": "a/x"}, use_query=True),
+            operator=CopyFields(field_to_field={"a": "a/x"}),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -2081,16 +2072,14 @@ class TestOperators(UnitxtTestCase):
         ]
 
         check_operator(
-            operator=ZipFieldValues(fields=["a", "b"], to_field="c", use_query=True),
+            operator=ZipFieldValues(fields=["a", "b"], to_field="c"),
             inputs=inputs,
             targets=targets,
             tester=self,
         )
 
         check_operator(
-            operator=ZipFieldValues(
-                fields=["a", "b"], to_field="c", use_query=True, longest=True
-            ),
+            operator=ZipFieldValues(fields=["a", "b"], to_field="c", longest=True),
             inputs=inputs,
             targets=targets_longest,
             tester=self,
@@ -2119,7 +2108,7 @@ class TestOperators(UnitxtTestCase):
         ]
 
         check_operator(
-            operator=TakeByField(field="a", index="b", to_field="c", use_query=True),
+            operator=TakeByField(field="a", index="b", to_field="c"),
             inputs=inputs,
             targets=targets,
             tester=self,
@@ -2127,7 +2116,7 @@ class TestOperators(UnitxtTestCase):
 
         # field plays the role of to_field
         check_operator(
-            operator=TakeByField(field="a", index="b", use_query=True),
+            operator=TakeByField(field="a", index="b"),
             inputs=inputs,
             targets=[{"a": 1, "b": 0}, {"a": 1, "b": "a"}],
             tester=self,

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -2023,6 +2023,7 @@ class TestOperators(UnitxtTestCase):
             {"prediction": "blue", "references": ["blue"]},
             {"prediction": "green", "references": ["red"]},
             {"prediction": "", "references": ["red"]},
+            {"prediction": "green", "references": []},
         ]
 
         targets = [
@@ -2030,6 +2031,7 @@ class TestOperators(UnitxtTestCase):
             {"prediction": 1, "references": [1]},
             {"prediction": 2, "references": [0]},
             {"prediction": 3, "references": [0]},
+            {"prediction": 2, "references": []},
         ]
 
         check_operator(
@@ -2039,12 +2041,10 @@ class TestOperators(UnitxtTestCase):
             tester=self,
         )
 
-        inputs = [
-            {"prediction": "green", "references": []},
-        ]
-        exception_text = "Error processing instance '0' from stream 'test' in EncodeLabels due to: set_multiple == True, but can not tell what or where to break up: either value, [], is not a list of len > 0, or '*' is not in query 'references/*'"
+        inputs = [{"prediction": "red", "references": "blue"}]
+        exception_text = "Error processing instance '0' from stream 'test' in EncodeLabels due to: query \"references/*\" did not match any item in dict: {'prediction': 'red', 'references': 'blue'}"
         check_operator_exception(
-            operator=EncodeLabels(fields=["prediction", "references/*"]),
+            operator=EncodeLabels(fields=["references/*", "prediction"]),
             inputs=inputs,
             tester=self,
             exception_text=exception_text,

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -2022,12 +2022,14 @@ class TestOperators(UnitxtTestCase):
             {"prediction": "red", "references": ["red", "blue"]},
             {"prediction": "blue", "references": ["blue"]},
             {"prediction": "green", "references": ["red"]},
+            {"prediction": "", "references": ["red"]},
         ]
 
         targets = [
             {"prediction": 0, "references": [0, 1]},
             {"prediction": 1, "references": [1]},
             {"prediction": 2, "references": [0]},
+            {"prediction": 3, "references": [0]},
         ]
 
         check_operator(
@@ -2035,6 +2037,17 @@ class TestOperators(UnitxtTestCase):
             inputs=inputs,
             targets=targets,
             tester=self,
+        )
+
+        inputs = [
+            {"prediction": "green", "references": []},
+        ]
+        exception_text = "Error processing instance '0' from stream 'test' in EncodeLabels due to: set_multiple == True, but can not tell what or where to break up: either value, [], is not a list of len > 0, or '*' is not in query 'references/*'"
+        check_operator_exception(
+            operator=EncodeLabels(fields=["prediction", "references/*"]),
+            inputs=inputs,
+            tester=self,
+            exception_text=exception_text,
         )
 
     def test_join_str(self):

--- a/tests/library/test_struct_data_operators.py
+++ b/tests/library/test_struct_data_operators.py
@@ -337,9 +337,7 @@ class TestStructDataOperators(UnitxtTestCase):
         ]
 
         check_operator(
-            operator=ListToKeyValPairs(
-                fields=["keys", "values"], to_field="kvpairs", use_query=True
-            ),
+            operator=ListToKeyValPairs(fields=["keys", "values"], to_field="kvpairs"),
             inputs=inputs,
             targets=targets,
             tester=self,


### PR DESCRIPTION
(1) removed argument use_dpath from dict_get
(2) removed argument use_dpath from dict_set
(3) removed use_query flag from all operators
(4) fixed  code of dict_get, to have *, when being last component on qpath, match an empty list too.
(5) added more tests to test_dict_utils, and improved dealing with edge-conditions