### PR TITLE
Improved testing of cards

### DIFF
--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -1,4 +1,3 @@
-import re
 from abc import abstractmethod
 from dataclasses import field
 from typing import Any, Dict, Generator, List, Optional, Union
@@ -488,8 +487,7 @@ class SequentialOperator(MultiStreamOperator):
         last_step = (
             self.max_steps - 1 if self.max_steps is not None else len(self.steps) - 1
         )
-        description = str(self.steps[last_step])
-        return re.sub(r"\w+=None, ", "", description)
+        return self.steps[last_step].__description__
 
     def _get_max_steps(self):
         return self.max_steps if self.max_steps is not None else len(self.steps)

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -124,11 +124,23 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
 
     def set_pipelines(self):
         self.loading = SequentialOperator()
+        self.loading.__description__ = "Loading the data from the data source."
         self.metadata = SequentialOperator()
+        self.metadata.__description__ = (
+            "Adding metadata (e.g. format, system prompt, template)  "
+        )
         self.standardization = SequentialOperator()
+        self.standardization.__description__ = (
+            "Standardizing the dataset fields to task definition."
+        )
         self.processing = SequentialOperator()
+        self.processing.__description__ = (
+            "Processing the task fields (e.g. selecting demos per sample if needed)."
+        )
         self.verblization = SequentialOperator()
+        self.verblization.__description__ = "Verbalizing the input to the model and gold references to the 'source', 'target' and 'references' fields."
         self.finalize = SequentialOperator()
+        self.finalize.__description__ = "Adding post processors. Removing intermediate fields. Creating the final output dataset."
 
         self.steps = [
             self.loading,

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -228,7 +228,7 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
             self.augmentor.set_task_input_fields(self.card.task.augmentable_inputs)
             self.processing.steps.append(self.augmentor)
 
-        if self.demos_pool_size is not None:
+        if self.demos_pool_size is not None and self.demos_pool_size > 0:
             self.processing.steps.append(
                 CreateDemosPool(
                     from_split=self.demos_taken_from,

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -234,7 +234,7 @@ def test_card(
     is typically 0.
 
     During the test, sample datasets instances, as well as the predictions/references
-    It also shows the processed predictions and references, after the templates post processors
+    It also shows the processed predictions and references, after the template's post processors
     are applied.  Thus wayit is possible to debug and see that the inputs to the metrics are as expected.
 
         Parameters:

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -233,7 +233,7 @@ def test_card(
     with random predictions (selected from a fixed set of values).  The score expected in this case
     is typically 0.
 
-    During the test, sample datasets instances, as well as the predictions/references
+    During the test, sample datasets instances, as well as the predictions/references are displayed.
     It also shows the processed predictions and references, after the template's post processors
     are applied.  Thus wayit is possible to debug and see that the inputs to the metrics are as expected.
 

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -226,7 +226,7 @@ def test_card(
 ):
     """Tests a given card.
 
-    By default, the test goes over all templates defined in the cards,
+    By default, the test goes over all templates defined in the card,
     and generates sample outputs for template. It also runs two tests on sample data.
     The first is running the metrics in the card with predictions which are equal to the references.
     The expected score in this case is typically 1.  The second test is running the metrics in the card

--- a/src/unitxt/text_utils.py
+++ b/src/unitxt/text_utils.py
@@ -89,6 +89,9 @@ def construct_dict_str(d, indent=0, indent_delta=4, max_chars=None):
             res += construct_dict_str(value, indent + indent_delta, max_chars=max_chars)
         else:
             str_value = str(value)
+            str_value = re.sub(r"\w+=None, ", "", str_value)
+            str_value = re.sub(r"\w+={}, ", "", str_value)
+            str_value = re.sub(r"\w+=\[\], ", "", str_value)
             line_width = max_chars - indent
             lines = str_value.split("\n")
             res += f"{indent_str}{key} ({type(value).__name__}):\n"


### PR DESCRIPTION
Right now testing of card using test_card performs  multiple checks implicitly (e.g generate the card with number of demos).
The goal of this pull request is to make things more explict, and more controllable by the users.

1. Do not add any defaults beyond what the user provide (e.g num demos) 
2. Improved debug messages.
3. Allow user to override the values when testing the card on random predictions.
