### PR TITLE
Fix missing experiment_id for multiprocessing evaluation

### DIFF
--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -1166,7 +1166,9 @@ class HuggingfaceBulkMetric(BulkInstanceMetric):
 
     def prepare(self):
         super().prepare()
-        self.metric = evaluate.load(self.hf_metric_name, experiment_id=str(uuid.uuid4()))
+        self.metric = evaluate.load(
+            self.hf_metric_name, experiment_id=str(uuid.uuid4())
+        )
 
     def compute(
         self,
@@ -1337,7 +1339,9 @@ class F1MultiLabel(GlobalMetric):
 
     def prepare(self):
         super().prepare()
-        self._metric = evaluate.load(self.metric, "multilabel", experiment_id=str(uuid.uuid4()))
+        self._metric = evaluate.load(
+            self.metric, "multilabel", experiment_id=str(uuid.uuid4())
+        )
 
     def add_str_to_id(self, str):
         if str not in self.str_to_id:

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -1166,7 +1166,7 @@ class HuggingfaceBulkMetric(BulkInstanceMetric):
 
     def prepare(self):
         super().prepare()
-        self.metric = evaluate.load(self.hf_metric_name)
+        self.metric = evaluate.load(self.hf_metric_name, experiment_id=str(uuid.uuid4()))
 
     def compute(
         self,
@@ -1213,7 +1213,7 @@ class F1(GlobalMetric):
 
     def prepare(self):
         super().prepare()
-        self._metric = evaluate.load(self.metric)
+        self._metric = evaluate.load(self.metric, experiment_id=str(uuid.uuid4()))
 
     def get_str_id(self, str):
         if str not in self.str_to_id:
@@ -1337,7 +1337,7 @@ class F1MultiLabel(GlobalMetric):
 
     def prepare(self):
         super().prepare()
-        self._metric = evaluate.load(self.metric, "multilabel")
+        self._metric = evaluate.load(self.metric, "multilabel", experiment_id=str(uuid.uuid4()))
 
     def add_str_to_id(self, str):
         if str not in self.str_to_id:


### PR DESCRIPTION
### Details
When using unitxt to evaluate with multiprocessing and the file system is shared between the processes, `evaluate.load()` can throw multiple errors, or it can be loaded successfully but fail to execute. Setting a unique experiment_id prevents this behavior.

Signed-off-by: ALON HALFON <ALONHAL@il.ibm.com>