### PR TITLE
Adding Detector metric for running any classifier from huggingface as a metric

### DIFF
--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -1974,7 +1974,7 @@ class Reward(BulkInstanceMetric):
         # compute the metric
         # add function_to_apply="none" to disable sigmoid
         return self.pipe(inputs, batch_size=self.batch_size)
-    
+
 
 class Detector(BulkInstanceMetric):
     reduction_map = {"mean": ["score"]}
@@ -2003,8 +2003,6 @@ class Detector(BulkInstanceMetric):
         predictions: List[Any],
         task_data: List[Dict],
     ) -> List[Dict[str, Any]]:
-        answers = predictions
-
         # compute the metric
         # add function_to_apply="none" to disable sigmoid
         return self.pipe(predictions, batch_size=self.batch_size)

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -1974,6 +1974,40 @@ class Reward(BulkInstanceMetric):
         # compute the metric
         # add function_to_apply="none" to disable sigmoid
         return self.pipe(inputs, batch_size=self.batch_size)
+    
+
+class Detector(BulkInstanceMetric):
+    reduction_map = {"mean": ["score"]}
+    main_score = "score"
+    batch_size: int = 32
+
+    prediction_type = "str"
+
+    model_name: str
+
+    _requirements_list: List[str] = ["transformers", "torch"]
+
+    def prepare(self):
+        super().prepare()
+        import torch
+        from transformers import pipeline
+
+        device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        self.pipe = pipeline(
+            "text-classification", model=self.model_name, device=device
+        )
+
+    def compute(
+        self,
+        references: List[List[Any]],
+        predictions: List[Any],
+        task_data: List[Dict],
+    ) -> List[Dict[str, Any]]:
+        answers = predictions
+
+        # compute the metric
+        # add function_to_apply="none" to disable sigmoid
+        return self.pipe(predictions, batch_size=self.batch_size)
 
 
 class LlamaIndexCorrectness(InstanceMetric):

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -706,7 +706,7 @@ class TestMetrics(UnitxtTestCase):
     def test_detector(self):
         metric = Detector(model_name = "MilaNLProc/bert-base-uncased-ear-misogyny")
         predictions = ["I hate women.", "I do not hate women."]
-        references = [["I hate you."], ["I love you."]]
+        references = [["I hate women."], ["I do not hate women."]]
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -711,7 +711,7 @@ class TestMetrics(UnitxtTestCase):
             metric=metric, predictions=predictions, references=references
         )
         global_target = 0.9562818706035614
-        self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
+        self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"], places=4)
 
     def test_normalized_sacrebleu(self):
         metric = NormalizedSacrebleu()

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -710,8 +710,7 @@ class TestMetrics(UnitxtTestCase):
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
-        print(outputs, '\n\n')
-        print(outputs[0]["score"]["global"]["score"])
+        
         global_target = 0.9562818706035614
         self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
 

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -702,16 +702,17 @@ class TestMetrics(UnitxtTestCase):
         global_target = 0.81649658092772
         self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
 
-
     def test_detector(self):
-        metric = Detector(model_name = "MilaNLProc/bert-base-uncased-ear-misogyny")
+        metric = Detector(model_name="MilaNLProc/bert-base-uncased-ear-misogyny")
         predictions = ["I hate women.", "I do not hate women."]
         references = [["I hate women."], ["I do not hate women."]]
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
         global_target = 0.9562818706035614
-        self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"], places=4)
+        self.assertAlmostEqual(
+            global_target, outputs[0]["score"]["global"]["score"], places=4
+        )
 
     def test_normalized_sacrebleu(self):
         metric = NormalizedSacrebleu()

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -7,6 +7,7 @@ from src.unitxt.metrics import (
     BinaryAccuracy,
     BinaryMaxAccuracy,
     BinaryMaxF1,
+    Detector,
     F1Binary,
     F1Macro,
     F1MacroMultiLabel,
@@ -698,7 +699,20 @@ class TestMetrics(UnitxtTestCase):
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
-        global_target = 0.81649658092772
+        global_target = 0.6025716662406921
+        self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
+
+
+    def test_detector(self):
+        metric = Detector(model_name = "MilaNLProc/bert-base-uncased-ear-misogyny")
+        predictions = ["I hate women.", "I do not hate women."]
+        references = [["I hate you."], ["I love you."]]
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+        print(outputs, '\n\n')
+        print(outputs[0]["score"]["global"]["score"])
+        global_target = 0.9562818706035614
         self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
 
     def test_normalized_sacrebleu(self):

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -699,7 +699,7 @@ class TestMetrics(UnitxtTestCase):
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
-        global_target = 0.6025716662406921
+        global_target = 0.81649658092772
         self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
 
 
@@ -710,7 +710,6 @@ class TestMetrics(UnitxtTestCase):
         outputs = apply_metric(
             metric=metric, predictions=predictions, references=references
         )
-        
         global_target = 0.9562818706035614
         self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
 


### PR DESCRIPTION
This PR is a simple addition to the `metrics` file in order to support incoming risk detectors. 

Detectors are small, typically BERT-like, classification models which take as input a sentence and output a probability score.

The current test file is a placeholder, using an [open source model](https://huggingface.co/MilaNLProc/bert-base-uncased-ear-misogyny) while we work through clearances for the detectors.