### PR TITLE
Ensure consistent evaluation of CI across implementations [Might change previous results]

### DIFF
--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -921,7 +921,9 @@ class InstanceMetric(SingleStreamOperator, MetricWithConfidenceInterval):
                     }
                 }
             }
-            for group_name in sorted(group_to_instance_scores.keys()) # sorted for consistency 
+            for group_name in sorted(
+                group_to_instance_scores.keys()
+            )  # sorted for consistency
         ]
 
     def _set_up_group_mean_aggregation(

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -921,7 +921,7 @@ class InstanceMetric(SingleStreamOperator, MetricWithConfidenceInterval):
                     }
                 }
             }
-            for group_name in sorted(group_to_instance_scores.keys())
+            for group_name in sorted(group_to_instance_scores.keys()) # sorted for consistency 
         ]
 
     def _set_up_group_mean_aggregation(

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -915,11 +915,13 @@ class InstanceMetric(SingleStreamOperator, MetricWithConfidenceInterval):
                             if uses_subgroups
                             else score_dict[default_subgroup_name]
                         )
-                        for score_name, score_dict in group_scores.items()
+                        for score_name, score_dict in group_to_instance_scores[
+                            group_name
+                        ].items()
                     }
                 }
             }
-            for group_scores in group_to_instance_scores.values()
+            for group_name in sorted(group_to_instance_scores.keys())
         ]
 
     def _set_up_group_mean_aggregation(

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -1122,7 +1122,7 @@ class TestConfidenceIntervals(UnitxtTestCase):
         self._test_grouped_instance_confidence_interval(
             metric=GroupMeanAccuracy(),
             expected_ci_low=0.025,
-            expected_ci_high=0.44105968464125495,
+            expected_ci_high=0.4407250456645065,
         )
 
         self._test_grouped_instance_confidence_interval(
@@ -1133,8 +1133,8 @@ class TestConfidenceIntervals(UnitxtTestCase):
 
         self._test_grouped_instance_confidence_interval(
             metric=GroupMeanStringContainment(),
-            expected_ci_low=0.15556138609239942,
-            expected_ci_high=0.707936507936508,
+            expected_ci_low=0.15627449950197503,
+            expected_ci_high=0.7080527276705952,
         )
 
         self._test_grouped_instance_confidence_interval(
@@ -1239,7 +1239,7 @@ class TestConfidenceIntervals(UnitxtTestCase):
                 "group_mean_f1_ci_high": 0.6805555555555555,
                 "score_ci_low": 0.22302503471948287,
                 "score_ci_high": 0.6805555555555555,
-                "group_mean_precision_ci_low": 0.20949399775845196,
+                "group_mean_precision_ci_low": 0.2095091529536007,
                 "group_mean_precision_ci_high": 0.6666666666666666,
             },
         )
@@ -1282,10 +1282,10 @@ class TestConfidenceIntervals(UnitxtTestCase):
         for score_name, score_value in global_result.items():
             if score_name in expected_global_result:
                 self.assertAlmostEqual(
-                    score_value,
                     expected_global_result[score_name],
+                    score_value,
                     places=5,
-                    msg=f"{group_score_name} score mismatch for {metric.__class__.__name__}, got {expected_global_result[score_name]} but expected {score_value}",
+                    msg=f"{score_name} score mismatch for {metric.__class__.__name__}, expected {expected_global_result[score_name]} but got {score_value}",
                 )
             else:
                 # An output score that is not expected


### PR DESCRIPTION
The new feature of Metric, sample-from-groups-scores, employs the CI over instances generated ad-hoc, one per group (a group is a subset of the input instances, whose member instances are those instances of the stream having a specific value in a specific field).  CI generates the samples through first generating a list of indices (into the input instances) and then dealing with the instances thus indexed. 
Hence, the result of CI for these instances generated ad-hoc depends on the order in which these instances are fed into CI.
This PR standardizes this order by the alphabetic order of the values that define the groups (as explained above)