### PR TITLE
Add tldr dataset

### DIFF
--- a/prepare/cards/tldr.py
+++ b/prepare/cards/tldr.py
@@ -18,4 +18,4 @@ test_card(
     card,
     format="formats.textual_assistant",
 )
-add_to_catalog(card, "cards.tldr")
+add_to_catalog(card, "cards.tldr", overwrite=True)

--- a/prepare/cards/tldr.py
+++ b/prepare/cards/tldr.py
@@ -1,0 +1,21 @@
+from unitxt import add_to_catalog
+from unitxt.blocks import AddFields, SplitRandomMix, TaskCard
+from unitxt.loaders import LoadHF
+from unitxt.operators import RenameFields
+from unitxt.test_utils.card import test_card
+
+card = TaskCard(
+    loader=LoadHF(path="webis/tldr-17", streaming=True),
+    preprocess_steps=[
+        SplitRandomMix({"train": "train[50%]", "test": "train[50%]"}),
+        RenameFields(field_to_field={"content": "document"}),
+        AddFields(fields={"document_type": "document"}),
+    ],
+    task="tasks.summarization.abstractive",
+    templates="templates.summarization.abstractive.all",
+)
+test_card(
+    card,
+    format="formats.textual_assistant",
+)
+add_to_catalog(card, "cards.tldr")

--- a/src/unitxt/catalog/cards/tldr.json
+++ b/src/unitxt/catalog/cards/tldr.json
@@ -1,0 +1,31 @@
+{
+    "type": "task_card",
+    "loader": {
+        "type": "load_hf",
+        "path": "webis/tldr-17",
+        "streaming": true
+    },
+    "preprocess_steps": [
+        {
+            "type": "split_random_mix",
+            "mix": {
+                "train": "train[50%]",
+                "test": "train[50%]"
+            }
+        },
+        {
+            "type": "rename_fields",
+            "field_to_field": {
+                "content": "document"
+            }
+        },
+        {
+            "type": "add_fields",
+            "fields": {
+                "document_type": "document"
+            }
+        }
+    ],
+    "task": "tasks.summarization.abstractive",
+    "templates": "templates.summarization.abstractive.all"
+}


### PR DESCRIPTION
The corpus contains preprocessed posts from the Reddit dataset (Webis-TLDR-17). The dataset consists of 3,848,330 posts with an average length of 270 words for content, and 28 words for the summary.

https://huggingface.co/datasets/webis/tldr-17
https://aclanthology.org/W17-4508/

In the scope of the task of absractive summarization the creators of the Webis-TLDR-17 propose mining social media for author-provided summaries and taking advantage of the common practice of appending a "TL;DR" to long posts. A large Reddit crawl was used to yield the Webis-TLDR-17 corpus. This dataset intends to complement the existing summarization corpora primarily from the news genre.