### PR TITLE
To be considered once #727 is merged: Remove set_multiple from dict_set.  

### DIFF
--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -467,6 +467,7 @@ def dict_set(
     dic: dict,
     query: str,
     value: Any,
+    use_dpath=True,
     not_exist_ok=True,
     set_multiple=False,
 ):  # sets dic to its new value


### PR DESCRIPTION
Value is not to be broken into individual components to sit far from each other in dict.
Value as a whole list can readily be assigned (set to) an element in dic.  
End result is that the members of V sit together, making up a list value of an element of dic, Potentially, several copies of V are set into elements of dic, if two or more paths in dic match the query.  However the components of V never spread in dic further than sitting together in same list.
