### PR TITLE
Revert "Avoid creating a demo pool if num_demos is 0."

### DIFF
--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -225,7 +225,7 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
             self.augmentor.set_task_input_fields(self.card.task.augmentable_inputs)
             self.processing.steps.append(self.augmentor)
 
-        if self.num_demos > 0:
+        if self.demos_pool_size is not None:
             self.processing.steps.append(
                 CreateDemosPool(
                     from_split=self.demos_taken_from,
@@ -234,6 +234,8 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
                     remove_targets_from_source_split=self.demos_removed_from_data,
                 )
             )
+
+        if self.num_demos > 0:
             if self.sampler is None:
                 if self.card.sampler is None:
                     raise ValueError(


### PR DESCRIPTION
Reverts IBM/unitxt#787

Reason is that if demos_taken_from=test, and demo_pool_size=100, we don't want the test set to change if num_demo > 0 (removing the demos from test set) and be different when num_demos =0 (not removing demos from test set).