### PR TITLE
Fix operator and metrics data bugs and add metric prefix

### DIFF
--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -1,6 +1,8 @@
 import re
 from typing import Any, List, Tuple
 
+from .text_utils import construct_dict_str
+
 indx = re.compile(r"^(\d+)$")
 name = re.compile(r"^[\w. -]+$")
 
@@ -395,21 +397,19 @@ def dict_get(
     if len(components) > 1:
         try:
             success, values = get_values(dic, components, -1 * len(components))
-            if not success:
-                if not_exist_ok:
-                    return default
-                raise ValueError(
-                    f'query "{query}" did not match any item in dict: {dic}'
-                )
-
-            return values
-
+            if success:
+                return values
         except Exception as e:
-            if not_exist_ok:
-                return default
             raise ValueError(
-                f'query "{query}" did not match any item in dict: {dic}'
+                f'query "{query}" did not match any item in dict:\n{construct_dict_str(dic)}'
             ) from e
+
+        if not_exist_ok:
+            return default
+
+        raise ValueError(
+            f'query "{query}" did not match any item in dict:\n{construct_dict_str(dic)}'
+        )
 
     # len(components) == 1
     if components[0] in dic:
@@ -418,7 +418,9 @@ def dict_get(
     if not_exist_ok:
         return default
 
-    raise ValueError(f'query "{query}" did not match any item in dict: {dic}')
+    raise ValueError(
+        f'query "{query}" did not match any item in dict:\n{construct_dict_str(dic)}'
+    )
 
 
 # dict_set sets a value, 'value', which by itself, can be a dict or list or scalar, into 'dic', to become the value of

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -173,7 +173,7 @@ class Metric(Artifact):
             self._parsed_prediction_type = parse_type_string(self.prediction_type)
         except ValueError:
             raise ValueError(
-                "Could convert prediction type '{self.prediction_type}' in {self.get_metric_name()} to known type.  To enable type checking for this prediction type, open unitxt issue with this message. Alternatively, set the metric's prediction_type to 'Any'"
+                f"Could convert prediction type '{self.prediction_type}' in {self.get_metric_name()} to known type.  To enable type checking for this prediction type, open unitxt issue with this message. Alternatively, set the metric's prediction_type to 'Any'"
             ) from None
         return self._parsed_prediction_type
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -393,6 +393,11 @@ class InstanceFieldOperator(StreamInstanceOperator):
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
     ) -> Dict[str, Any]:
+        # Need to deep copy instance, because when assigning two dictionary fields,
+        # dict_set() the target field dictionary fields.
+        # This means that if this target field was assigned to another field before,
+        # the field is updated as well.
+        instance = deepcopy(instance)
         for from_field, to_field in self._field_to_field:
             try:
                 old_value = dict_get(

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -205,7 +205,7 @@ def test_predictions(
         )
     logger.info("*" * 80)
     logger.info("Sample score output:")
-    logger.info(json.dumps(results[0]["score"]["global"], sort_keys=True, indent=4))
+    logger.info(json.dumps(results[0]["score"], sort_keys=True, indent=4))
     logger.info("*" * 80)
 
     score_name = results[0]["score"]["global"]["score_name"]

--- a/src/unitxt/version.py
+++ b/src/unitxt/version.py
@@ -1,1 +1,1 @@
-version = "1.8.1"
+version = "1.9.0"

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -192,6 +192,39 @@ class TestMetrics(UnitxtTestCase):
         for output, target in zip(outputs, instance_targets):
             self.assertDictEqual(output["score"]["instance"], target)
 
+    def test_accuracy_with_prefix(self):
+        metric = Accuracy(score_prefix="my_")
+
+        predictions = ["A", "B", "C"]
+        references = [["B", "C"], ["A"], ["B", "C"]]
+
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+
+        expected_global_result = {
+            "my_accuracy": 1 / 3,
+            "score": 1 / 3,
+            "score_name": "my_accuracy",
+        }
+
+        global_result = outputs[0]["score"]["global"].copy()
+        # Only check the keys that are expected, i.e. exist in expected_global_result
+        global_result = {
+            key: value
+            for key, value in global_result.items()
+            if key in expected_global_result
+        }
+        self.assertDictEqual(global_result, expected_global_result)
+
+        instance_targets = [
+            {"my_accuracy": 0.0, "score": 0.0, "score_name": "my_accuracy"},
+            {"my_accuracy": 0.0, "score": 0.0, "score_name": "my_accuracy"},
+            {"my_accuracy": 1.0, "score": 1.0, "score_name": "my_accuracy"},
+        ]
+        for output, target in zip(outputs, instance_targets):
+            self.assertDictEqual(output["score"]["instance"], target)
+
     def test_accuracy_max_aggregation(self):
         metric = MaxAccuracy()
 
@@ -237,6 +270,42 @@ class TestMetrics(UnitxtTestCase):
         self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
         self.assertEqual("f1_micro", outputs[0]["score"]["global"]["score_name"])
         self.assertEqual("f1_micro", outputs[0]["score"]["instance"]["score_name"])
+
+    def test_f1_micro_with_prefix(self):
+        metric = F1Micro(score_prefix="my_")
+
+        references = [["cat"], ["dog"], ["dog"], ["dog"], ["cat"], ["cat"]]
+        predictions = ["cat", "cat", "dog", "dog", "cat", "cat"]
+
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+
+        expected_global_result = {
+            "my_f1_micro": 5 / 6,
+            "score": 5 / 6,
+            "score_name": "my_f1_micro",
+        }
+
+        global_result = outputs[0]["score"]["global"].copy()
+        # Only check the keys that are expected, i.e. exist in expected_global_result
+        global_result = {
+            key: value
+            for key, value in global_result.items()
+            if key in expected_global_result
+        }
+        self.assertDictEqual(global_result, expected_global_result)
+
+        instance_targets = [
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 0.0, "score": 0.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+        ]
+        for output, target in zip(outputs, instance_targets):
+            self.assertDictEqual(output["score"]["instance"], target)
 
     def test_f1_errors(self):
         metric = F1Micro()
@@ -1027,6 +1096,47 @@ class TestMetrics(UnitxtTestCase):
         self.assertAlmostEqual(
             first_instance_target, outputs[0]["score"]["instance"]["score"]
         )
+
+    def test_perplexity_with_prefix(self):
+        prediction = ["who are we?"]
+        references = [["we are the world"]]
+
+        perplexity_question = Perplexity(
+            model_name="google/flan-t5-small",
+            source_template="Generate a question based on the given content: {reference}",
+            target_template="{prediction}",
+            score_prefix="my_",
+        )
+
+        outputs = apply_metric(
+            metric=perplexity_question, predictions=prediction, references=references
+        )
+
+        expected_global_result = {
+            "my_perplexity": 0.05986589565873146,
+            "score": 0.05986589565873146,
+            "score_name": "my_perplexity",
+        }
+
+        global_result = outputs[0]["score"]["global"].copy()
+        # Only check the keys that are expected, i.e. exist in expected_global_result
+        global_result = {
+            key: value
+            for key, value in global_result.items()
+            if key in expected_global_result
+        }
+        self.assertDictEqual(global_result, expected_global_result)
+
+        instance_targets = [
+            {
+                "my_perplexity": 0.05986589565873146,
+                "score": 0.05986589565873146,
+                "score_name": "my_perplexity",
+                "my_reference_scores": [0.05986589565873146],
+            }
+        ]
+        for output, target in zip(outputs, instance_targets):
+            self.assertDictEqual(output["score"]["instance"], target)
 
 
 class TestConfidenceIntervals(UnitxtTestCase):

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -674,7 +674,10 @@ class TestOperators(UnitxtTestCase):
             tester=self,
         )
 
-        exception_text = "Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to get 'label2' from {'label': 'b'} due to : query \"label2\" did not match any item in dict: {'label': 'b'}"
+        exception_text = """Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to get 'label2' due to : query "label2" did not match any item in dict:
+label (str):
+    b
+"""
         check_operator_exception(
             operator=RemoveValues(field="label2", unallowed_values=["c"]),
             inputs=inputs,
@@ -2266,7 +2269,12 @@ class TestOperators(UnitxtTestCase):
         )
 
         inputs = [{"prediction": "red", "references": "blue"}]
-        exception_text = "Error processing instance '0' from stream 'test' in EncodeLabels due to: query \"references/*\" did not match any item in dict: {'prediction': 'red', 'references': 'blue'}"
+        exception_text = """Error processing instance '0' from stream 'test' in EncodeLabels due to: query \"references/*\" did not match any item in dict:
+prediction (str):
+    red
+references (str):
+    blue
+"""
         check_operator_exception(
             operator=EncodeLabels(fields=["references/*", "prediction"]),
             inputs=inputs,


### PR DESCRIPTION
There were some very subtle bugs in treatment of operators.  

The issue was that if we assign a field to a field (E.g in CopyField operator) , and these are both fields that are dictionary.
then field the dictionary values of the source field were copied to the target field.  
If the one of these fields, was further modified - they effected on another.

CopyField(pred -> pred_orig) 
CopyField(pred/contexts -> refs)
ListFields[task/question -> pred)

Following this, pred_orig was equal to the task/question.

As a first solution - I a deep copied instances in instance operators, so they don't effect each other.

Another issue was that metric global scores were shared across instances, and this also caused problems following the above change. The code was simplified that each global score is a separate object.

Finally, added an option for metric to receive a score_prefix, that is added to all scores (except "score" and "score_name"). 
This allows running the same metric on two different fields of the task.

This is a currently branch over 1.9.0 to allow people who need to use it on a stable version before a release.

