### PR TITLE
fix wrong handling of list in dict_get

### DIFF
--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -372,12 +372,6 @@ def dict_get(
                 raise ValueError(
                     f'query "{query}" did not match any item in dict: {dic}'
                 )
-            if isinstance(values, list) and len(values) == 0:
-                if not_exist_ok:
-                    return default
-                raise ValueError(
-                    f'query "{query}" did not match any item in dict: {dic} while not_exist_ok=False'
-                )
 
             return values
 

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -4,24 +4,28 @@ from tests.utils import UnitxtTestCase
 
 class TestDictUtils(UnitxtTestCase):
     def test_simple_get(self):
-        dic = {"a": 1, "b": 2, "d": [3, 4]}
+        dic = {"a": 1, "b": 2, "d": [3, 4], "f": []}
         self.assertEqual(dict_get(dic, "a"), 1)
         self.assertEqual(dict_get(dic, "b"), 2)
         self.assertEqual(dict_get(dic, "c", not_exist_ok=True), None)
         with self.assertRaises(ValueError):
             dict_get(dic, "c")
+        self.assertEqual(dict_get(dic, "d"), [3, 4])
         self.assertEqual(dict_get(dic, "d/1"), 4)
         self.assertEqual(dict_get(dic, "d/8", not_exist_ok=True), None)
         with self.assertRaises(ValueError):
             dict_get(dic, "d/2")
+        self.assertEqual(dict_get(dic, "f", use_dpath=True), [])
 
     def test_nested_get(self):
-        dic = {"a": {"b": 1, "c": 2}}
+        dic = {"a": {"b": 1, "c": 2, "f": [3, 4], "g": []}}
         self.assertEqual(dict_get(dic, "a/b", use_dpath=True), 1)
         self.assertEqual(dict_get(dic, "a/c", use_dpath=True), 2)
         self.assertEqual(dict_get(dic, "a/d", use_dpath=True, not_exist_ok=True), None)
         with self.assertRaises(ValueError):
             dict_get(dic, "a/d", use_dpath=True)
+        self.assertEqual(dict_get(dic, "a/f", use_dpath=True), [3, 4])
+        self.assertEqual(dict_get(dic, "a/g", use_dpath=True), [])
 
     def test_query_get(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}


### PR DESCRIPTION
When accessing a nested empty list, returned an error, while this is legal.

Also added tests.