### PR TITLE
add MinimumOneExamplePerLabelRefiner

### DIFF
--- a/prepare/operators/balancers/per_task.py
+++ b/prepare/operators/balancers/per_task.py
@@ -1,5 +1,9 @@
 from unitxt.catalog import add_to_catalog
-from unitxt.operators import DeterministicBalancer, LengthBalancer
+from unitxt.operators import (
+    DeterministicBalancer,
+    LengthBalancer,
+    MinimumOneExamplePerLabelRefiner,
+)
 
 balancer = DeterministicBalancer(fields=["outputs/label"])
 
@@ -19,4 +23,12 @@ balancer = LengthBalancer(fields=["outputs/labels"], segments_boundaries=[1])
 
 add_to_catalog(
     balancer, "operators.balancers.ner.zero_vs_many_entities", overwrite=True
+)
+
+balancer = MinimumOneExamplePerLabelRefiner(fields=["outputs/label"])
+
+add_to_catalog(
+    balancer,
+    "operators.balancers.classification.minimum_one_example_per_class",
+    overwrite=True,
 )

--- a/src/unitxt/catalog/operators/balancers/classification/minimum_one_example_per_class.json
+++ b/src/unitxt/catalog/operators/balancers/classification/minimum_one_example_per_class.json
@@ -1,0 +1,6 @@
+{
+    "type": "minimum_one_example_per_label_refiner",
+    "fields": [
+        "outputs/label"
+    ]
+}

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1990,7 +1990,7 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
     """A class used to return a specified number instances ensuring atleast one example  per label.
 
     For each instance, a signature value is constructed from the values of the instance in specified input 'fields'.
-    By discarding instances from the input stream, MinimumOneExamplePerLabelRefiner maintains at least one
+    MinimumOneExamplePerLabelRefiner takes first instance that appears from each label (each unique signature), and then adds more elements up to the max_instances limit.  In general, the refiner takes the first elements in the stream that meet the required conditions.
     example per label. MinimumOneExamplePerLabelRefiner shuffles the results to avoid having one element
     from each class first and then the rest . If max instance is not set, the original stream will be used
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1987,7 +1987,7 @@ class DeterministicBalancer(StreamRefiner):
 
 
 class MinimumOneExamplePerLabelRefiner(StreamRefiner):
-    """A class used to return a specified number instances ensuring atleast one example  per label.
+    """A class used to return a specified number instances ensuring at least one example  per label.
 
     For each instance, a signature value is constructed from the values of the instance in specified input 'fields'.
     MinimumOneExamplePerLabelRefiner takes first instance that appears from each label (each unique signature), and then adds more elements up to the max_instances limit.  In general, the refiner takes the first elements in the stream that meet the required conditions.
@@ -1996,7 +1996,7 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
 
     Attributes:
         fields (List[str]): A list of field names to be used in producing the instance's signature.
-        max_instances (Optional, int): Number of elements to select. Note that max_instances of StreamRefiners that are passed to the recipe (e.g. 'train_refiner'. `test_refiner`) are overridden by the recipe parameters ( `max_train_instances`, `max_test_instances`) 
+        max_instances (Optional, int): Number of elements to select. Note that max_instances of StreamRefiners that are passed to the recipe (e.g. 'train_refiner'. `test_refiner`) are overridden by the recipe parameters ( `max_train_instances`, `max_test_instances`)
 
     Usage:
         balancer = MinimumOneExamplePerLabelRefiner(fields=["field1", "field2"], max_instances=200)
@@ -2004,9 +2004,9 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
 
     Example:
         When input [{"a": 1, "b": 1},{"a": 1, "b": 2},{"a": 1, "b": 3},{"a": 1, "b": 4},{"a": 2, "b": 5}] is fed into
-        MinimumOneExamplePerLabelRefiner(fields=["a"], max_instances=2)
+        MinimumOneExamplePerLabelRefiner(fields=["a"], max_instances=3)
         the resulting stream will be:
-        [{"a": 2, "b": 5}] + one of [{"a": 1, "b": 1},{"a": 1, "b": 2},{"a": 1, "b": 3},{"a": 1, "b": 4}]
+        [{'a': 1, 'b': 1}, {'a': 1, 'b': 2}, {'a': 2, 'b': 5}] (order may be different)
     """
 
     fields: List[str]
@@ -2015,8 +2015,9 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
         return str(tuple(dict_get(instance, field) for field in self.fields))
 
     def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
-        for instance in stream:
-            yield instance
+        if self.max_instances is None:
+            for instance in stream:
+                yield instance
 
         counter = Counter()
         for instance in stream:

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1996,28 +1996,26 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
 
     Attributes:
         fields (List[str]): A list of field names to be used in producing the instance's signature.
-        max_instances (Optional, int)
+        max_instances (int): Number of elements to select
 
     Usage:
         balancer = MinimumOneExamplePerLabelRefiner(fields=["field1", "field2"], max_instances=200)
         balanced_stream = balancer.process(stream)
 
     Example:
-        When input [{"a": 1, "b": 1},{"a": 1, "b": 2},{"a": 1},{"a": 1},{"a": 2}] is fed into
+        When input [{"a": 1, "b": 1},{"a": 1, "b": 2},{"a": 1, "b": 3},{"a": 1, "b": 4},{"a": 2, "b": 5}] is fed into
         MinimumOneExamplePerLabelRefiner(fields=["a"], max_instances=2)
-        the resulting stream will be: [{"a": 2}] + one of [{"a": 1, "b": 1},{"a": 1, "b": 2},{"a": 1}]
+        the resulting stream will be:
+        [{"a": 2, "b": 5}] + one of [{"a": 1, "b": 1},{"a": 1, "b": 2},{"a": 1, "b": 3},{"a": 1, "b": 4}]
     """
 
     fields: List[str]
+    max_instances: int
 
     def signature(self, instance):
         return str(tuple(dict_get(instance, field) for field in self.fields))
 
     def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
-        if self.max_instances is None:
-            for instance in stream:
-                yield instance
-
         counter = Counter()
 
         for instance in stream:

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1996,7 +1996,7 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
 
     Attributes:
         fields (List[str]): A list of field names to be used in producing the instance's signature.
-        max_instances (Optional, int): Number of elements to select
+        max_instances (Optional, int): Number of elements to select. Note that max_instances of StreamRefiners that are passed to the recipe (e.g. 'train_refiner'. `test_refiner`) are overridden by the recipe parameters ( `max_train_instances`, `max_test_instances`) 
 
     Usage:
         balancer = MinimumOneExamplePerLabelRefiner(fields=["field1", "field2"], max_instances=200)

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -2028,7 +2028,7 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
 
         if self.max_instances is not None and len(all_keys) > self.max_instances:
             raise Exception(
-                f"max instances of {self.max_instances} is smaller than the number of different labels"
+                f"Can not generate a stream with at least one example per label, because the max instances requested  {self.max_instances} is smaller than the number of different labels {len(all_keys)}"
                 f" ({len(all_keys)}"
             )
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1987,7 +1987,7 @@ class DeterministicBalancer(StreamRefiner):
 
 
 class MinimumOneExamplePerLabelRefiner(StreamRefiner):
-    """A class used to include at least one example per label.
+    """A class used to return a specified number instances ensuring atleast one example  per label.
 
     For each instance, a signature value is constructed from the values of the instance in specified input 'fields'.
     By discarding instances from the input stream, MinimumOneExamplePerLabelRefiner maintains at least one

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1989,7 +1989,7 @@ class DeterministicBalancer(StreamRefiner):
 class MinimumOneExamplePerLabelRefiner(StreamRefiner):
     """A class used to include at least one example per label.
 
-    For each instance, a signature is constructed from the values of the instance in specified input 'fields'.
+    For each instance, a signature value is constructed from the values of the instance in specified input 'fields'.
     By discarding instances from the input stream, MinimumOneExamplePerLabelRefiner maintains at least one
     example per label. MinimumOneExamplePerLabelRefiner shuffles the results to avoid having one element
     from each class first and then the rest . If max instance is not set, the original stream will be used

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1991,7 +1991,7 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
 
     For each instance, a signature value is constructed from the values of the instance in specified input 'fields'.
     MinimumOneExamplePerLabelRefiner takes first instance that appears from each label (each unique signature), and then adds more elements up to the max_instances limit.  In general, the refiner takes the first elements in the stream that meet the required conditions.
-    example per label. MinimumOneExamplePerLabelRefiner shuffles the results to avoid having one element
+    MinimumOneExamplePerLabelRefiner then shuffles the results to avoid having one instance
     from each class first and then the rest . If max instance is not set, the original stream will be used
 
     Attributes:

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1996,7 +1996,7 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
 
     Attributes:
         fields (List[str]): A list of field names to be used in producing the instance's signature.
-        max_instances (int): Number of elements to select
+        max_instances (Optional, int): Number of elements to select
 
     Usage:
         balancer = MinimumOneExamplePerLabelRefiner(fields=["field1", "field2"], max_instances=200)
@@ -2010,14 +2010,15 @@ class MinimumOneExamplePerLabelRefiner(StreamRefiner):
     """
 
     fields: List[str]
-    max_instances: int
 
     def signature(self, instance):
         return str(tuple(dict_get(instance, field) for field in self.fields))
 
     def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
-        counter = Counter()
+        for instance in stream:
+            yield instance
 
+        counter = Counter()
         for instance in stream:
             counter[self.signature(instance)] += 1
         all_keys = counter.keys()

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -36,6 +36,7 @@ from unitxt.operators import (
     ListFieldValues,
     MapInstanceValues,
     MergeStreams,
+    MinimumOneExamplePerLabelRefiner,
     NullAugmentor,
     Perturb,
     RemoveFields,
@@ -2407,6 +2408,52 @@ class TestOperators(UnitxtTestCase):
         check_operator(
             operator=DeterministicBalancer(fields=["a", "b"], max_instances=2),
             inputs=inputs + inputs,
+            targets=targets,
+            tester=self,
+        )
+
+    def test_minimum_one_per_label_balancer(self):
+        inputs = [
+            {"text": "I love dogs", "label": "dogs", "id": 0},
+            {"text": "I love dogs", "label": "dogs", "id": 1},
+            {"text": "I love dogs", "label": "dogs", "id": 2},
+            {"text": "I love dogs", "label": "dogs", "id": 3},
+            {"text": "I love dogs", "label": "dogs", "id": 4},
+            {"text": "I love dogs", "label": "dogs", "id": 5},
+            {"text": "I love dogs", "label": "dogs", "id": 6},
+            {"text": "I love dogs", "label": "dogs", "id": 7},
+            {"text": "I love dogs", "label": "dogs", "id": 8},
+            {"text": "I love cats", "label": "cats", "id": 9},
+            {"text": "I love parrots", "label": "parrots", "id": 10},
+        ]
+
+        targets = [
+            {"text": "I love cats", "label": "cats", "id": 9},
+            {"text": "I love dogs", "label": "dogs", "id": 0},
+            {"text": "I love parrots", "label": "parrots", "id": 10},
+        ]
+
+        check_operator(
+            operator=MinimumOneExamplePerLabelRefiner(
+                fields=["label"], max_instances=3
+            ),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
+        targets = [
+            {"text": "I love dogs", "label": "dogs", "id": 0},
+            {"text": "I love cats", "label": "cats", "id": 9},
+            {"text": "I love parrots", "label": "parrots", "id": 10},
+            {"text": "I love dogs", "label": "dogs", "id": 1},
+        ]
+
+        check_operator(
+            operator=MinimumOneExamplePerLabelRefiner(
+                fields=["label"], max_instances=4
+            ),
+            inputs=inputs,
             targets=targets,
             tester=self,
         )


### PR DESCRIPTION
to allow having at least one element per label when using a sub-sample of the train set
unit tests to show the expected behavior.

Signed-off-by: ALON HALFON <ALONHAL@il.ibm.com>