### PR TITLE
Fix UI load failure due to typo

### DIFF
--- a/src/unitxt/ui/load_catalog_data.py
+++ b/src/unitxt/ui/load_catalog_data.py
@@ -31,7 +31,7 @@ def safe_load_json(file):
 
 def get_templates(template_data):
     def get_from_str(template_str):
-        if template_data.endswith(".all"):
+        if template_str.endswith(".all"):
             template_file = get_file_from_item_name(template_str)
             return set(load_json(template_file)["items"])
         return {template_str}


### PR DESCRIPTION
Failure was due to a wrong variable being checked.


 python ./fm_eval/utils/run_ui.py

  File "/Users/XXXXl/PycharmProjects/unitxt/src/unitxt/ui/load_catalog_data.py", line 34, in get_from_str
    if template_data.endswith(".all"):
AttributeError: 'list' object has no attribute 'endswith'