### PR TITLE
Add financebench

### DIFF
--- a/prepare/cards/cohere_for_ai.py
+++ b/prepare/cards/cohere_for_ai.py
@@ -41,15 +41,9 @@ for subset in subsets:
         from copy import deepcopy
 
         card_for_test = deepcopy(card)
-        from unitxt.blocks import (
-            FormTask,
-        )
-
-        card_for_test.task = FormTask(
-            inputs=["question"],
-            outputs=["answers"],
-            metrics=["metrics.rag.correctness.llama_index_by_mock"],
-        )
+        card_for_test.task.metrics = [
+            "metrics.rag.correctness.llama_index_by_mock",
+        ]
 
         test_card(card_for_test, debug=False, strict=False)
         add_to_catalog(

--- a/prepare/cards/financebench.py
+++ b/prepare/cards/financebench.py
@@ -1,0 +1,39 @@
+from copy import deepcopy
+
+from unitxt.blocks import AddFields, LoadHF, RenameFields, SplitRandomMix, TaskCard
+from unitxt.catalog import add_to_catalog
+from unitxt.operators import ListFieldValues
+from unitxt.test_utils.card import test_card
+
+card = TaskCard(
+    loader=LoadHF(
+        path="PatronusAI/financebench",
+    ),
+    preprocess_steps=[
+        SplitRandomMix({"train": "train[10%]", "test": "train[90%]"}),
+        RenameFields(field_to_field={"answer": "answers", "evidence_text": "context"}),
+        ListFieldValues(fields=["answers"], to_field="answers"),
+        AddFields(fields={"context_type": "context"}),
+    ],
+    task="tasks.qa.with_context.abstractive[metrics=[metrics.rag.response_generation.correctness.bert_score.deberta_large_mnli]]",
+    templates="templates.qa.with_context.all",
+)
+
+# testing the card is too slow with the bert-score metric, so dropping it
+card_for_test = deepcopy(card)
+card_for_test.task.metrics = [
+    "metrics.rag.response_generation.correctness.token_overlap",
+]
+
+test_card(
+    card_for_test,
+    debug=False,
+    strict=False,
+    format="formats.textual_assistant",
+)
+add_to_catalog(
+    card,
+    "cards.financebench",
+    overwrite=True,
+    catalog_path="src/unitxt/catalog",
+)

--- a/src/unitxt/catalog/cards/financebench.json
+++ b/src/unitxt/catalog/cards/financebench.json
@@ -1,0 +1,38 @@
+{
+    "type": "task_card",
+    "loader": {
+        "type": "load_hf",
+        "path": "PatronusAI/financebench"
+    },
+    "preprocess_steps": [
+        {
+            "type": "split_random_mix",
+            "mix": {
+                "train": "train[10%]",
+                "test": "train[90%]"
+            }
+        },
+        {
+            "type": "rename_fields",
+            "field_to_field": {
+                "answer": "answers",
+                "evidence_text": "context"
+            }
+        },
+        {
+            "type": "list_field_values",
+            "fields": [
+                "answers"
+            ],
+            "to_field": "answers"
+        },
+        {
+            "type": "add_fields",
+            "fields": {
+                "context_type": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.with_context.abstractive[metrics=[metrics.rag.response_generation.correctness.bert_score.deberta_large_mnli]]",
+    "templates": "templates.qa.with_context.all"
+}


### PR DESCRIPTION
FinanceBench is a fsuite for evaluating the performance of LLMs on open book financial question answering (QA). It is an open source sample of 150 annotated examples used in the evaluation and analysis of models assessed in the FinanceBench paper.

https://huggingface.co/datasets/PatronusAI/financebench?row=0
Currently the dataset is implemented as a contextual qa with the evidence as contexts, this is the _Oracle_ scenario in the paper (https://arxiv.org/abs/2311.11944)
Will add more tasks if I see a reason (saturation for example).