### PR TITLE
Return loading step to enforce loader limit.

### DIFF
--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -195,6 +195,10 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
             logger.info(f"Loader line limit was set to  {self.loader_limit}")
         self.loading.steps.append(loader)
 
+        # This is required in case loader_limit is not enforced by the loader
+        if self.loader_limit:
+            self.loading.steps.append(StreamRefiner(max_instances=self.loader_limit))
+
         self.metadata.steps.append(
             AddFields(
                 fields={


### PR DESCRIPTION
Some Loaders to not respect LoaderLimit.

For this we added a StreamRefiner step that forces the limit.  
This step was removed in a refactor recently and is returned.