### PR TITLE
fix a small bug in BinaryMaxAccuracy

### DIFF
--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -3356,7 +3356,7 @@ class BinaryMaxAccuracy(GlobalMetric):
     def compute(
         self,
         references: List[List[str]],
-        predictions: List[List[str]],
+        predictions: List[str],
         task_data: List[Dict],
     ) -> dict:
         float_predictions = [to_float_or_default(p) for p in predictions]
@@ -3364,24 +3364,52 @@ class BinaryMaxAccuracy(GlobalMetric):
             ["1"] if r[0].lower() in self.pos_classes else ["0"] for r in references
         ]
 
-        best_thr = -1
-        best_acc = -1
-        for thr in set(float_predictions):
-            new_predictions = [
-                "1" if float_prediction >= thr else "0"
-                for float_prediction in float_predictions
-            ]
-            acc = np.mean(
-                [
-                    [prediction] == reference
-                    for prediction, reference in zip(new_predictions, references)
-                ]
-            )
-            if acc > best_acc:
-                best_acc = acc
-                best_thr = thr
+        # Sticking to the test >= thr, accuracy induced by threshold thr is the number of float predictions
+        # that pass the test (are >= thr) and are paired with reference "1" plus the number of float predictions that
+        # fail the test (are < thr) and are paired with reference "0".
+        # A given threshold thr induces the same partition over the float predictions into passing and failing
+        # as threshold thr' induces, with thr' being the smallest among the ones passing the test of thr.
+        # Hence, we only need to review thresholds being float predictions, plus a threshold being larger than
+        # the largest float predictions, to induce the partition into all-failing , none-passing.
 
-        return {self.main_score: best_acc, "best_thr_max_acc": best_thr}
+        fp = [
+            (float_predictions[i], i, -1 if references[i][0] == "1" else +1)
+            for i in range(len(float_predictions))
+        ]
+        fp.sort()
+        # each triplet above: float-prediction f; f's ordinal position in float_predictions, which is also
+        # a means to obtain distinct triplets; and: the change in number of predictions that the test sends
+        # to the reference they are paired with, a change implied by a move of thr that transfers f
+        # from the set of passing the test to the set of failing it.
+
+        rightmost_thr = 1.0 if fp[-1][0] < 1 else fp[-1][0] + 0.01
+        # trying to be esthetic, have the threshold within [0,1], although this is not a requirement,
+        # and even the float predictions are not guaranteed to be within the range [0,1]
+
+        current_thr = fp[0][0]
+        # partition float_predictions into all-passing, none-failing
+        current_acc = sum(r[0] == "1" for r in references)
+        # number of predictions that thr sends to the reference they are paired with
+
+        best_acc = current_acc
+        best_thr = current_thr
+
+        i = 0
+        while i < len(predictions):
+            delta = fp[i][2]
+            i += 1
+            while i < len(predictions) and fp[i][0] <= fp[i - 1][0]:
+                delta += fp[i][2]
+                i += 1
+            current_acc += delta
+            if current_acc > best_acc:
+                best_acc = current_acc
+                best_thr = fp[i][0] if i < len(predictions) else rightmost_thr
+
+        return {
+            self.main_score: float(best_acc) / len(predictions),
+            "best_thr_max_acc": best_thr,
+        }
 
 
 ######################

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -3395,7 +3395,8 @@ class BinaryMaxAccuracy(GlobalMetric):
         best_thr = current_thr
 
         i = 0
-        while i < len(predictions):
+        while (i < len(predictions)) and (best_acc < len(predictions)):
+            # best_acc can not exceed len(predictions)
             delta = fp[i][2]
             i += 1
             while i < len(predictions) and fp[i][0] <= fp[i - 1][0]:

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -385,6 +385,41 @@ class TestMetrics(UnitxtTestCase):
             "max_accuracy_binary", outputs[0]["score"]["instance"]["score_name"]
         )
 
+        references = [["0"], ["0"], ["0"]]
+        predictions = ["0.3", "0.9", "0.7"]
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+        self.assertAlmostEqual(1.0, outputs[0]["score"]["global"]["score"])
+
+        references = [["1"], ["0"], ["0"], ["1"], ["0"], ["0"]]
+        predictions = ["0.7", "0.3", "0.7", "0.8", "0.9", "0.3"]
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+        self.assertAlmostEqual(2 / 3, outputs[0]["score"]["global"]["score"])
+
+        references = [["1"]]
+        predictions = ["0.7"]
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+        self.assertAlmostEqual(1.0, outputs[0]["score"]["global"]["score"])
+
+        references = [["0"]]
+        predictions = ["0.7"]
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+        self.assertAlmostEqual(1.0, outputs[0]["score"]["global"]["score"])
+
+        references = [["0"]]
+        predictions = ["1.7"]
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+        self.assertAlmostEqual(1.0, outputs[0]["score"]["global"]["score"])
+
     def test_f1_macro(self):
         metric = F1Macro()
         references = [["cat"], ["dog"], ["dog"], ["dog"], ["cat"], ["cat"]]


### PR DESCRIPTION
Currently:
      
```
 metric = BinaryMaxAccuracy()
 references = [["0"], ["0"], ["0"]]
 predictions = ["0.3", "0.5", "0"]
 outputs = apply_metric(
         metric=metric, predictions=predictions, references=references
 )
 print(outputs[0]["score"]["global"])
```
     
prints out:

```
{'max_accuracy_binary': 0.6666666666666666, 'best_thr_max_acc': 0.5, 'score': 
0.6666666666666666, 'score_name': 'max_accuracy_binary', 'score_ci_low': nan, 
'score_ci_high': nan, 'max_accuracy_binary_ci_low': nan, 
'max_accuracy_binary_ci_high': nan}
```       
       
Although clearly accuracy = 1.0 can be obtained for any thr > 0.5.  E.g for thr = 0.7.
       
This PR fixes this small bug, and while the hood is open, suggests an  n log n algorithm to replace the n^2 existing one, for the fun of it.