### PR TITLE
Support prediction regex match by setting the operator as a postproce…

### DIFF
--- a/prepare/metrics/jaccard_index.py
+++ b/prepare/metrics/jaccard_index.py
@@ -1,0 +1,28 @@
+from unitxt import add_to_catalog
+from unitxt.metrics import JaccardIndex
+from unitxt.test_utils.metrics import test_metric
+
+metric = JaccardIndex()
+
+predictions = [["A", "B", "C"]]
+references = [[["B", "A", "D"]]]
+
+instance_targets = [
+    {"jaccard_index": 0.5, "score": 0.5, "score_name": "jaccard_index"},
+]
+
+global_target = {
+    "jaccard_index": 0.5,
+    "score": 0.5,
+    "score_name": "jaccard_index",
+}
+
+outputs = test_metric(
+    metric=metric,
+    predictions=predictions,
+    references=references,
+    instance_targets=instance_targets,
+    global_target=global_target,
+)
+
+add_to_catalog(metric, "metrics.jaccard_index", overwrite=True)

--- a/prepare/processors/processors.py
+++ b/prepare/processors/processors.py
@@ -12,6 +12,7 @@ from unitxt.processors import (
     LowerCase,
     LowerCaseTillPunc,
     MatchClosestOption,
+    RegexParser,
     StanceToProCon,
     StringOrNotString,
     StrToFloatFormat,
@@ -310,5 +311,11 @@ add_to_catalog(
         ]
     ),
     "processors.extract_mt_bench_judgment",
+    overwrite=True,
+)
+
+add_to_catalog(
+    RegexParser(field="prediction", regex=".+", process_every_value=False),
+    "processors.regex_parser_from_prediction",
     overwrite=True,
 )

--- a/prepare/processors/to_list_by_comma.py
+++ b/prepare/processors/to_list_by_comma.py
@@ -12,3 +12,13 @@ add_to_catalog(
     "processors.to_list_by_comma",
     overwrite=True,
 )
+
+add_to_catalog(
+    SequentialOperator(
+        steps=[
+            ToListByComma(field="references", process_every_value=True),
+        ]
+    ),
+    "processors.to_list_by_comma_from_references",
+    overwrite=True,
+)

--- a/src/unitxt/catalog/metrics/jaccard_index.json
+++ b/src/unitxt/catalog/metrics/jaccard_index.json
@@ -1,0 +1,3 @@
+{
+    "type": "jaccard_index"
+}

--- a/src/unitxt/catalog/processors/regex_parser_from_prediction.json
+++ b/src/unitxt/catalog/processors/regex_parser_from_prediction.json
@@ -1,0 +1,6 @@
+{
+    "type": "regex_parser",
+    "field": "prediction",
+    "regex": ".+",
+    "process_every_value": false
+}

--- a/src/unitxt/catalog/processors/to_list_by_comma_from_references.json
+++ b/src/unitxt/catalog/processors/to_list_by_comma_from_references.json
@@ -1,0 +1,10 @@
+{
+    "type": "sequential_operator",
+    "steps": [
+        {
+            "type": "to_list_by_comma",
+            "field": "references",
+            "process_every_value": true
+        }
+    ]
+}

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -977,6 +977,40 @@ class Accuracy(InstanceMetric):
         return result
 
 
+class JaccardIndex(InstanceMetric):
+    reduction_map = {"mean": ["jaccard_index"]}
+    main_score = "jaccard_index"
+    ci_scores = ["jaccard_index"]
+
+    prediction_type = "Any"  # string representation is compared
+
+    def compute(
+        self, references: List[Any], prediction: Any, task_data: List[Dict]
+    ) -> dict:
+        if not isinstance(prediction, set):
+            prediction = set(prediction)
+        references = [set(reference) for reference in references]
+
+        result = {
+            self.main_score: max(
+                [
+                    float(
+                        (len(reference.intersection(prediction)))
+                        / (
+                            len(reference)
+                            + len(prediction)
+                            - len(reference.intersection(prediction))
+                        )
+                    )
+                    for reference in references
+                ]
+            )
+        }
+        result["score"] = result[self.main_score]
+        result["score_name"] = self.main_score
+        return result
+
+
 class MaxAccuracy(Accuracy):
     """Calculate the maximal accuracy over all instances as the global score."""
 


### PR DESCRIPTION
This PR adds the ability to extract parts of the predictions with regex and compare them with a reference
The regex extraction only applies for the prediction
The to_list_by_comma only happens for the refernce
Adding the Jaccard index for comparing the two groups

After the regex processor is added it can be configured, example: `processors.prediction_regex_parser[regex=\d+]`