### PR TITLE
Fix operator and metrics data bugs and add metric prefix in main

### DIFF
--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -1,6 +1,8 @@
 import re
 from typing import Any, List, Tuple
 
+from .text_utils import construct_dict_str
+
 indx = re.compile(r"^(\d+)$")
 name = re.compile(r"^[\w. -]+$")
 
@@ -395,21 +397,19 @@ def dict_get(
     if len(components) > 1:
         try:
             success, values = get_values(dic, components, -1 * len(components))
-            if not success:
-                if not_exist_ok:
-                    return default
-                raise ValueError(
-                    f'query "{query}" did not match any item in dict: {dic}'
-                )
-
-            return values
-
+            if success:
+                return values
         except Exception as e:
-            if not_exist_ok:
-                return default
             raise ValueError(
-                f'query "{query}" did not match any item in dict: {dic}'
+                f'query "{query}" did not match any item in dict:\n{construct_dict_str(dic)}'
             ) from e
+
+        if not_exist_ok:
+            return default
+
+        raise ValueError(
+            f'query "{query}" did not match any item in dict:\n{construct_dict_str(dic)}'
+        )
 
     # len(components) == 1
     if components[0] in dic:
@@ -418,7 +418,9 @@ def dict_get(
     if not_exist_ok:
         return default
 
-    raise ValueError(f'query "{query}" did not match any item in dict: {dic}')
+    raise ValueError(
+        f'query "{query}" did not match any item in dict:\n{construct_dict_str(dic)}'
+    )
 
 
 # dict_set sets a value, 'value', which by itself, can be a dict or list or scalar, into 'dic', to become the value of

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -96,6 +96,28 @@ class Metric(Artifact):
     # parsing on every use
     _parsed_prediction_type = None
 
+    #
+    # Used to add a prefix to all score, except the "score_name" and "score" fields.
+    # This is used to distinguish two scores of the same metrics, operating on different fields of the task
+    #
+    score_prefix: str = ""
+
+    def _add_score_prefix(self, score_name):
+        return (
+            self.score_prefix + score_name
+            if score_name not in ["score", "score_name"]
+            else score_name
+        )
+
+    def _add_score_prefixes_to_score_dict(self, scores: Dict[str, Any]):
+        new_scores = {}
+        for score_name, score in scores.items():
+            score_with_prefix = self._add_score_prefix(score_name)
+            new_scores[score_with_prefix] = (
+                score if score_name not in ["score_name"] else self.score_prefix + score
+            )
+        return new_scores
+
     def _validate_references_and_prediction(self, references, predictions):
         if not isoftype(predictions, List[Any]):
             raise ValueError(
@@ -153,7 +175,7 @@ class Metric(Artifact):
             self._parsed_prediction_type = parse_type_string(self.prediction_type)
         except ValueError:
             raise ValueError(
-                "Could convert prediction type '{self.prediction_type}' in {self.get_metric_name()} to known type.  To enable type checking for this prediction type, open unitxt issue with this message. Alternatively, set the metric's prediction_type to 'Any'"
+                f"Could convert prediction type '{self.prediction_type}' in {self.get_metric_name()} to known type.  To enable type checking for this prediction type, open unitxt issue with this message. Alternatively, set the metric's prediction_type to 'Any'"
             ) from None
         return self._parsed_prediction_type
 
@@ -451,14 +473,13 @@ class GlobalMetric(StreamOperator, MetricWithConfidenceInterval):
             instance = self.verify_instance(instance)
 
             if "score" not in instance:
-                instance["score"] = {"global": global_score, "instance": {}}
-            else:
-                global_score = instance["score"]["global"]
+                instance["score"] = {"global": {}, "instance": {}}
 
             instance_references, instance_prediction = (
                 instance["references"],
                 instance["prediction"],
             )
+
             references.append(instance_references)
             predictions.append(instance_prediction)
             instances.append(instance)
@@ -468,6 +489,7 @@ class GlobalMetric(StreamOperator, MetricWithConfidenceInterval):
             )
             task_data.append(instance_task_data)
             instance_score = None
+
             # for backward compatibility
             no_score_value = np.nan
             if self.process_single_instances:
@@ -488,13 +510,14 @@ class GlobalMetric(StreamOperator, MetricWithConfidenceInterval):
                 if isinstance(self.main_score, str):
                     instance_score[self.main_score] = no_score_value
 
-            instance["score"]["instance"].update(instance_score)
+            instance["score"]["instance"].update(
+                self._add_score_prefixes_to_score_dict(instance_score)
+            )
         self._validate_references_and_prediction(references, predictions)
 
         result = self._compute(references, predictions, task_data)
 
-        global_score.update(result)
-
+        global_score.update(self._add_score_prefixes_to_score_dict(result))
         score_name = global_score["score_name"]
         confidence_interval = self.compute_global_confidence_intervals(
             references, predictions, task_data, score_name
@@ -502,7 +525,7 @@ class GlobalMetric(StreamOperator, MetricWithConfidenceInterval):
         global_score.update(confidence_interval)
 
         for instance in instances:
-            instance["score"]["global"] = global_score
+            instance["score"]["global"].update(global_score)
             yield instance
 
     def _compute(
@@ -541,6 +564,7 @@ class BulkInstanceMetric(StreamOperator, MetricWithConfidenceInterval):
         default_factory=lambda: settings.num_resamples_for_instance_metrics
     )
     main_score: str
+
     reduction_map: Dict[str, List[str]]
 
     implemented_reductions: List[str] = field(default_factory=lambda: ["mean"])
@@ -581,12 +605,11 @@ class BulkInstanceMetric(StreamOperator, MetricWithConfidenceInterval):
 
         for instance, score in zip(stream, instance_scores):
             if "score" not in instance:
-                instance["score"] = {"global": global_score, "instance": {}}
-            else:
-                global_score = instance["score"]["global"]
+                instance["score"] = {"global": {}, "instance": {}}
 
-            instance["score"]["instance"].update(score)
-
+            instance["score"]["instance"].update(
+                self._add_score_prefixes_to_score_dict(score)
+            )
             instances.append(instance)
 
         for reduction, fields in self.reduction_map.items():
@@ -596,27 +619,32 @@ class BulkInstanceMetric(StreamOperator, MetricWithConfidenceInterval):
 
             if reduction == "mean":
                 for field_name in fields:
-                    global_score[field_name] = mean(
+                    field_name_with_prefix = self._add_score_prefix(field_name)
+                    global_score[field_name_with_prefix] = mean(
                         [
-                            instance["score"]["instance"][field_name]
+                            instance["score"]["instance"][field_name_with_prefix]
                             for instance in instances
                         ]
                     )
                     if field_name == self.main_score:
-                        global_score["score"] = global_score[field_name]
-                        global_score["score_name"] = self.main_score
+                        global_score["score"] = global_score[field_name_with_prefix]
+                        global_score["score_name"] = self.score_prefix + self.main_score
 
                 ci_fields = (
                     list(set(self.ci_scores))
                     if self.ci_scores is not None
                     else [self.main_score]
                 )
+                ci_fields_with_prefix = [
+                    self._add_score_prefix(ci_field) for ci_field in ci_fields
+                ]
                 confidence_interval = self.score_based_confidence_interval(
-                    instances=instances, score_names=ci_fields
+                    instances=instances, score_names=ci_fields_with_prefix
                 )
                 global_score.update(confidence_interval)
 
         for instance in instances:
+            instance["score"]["global"].update(global_score)
             yield instance
 
     @abstractmethod
@@ -755,8 +783,8 @@ class InstanceMetric(StreamOperator, MetricWithConfidenceInterval):
             ), f"each instance task_data dict must have a key {self.subgroup_column}"
 
     def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
-        instances, global_score = self.compute_instance_scores(stream)
-
+        instances = self.compute_instance_scores(stream)
+        global_score = {}
         for reduction_type, reduction_params in self.reduction_map.items():
             assert (
                 reduction_type in self.implemented_reductions
@@ -802,7 +830,9 @@ class InstanceMetric(StreamOperator, MetricWithConfidenceInterval):
 
             # calculate global scores for each reduction field
             for field_name in reduction_fields:
-                field_name_full = field_name_full_prefix + field_name
+                field_name_full = (
+                    field_name_full_prefix + self.score_prefix + field_name
+                )
                 # if group resampling (3rd element of agg_func parameter) is True, then
                 #   1. scores_to_resample are the group scores, and
                 #   2. aggregation_function is to take the raw mean
@@ -811,7 +841,7 @@ class InstanceMetric(StreamOperator, MetricWithConfidenceInterval):
                 #   2. aggregation_function is to apply the group aggregation from the instance scores
                 # either way, the application of aggregation_function to scores_to_resample yields the global score
                 global_score[field_name_full] = aggregation_function(
-                    scores_to_resample, field_name
+                    scores_to_resample, self.score_prefix + field_name
                 )
                 if field_name == self.main_score:
                     global_score["score"] = global_score[field_name_full]
@@ -822,18 +852,21 @@ class InstanceMetric(StreamOperator, MetricWithConfidenceInterval):
             if self.ci_scores is not None:
                 confidence_interval = self.score_based_confidence_interval(
                     instances=scores_to_resample,
-                    score_names=list(set(self.ci_scores)),
+                    score_names=[
+                        self.score_prefix + ci_score for ci_score in set(self.ci_scores)
+                    ],
                     ci_score_prefix=field_name_full_prefix,
                     aggregation_func=aggregation_function,
                 )
                 global_score.update(confidence_interval)
 
+        for instance in instances:
+            instance["score"]["global"].update(global_score)
         yield from instances
 
     def compute_instance_scores(
         self, stream: Stream, stream_name: Optional[str] = None
     ):
-        global_score = {}
         instances = []
 
         for instance in stream:
@@ -858,18 +891,19 @@ class InstanceMetric(StreamOperator, MetricWithConfidenceInterval):
             instance_score = self.compute(
                 references=refs, prediction=pred, task_data=task_data
             )
+
             instance_score["score"] = instance_score[self.main_score]
             instance_score["score_name"] = self.main_score
             if "score" not in instance:
-                instance["score"] = {"global": global_score, "instance": {}}
-            else:
-                global_score = instance["score"]["global"]
+                instance["score"] = {"global": {}, "instance": {}}
 
-            instance["score"]["instance"].update(instance_score)
+            instance["score"]["instance"].update(
+                self._add_score_prefixes_to_score_dict(instance_score)
+            )
 
             instances.append(instance)
 
-        return instances, global_score
+        return instances
 
     def get_group_scores(
         self, instances: List[dict], score_names: List[str], group_aggregation_func
@@ -1091,8 +1125,14 @@ class MetricPipeline(MultiStreamOperator, Metric):
         super().prepare()
         self.prepare_score = CopyFields(
             field_to_field=[
-                [f"score/instance/{self.main_score}", "score/instance/score"],
-                [f"score/global/{self.main_score}", "score/global/score"],
+                [
+                    f"score/instance/{self.metric._add_score_prefix(self.main_score)}",
+                    "score/instance/score",
+                ],
+                [
+                    f"score/global/{self.metric._add_score_prefix(self.main_score)}",
+                    "score/global/score",
+                ],
             ],
         )
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -394,6 +394,11 @@ class InstanceFieldOperator(InstanceOperator):
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
     ) -> Dict[str, Any]:
+        # Need to deep copy instance, because when assigning two dictionary fields,
+        # dict_set() the target field dictionary fields.
+        # This means that if this target field was assigned to another field before,
+        # the field is updated as well.
+        instance = deepcopy(instance)
         for from_field, to_field in self._field_to_field:
             try:
                 old_value = dict_get(

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -223,7 +223,6 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
             AddFields(
                 fields={
                     "recipe_metadata": {
-                        "card": self.card,
                         "template": self.template,
                         "system_prompt": self.system_prompt,
                         "format": self.format,

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -131,7 +131,7 @@ def print_predictions(correct_predictions, results):
         )
     logger.info("*" * 5)
     logger.info("Score output:")
-    logger.info(json.dumps(results[0]["score"]["global"], sort_keys=True, indent=4))
+    logger.info(json.dumps(results[0]["score"], sort_keys=True, indent=4))
 
 
 def test_correct_predictions(examples, strict, exact_match_score):

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -193,6 +193,39 @@ class TestMetrics(UnitxtTestCase):
         for output, target in zip(outputs, instance_targets):
             self.assertDictEqual(output["score"]["instance"], target)
 
+    def test_accuracy_with_prefix(self):
+        metric = Accuracy(score_prefix="my_")
+
+        predictions = ["A", "B", "C"]
+        references = [["B", "C"], ["A"], ["B", "C"]]
+
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+
+        expected_global_result = {
+            "my_accuracy": 1 / 3,
+            "score": 1 / 3,
+            "score_name": "my_accuracy",
+        }
+
+        global_result = outputs[0]["score"]["global"].copy()
+        # Only check the keys that are expected, i.e. exist in expected_global_result
+        global_result = {
+            key: value
+            for key, value in global_result.items()
+            if key in expected_global_result
+        }
+        self.assertDictEqual(global_result, expected_global_result)
+
+        instance_targets = [
+            {"my_accuracy": 0.0, "score": 0.0, "score_name": "my_accuracy"},
+            {"my_accuracy": 0.0, "score": 0.0, "score_name": "my_accuracy"},
+            {"my_accuracy": 1.0, "score": 1.0, "score_name": "my_accuracy"},
+        ]
+        for output, target in zip(outputs, instance_targets):
+            self.assertDictEqual(output["score"]["instance"], target)
+
     def test_accuracy_max_aggregation(self):
         metric = MaxAccuracy()
 
@@ -238,6 +271,42 @@ class TestMetrics(UnitxtTestCase):
         self.assertAlmostEqual(global_target, outputs[0]["score"]["global"]["score"])
         self.assertEqual("f1_micro", outputs[0]["score"]["global"]["score_name"])
         self.assertEqual("f1_micro", outputs[0]["score"]["instance"]["score_name"])
+
+    def test_f1_micro_with_prefix(self):
+        metric = F1Micro(score_prefix="my_")
+
+        references = [["cat"], ["dog"], ["dog"], ["dog"], ["cat"], ["cat"]]
+        predictions = ["cat", "cat", "dog", "dog", "cat", "cat"]
+
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+
+        expected_global_result = {
+            "my_f1_micro": 5 / 6,
+            "score": 5 / 6,
+            "score_name": "my_f1_micro",
+        }
+
+        global_result = outputs[0]["score"]["global"].copy()
+        # Only check the keys that are expected, i.e. exist in expected_global_result
+        global_result = {
+            key: value
+            for key, value in global_result.items()
+            if key in expected_global_result
+        }
+        self.assertDictEqual(global_result, expected_global_result)
+
+        instance_targets = [
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 0.0, "score": 0.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+            {"my_f1_micro": 1.0, "score": 1.0, "score_name": "my_f1_micro"},
+        ]
+        for output, target in zip(outputs, instance_targets):
+            self.assertDictEqual(output["score"]["instance"], target)
 
     def test_f1_errors(self):
         metric = F1Micro()
@@ -1063,6 +1132,47 @@ class TestMetrics(UnitxtTestCase):
         )
         self.assertTrue("f1_Person" not in outputs[0]["score"]["global"])
         self.assertTrue("f1_Location" not in outputs[0]["score"]["global"])
+
+    def test_perplexity_with_prefix(self):
+        prediction = ["who are we?"]
+        references = [["we are the world"]]
+
+        perplexity_question = Perplexity(
+            model_name="google/flan-t5-small",
+            source_template="Generate a question based on the given content: {reference}",
+            target_template="{prediction}",
+            score_prefix="my_",
+        )
+
+        outputs = apply_metric(
+            metric=perplexity_question, predictions=prediction, references=references
+        )
+
+        expected_global_result = {
+            "my_perplexity": 0.05986589565873146,
+            "score": 0.05986589565873146,
+            "score_name": "my_perplexity",
+        }
+
+        global_result = outputs[0]["score"]["global"].copy()
+        # Only check the keys that are expected, i.e. exist in expected_global_result
+        global_result = {
+            key: value
+            for key, value in global_result.items()
+            if key in expected_global_result
+        }
+        self.assertDictEqual(global_result, expected_global_result)
+
+        instance_targets = [
+            {
+                "my_perplexity": 0.05986589565873146,
+                "score": 0.05986589565873146,
+                "score_name": "my_perplexity",
+                "my_reference_scores": [0.05986589565873146],
+            }
+        ]
+        for output, target in zip(outputs, instance_targets):
+            self.assertDictEqual(output["score"]["instance"], target)
 
 
 class TestConfidenceIntervals(UnitxtTestCase):

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -675,7 +675,7 @@ class TestOperators(UnitxtTestCase):
             tester=self,
         )
 
-        exception_text = """Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to get 'label2' due to : query "label2" did not match any item in dict:
+        exception_text = """Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to get 'label2' from {'label': 'b'} due to : query "label2" did not match any item in dict:
 label (str):
     b
 """

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -675,7 +675,10 @@ class TestOperators(UnitxtTestCase):
             tester=self,
         )
 
-        exception_text = "Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to get 'label2' from {'label': 'b'} due to : query \"label2\" did not match any item in dict: {'label': 'b'}"
+        exception_text = """Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to get 'label2' due to : query "label2" did not match any item in dict:
+label (str):
+    b
+"""
         check_operator_exception(
             operator=RemoveValues(field="label2", unallowed_values=["c"]),
             inputs=inputs,
@@ -2267,7 +2270,12 @@ class TestOperators(UnitxtTestCase):
         )
 
         inputs = [{"prediction": "red", "references": "blue"}]
-        exception_text = "Error processing instance '0' from stream 'test' in EncodeLabels due to: query \"references/*\" did not match any item in dict: {'prediction': 'red', 'references': 'blue'}"
+        exception_text = """Error processing instance '0' from stream 'test' in EncodeLabels due to: query \"references/*\" did not match any item in dict:
+prediction (str):
+    red
+references (str):
+    blue
+"""
         check_operator_exception(
             operator=EncodeLabels(fields=["references/*", "prediction"]),
             inputs=inputs,


### PR DESCRIPTION
here were some very subtle bugs in treatment of operators.

The issue was that if we assign a field to a field (E.g in CopyField operator) , and these are both fields that are dictionary.
then field the dictionary values of the source field were copied to the target field.
If the one of these fields, was further modified - they effected on another.

CopyField(pred -> pred_orig)
CopyField(pred/contexts -> refs)
ListFields[task/question -> pred)

Following this, pred_orig was equal to the task/question.

As a first solution - I a deep copied instances in instance operators, so they don't effect each other.

Another issue was that metric global scores were shared across instances, and this also caused problems following the above change. The code was simplified that each global score is a separate object.

Finally, added an option for metric to receive a score_prefix, that is added to all scores (except "score" and "score_name").
This allows running the same metric on two different fields of the task.

