### PR TITLE
use aggregators as a uniform incarnation for the across-instances computation for both instance and global metrics

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-08-04T13:44:11Z",
+  "generated_at": "2024-08-04T16:04:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "fa172616e9af3d2a24b5597f264eab963fe76889",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1894,
+        "line_number": 882,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/src/unitxt/aggregators.py
+++ b/src/unitxt/aggregators.py
@@ -1,0 +1,407 @@
+import warnings
+from abc import abstractmethod
+from collections import defaultdict
+from typing import Any, Callable, Dict, List, Literal, Tuple
+
+import numpy
+import numpy as np
+from scipy.stats import bootstrap
+
+from .artifact import Artifact
+from .dict_utils import dict_get
+from .operators import FilterByCondition
+from .random_utils import get_seed
+
+
+class Aggregator(Artifact):
+    """Aggregates over a list of instances, updating the score/global field of each of them by a dictionary of scores."""
+
+    score_names: List[str] = None
+
+    # currently, for backward compatibility, non trivial only for grouper_aggregator
+    aggregator_based_score_prefix = ""
+
+    # computes global score, and accordingly updates instance["score"]["global"] of each instance
+    @abstractmethod
+    def aggregate(self, instances: List[Dict[str, Any]]) -> Dict[str, Any]:
+        pass
+
+    # prefix and add "score" and "score_name"
+    def prefix_global_scores(self, gs: Dict[str, Any]) -> Dict[str, Any]:
+        full_prefix = self.aggregator_based_score_prefix + self.score_prefix
+        new_gs = {}
+        new_gs["score_name"] = full_prefix + self.main_score
+        new_gs["score"] = gs[self.main_score]
+        if self.main_score + "_ci_low" in gs:
+            new_gs["score_ci_low"] = gs[self.main_score + "_ci_low"]
+        if self.main_score + "_ci_high" in gs:
+            new_gs["score_ci_high"] = gs[self.main_score + "_ci_high"]
+
+        for score_name, score in gs.items():
+            new_gs[full_prefix + score_name] = score
+
+        return new_gs
+
+    # trivial for all but grouperaggregator
+    def instances_to_sample_from_and_sample_aggregator(
+        self, instances: List[Dict[str, Any]]
+    ) -> Tuple[List[Dict[str, Any]], Any]:
+        return (instances, self)
+
+    def set_metric_related_properties(
+        self,
+        is_serving_global_metric: bool,
+        n_resamples: int,
+        ci_scores: List[str],
+        main_score: str,
+        score_prefix: str = "",
+        aggregating_function_name: str = "",
+        confidence_level: float = 0.95,
+    ):
+        self.n_resamples = n_resamples
+        self.ci_scores = ci_scores
+        self.confidence_level = confidence_level
+        self.main_score = main_score
+        self.score_prefix = score_prefix
+        self.aggregating_function_name = aggregating_function_name
+        self.is_serving_global_metric = is_serving_global_metric
+
+    def compute_ci(self, instances: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if (
+            self.n_resamples is None
+            or self.n_resamples <= 0
+            or len(self.ci_scores) == 0
+        ):
+            return {}
+        (
+            instances_to_sample_from,
+            aggregator,
+        ) = self.instances_to_sample_from_and_sample_aggregator(instances)
+        confidence_interval_calculator = ConfidenceIntervalCalculator(
+            n_resamples=self.n_resamples,
+            ci_scores=self.ci_scores,
+            confidence_level=self.confidence_level,
+            instances_to_sample_from=instances_to_sample_from,
+            aggregator=aggregator,
+            is_serving_global_metric=self.is_serving_global_metric,
+        )
+        return confidence_interval_calculator.compute_ci()
+
+    # update instance["score"]["global"] with the newly computed global score, for the
+    # current metric computed.  global_score contains "score" and "score_name" fields that reflect
+    # (the main_score of) the current metric.
+    # A simple python-dictionary-update adds new fields to instance["score"]["global"], and also replaces the values
+    # of its fields "score" and "score_name", to reflect the current metric, overwriting previous metrics' settings
+    # of these fields (if any previous metric exists).
+    # When global_score does NOT contain ci score (because CI was not computed for the current metric), but
+    # one of the previous metrics computed did have, the last of such previous metrics set the values in
+    # fields "score_ci_low" and "score_ci_high" in instance["score"]["global"] to reflect its
+    # (the previous metric's) CI scores.
+    # Because CI is not computed for the current metric, global_score does not contain fields "score_ci_low" and
+    # "score_ci_high" to overwrite the ones existing in instance["score"]["global"], and these might remain in
+    # instance["score"]["global"], but their values, that are not associated with the current metric, are,
+    # therefore, not consistent with "score_name".
+    # In such a case, following the python-dictionary-update, we pop out fields "score_ci_low" and
+    # "score_ci_high" from instance["score"]["global"], so that now all the fields "score.." in
+    # instance["score"]["global"] are consistent with the current metric: The current metric
+    # is named instance["score"]["global"]["score_name"], its score shows in
+    # field instance["score"]["global"]["score"], and it does not have ci_scores,
+    # which is also reflected in the absence of fields "score_ci_low" and "score_ci_high" from instance["score"]["global"].
+    # If ci IS computed for the current metric, global_score contains "score_ci_low" and "score_ci_high", and these overwrite
+    # the ones existing in instance["score"]["global"] by a simple python-dictionary-update, and no need for any further fixeup.
+    def update_and_adjust_global_score(
+        self, instance: Dict[str, Any], global_score: dict
+    ):
+        instance["score"]["global"].update(global_score)
+        for score_ci in ["score_ci_low", "score_ci_high"]:
+            if score_ci in global_score:
+                continue
+            if score_ci in instance["score"]["global"]:
+                instance["score"]["global"].pop(score_ci)
+
+    def update_global_score(self, instances: List[Dict[str, Any]], gs: Dict[str, Any]):
+        for instance in instances:
+            if "global" not in instance["score"]:
+                instance["score"]["global"] = {}
+            self.update_and_adjust_global_score(instance, gs)
+
+    def compute_global_score(self, instances: List[Dict[str, Any]]):
+        gs = self.aggregate(instances)
+        gs.update(self.compute_ci(instances))
+        gs = self.prefix_global_scores(gs)
+        self.update_global_score(instances=instances, gs=gs)
+
+
+class MeanAggregator(Aggregator):
+    def aggregate(self, instances: List[Dict[str, Any]]) -> Dict[str, Any]:
+        result = {}
+        for score_name in self.score_names:
+            result[score_name] = nan_mean(
+                [instance["score"]["instance"][score_name] for instance in instances]
+            )
+
+        return result
+
+
+class MaxAggregator(Aggregator):
+    def aggregate(self, instances: List[Dict[str, Any]]) -> Dict[str, Any]:
+        result = {}
+        for score_name in self.score_names:
+            result[score_name] = nan_max(
+                [instance["score"]["instance"][score_name] for instance in instances]
+            )
+
+        return result
+
+
+class FilterAggregator(Aggregator):
+    aggregator: Aggregator
+    filter_by_condition: FilterByCondition
+
+    def aggregate(self, instances: List[Dict[str, Any]]) -> Dict[str, Any]:
+        filtered_instances = [
+            instance
+            for instance in instances
+            if self.filter_by_condition._is_required(instance)
+        ]
+
+        self.aggregator.score_names = self.score_names
+        return self.aggregator.aggregate(instances=filtered_instances)
+
+
+class GrouperAggregator(Aggregator):
+    """Splits the input instances into groups by the value found in them in field "split_to_groups_by_query".
+
+    Then, aggregates over each group yielding a dictionary of global scores.
+    These dictionaries are then sorted by the values associated with each
+    group, by which it was split from the other groups, and "dressed" like instance scores, and these are
+    averaged, to return the result.
+    """
+
+    split_to_groups_by_query: str
+    one_group_aggregator: Aggregator
+    # the following boolean flag specifies whether resampling for CI
+    # should be done from the individual groups' scores (True), as if each group is represented by
+    # one instance whose instance["score"]["instance"][score_name] is the group's global score for score_name,
+    # Or from the whole stream (False), where each resample is then split to
+    # groups, the score of which is then computed, and finally averaged with the other groups' scores, as done
+    # here for the original whole stream.
+    ci_samples_from_groups_scores: bool = False
+
+    def split_to_group_by(
+        self, instances: List[Dict[str, Any]]
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        res = defaultdict(list)
+        for instance in instances:
+            val = dict_get(instance, self.split_to_groups_by_query)
+            res[val].append(instance)
+        return res
+
+    def gen_instances_from_group_scores(
+        self, instances: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        ms_dict = self.split_to_group_by(instances)
+        self.one_group_aggregator.score_names = self.score_names
+        groups_scores = []
+        for group_name in sorted(ms_dict.keys()):
+            group_gs = self.one_group_aggregator.aggregate(
+                instances=ms_dict[group_name]
+            )
+            groups_scores.append({"score": {"instance": group_gs}})
+        return groups_scores
+
+    def aggregate(self, instances: List[Dict[str, Any]]) -> Dict[str, Any]:
+        groups_scores = self.gen_instances_from_group_scores(instances)
+        over_groups_aggregator = MeanAggregator(score_names=self.score_names)
+        return over_groups_aggregator.aggregate(groups_scores)
+
+    def prefix_global_scores(self, gs: Dict[str, Any]) -> Dict[str, Any]:
+        # for backward compatibility, only for this aggregator we have this informative prefix, perhaps now
+        # is time to allow for other aggregators too
+        self.aggregator_based_score_prefix = (
+            "fixed_group_" if self.ci_samples_from_groups_scores else "group_"
+        )
+        if len(self.aggregating_function_name) > 0:
+            self.aggregator_based_score_prefix += self.aggregating_function_name + "_"
+        return super().prefix_global_scores(gs=gs)
+
+    def instances_to_sample_from_and_sample_aggregator(
+        self, instances: List[Dict[str, Any]]
+    ) -> Tuple[List[Dict[str, Any]], Aggregator]:
+        if self.ci_samples_from_groups_scores:
+            return (
+                self.gen_instances_from_group_scores(instances),
+                MeanAggregator(score_names=self.score_names),
+            )
+        return (instances, self)
+
+
+class ControlComparisonAggregator(Aggregator):
+    # Generate a score that compares the scores of two subsets of the input stream: subset 'control' and subset 'comparison'
+    # The input stream (instances) may be one group (in case that split_to_groups_by is not None), or per the whole
+    # stream (in case that split_to_groups_by is None).
+    control_comparison_subsets: Dict[
+        Literal["control", "comparison"], FilterByCondition
+    ]
+    control_comparison_floats_comparator: Callable[[List[float], List[float]], float]
+    return_abs_value: bool = False
+
+    def aggregate(self, instances: List[Dict[str, Any]]) -> Dict[str, Any]:
+        subsets_dict = {
+            side: [
+                instance
+                for instance in instances
+                if self.control_comparison_subsets[side]._is_required(instance)
+            ]
+            for side in ["control", "comparison"]
+        }
+        dict_to_return = {}
+        for score_name in self.score_names:
+            control_floats = [
+                instance["score"]["instance"][score_name]
+                for instance in subsets_dict["control"]
+            ]
+            comparison_floats = [
+                instance["score"]["instance"][score_name]
+                for instance in subsets_dict["comparison"]
+            ]
+            val = self.control_comparison_floats_comparator(
+                control_subset=control_floats, comparison_subset=comparison_floats
+            )
+
+            dict_to_return[score_name] = np.abs(val) if self.return_abs_value else val
+        return dict_to_return
+
+
+class ConfidenceIntervalCalculator(Artifact):
+    """Generates samples from the input instances, then aggregates each sample, and returns the percentiles."""
+
+    n_resamples: int = None
+    ci_scores: List[str] = None
+
+    confidence_level: float = 0.95
+    instances_to_sample_from: List[Dict[str, Any]]
+    aggregator: Aggregator  # to aggregate over each resample
+    is_serving_global_metric: bool  # needed for a precheck of all scores are equal
+
+    @staticmethod
+    def new_random_generator():
+        # The np.random.default_rng expects a 32-bit int, while hash(..) can return a 64-bit integer.
+        # So use '& MAX_32BIT' to get a 32-bit seed.
+        _max_32bit = 2**32 - 1
+        return np.random.default_rng(hash(get_seed()) & _max_32bit)
+
+    def _can_compute_confidence_intervals(
+        self, instances: List[Dict[str, Any]]
+    ) -> bool:
+        return (
+            self.n_resamples is not None and self.n_resamples > 1 and len(instances) > 1
+        )
+
+    def resample_from_non_nan(self, values):
+        """Given an array values, will replace any NaN values with elements resampled with replacement from the non-NaN ones.
+
+        here we deal with samples on which the metric could not be computed. These are
+        edge cases - for example, when the sample contains only empty strings.
+        CI is about the distribution around the statistic (e.g. mean), it doesn't deal with
+        cases in which the metric is not computable. Therefore, we ignore these edge cases
+        as part of the computation of CI.
+
+        In theory there would be several ways to deal with this:
+        1. skip the errors and return a shorter array => this fails because Scipy requires
+        this callback (i.e. the statistic() callback) to return an array of the same size
+        as the number of resamples
+        2. Put np.nan for the errors => this fails because in such case the ci itself
+        becomes np.nan. So one edge case can fail the whole CI computation.
+        3. Replace the errors with a sampling from the successful cases => this is what is implemented.
+
+        This resampling makes it so that, if possible, the bca confidence interval returned by bootstrap will not be NaN, since
+        bootstrap does not ignore NaNs.  However, if there are 0 or 1 non-NaN values, or all non-NaN values are equal,
+        the resulting distribution will be degenerate (only one unique value) so the CI will still be NaN since there is
+        no variability.  In this case, the CI is essentially an interval of length 0 equaling the mean itself.
+        """
+        if values.size > 1:
+            error_indices = numpy.isnan(values)
+            n_errors = sum(error_indices)
+            if 0 < n_errors < values.size:
+                # replace NaN aggregate scores with random draws from non-NaN scores, so that confidence interval isn't NaN itself
+                values[error_indices] = self.new_random_generator().choice(
+                    values[~error_indices], n_errors, replace=True
+                )
+        return values
+
+    @staticmethod
+    def _all_instance_scores_equal(instances, score_name):
+        instance_scores = [
+            instance["score"]["instance"][score_name] for instance in instances
+        ]
+        non_nan_instance_scores = [
+            score for score in instance_scores if score is not np.nan
+        ]
+        num_unique_scores = len(set(non_nan_instance_scores))
+        return num_unique_scores == 1
+
+    def compute_ci(self) -> Dict[str, Any]:
+        """Compute confidence intervals based on existing scores, if exist, or compute via arg metric."""
+        if not self._can_compute_confidence_intervals(self.instances_to_sample_from):
+            return {}
+
+        result = {}
+
+        for score_name in self.ci_scores:
+            if not self.is_serving_global_metric and self._all_instance_scores_equal(
+                self.instances_to_sample_from, score_name
+            ):
+                continue
+
+            # generate resamples from instances_to_sample_from, then aggregate over each.
+            # and extract the percentiles thereof
+
+            # need to redefine the statistic function within the loop because score_name is a loop variable
+            def statistic(arr, axis, score_name=score_name):
+                # arr is a 2d array where each row is a resampling, so we
+                # iterate over the rows and compute the metric on each resampling
+                scores = numpy.apply_along_axis(
+                    lambda resampled_instances: self.aggregator.aggregate(
+                        instances=resampled_instances
+                    )[score_name],
+                    axis=axis,
+                    arr=arr,
+                )
+                return self.resample_from_non_nan(scores)
+
+            with warnings.catch_warnings():
+                # Avoid RuntimeWarning in bootstrap computation. This happens on small datasets where
+                # the value of the computed global metric is the same on all resamplings.
+                warnings.simplefilter("ignore", category=RuntimeWarning)
+                ci = bootstrap(
+                    (self.instances_to_sample_from,),
+                    statistic=statistic,
+                    n_resamples=self.n_resamples,
+                    confidence_level=self.confidence_level,
+                    random_state=self.new_random_generator(),
+                ).confidence_interval
+            result[score_name + "_ci_low"] = ci.low
+            result[score_name + "_ci_high"] = ci.high
+
+        return result
+
+
+def nan_mean(x):
+    with warnings.catch_warnings():
+        # final mean should be mean of scores, ignoring NaN, hence nanmean
+        # but if the group function values is NaN for ALL values, nanmean throws a
+        # RuntimeWarning that it is calculating the mean of an empty slice (with no non-Nans)
+        # this is the desired behavior, but we want to avoid the warning here
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        return np.nanmean(x)
+
+
+def nan_max(x):
+    with warnings.catch_warnings():
+        # final mean should be mean of scores, ignoring NaN, hence nanmax
+        # but if the group function values is NaN for ALL values, nanmean throws a
+        # RuntimeWarning that it is calculating the mean of an empty slice (with no non-Nans)
+        # this is the desired behavior, but we want to avoid the warning here
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        return np.nanmax(x)

--- a/src/unitxt/base_metrics.py
+++ b/src/unitxt/base_metrics.py
@@ -1,0 +1,456 @@
+import warnings
+from abc import abstractmethod
+from typing import Any, Dict, Generator, List, Optional, Union
+
+import numpy as np
+from scipy.stats._warnings_errors import DegenerateDataWarning
+
+from .aggregators import Aggregator, MeanAggregator
+from .artifact import Artifact
+from .dataclass import AbstractField, Field, OptionalField
+from .logging_utils import get_logger
+from .operator import StreamOperator
+from .settings_utils import get_settings
+from .stream import Stream
+from .type_utils import Type, isoftype, parse_type_string, to_type_string
+
+logger = get_logger()
+settings = get_settings()
+warnings.filterwarnings("ignore", category=DegenerateDataWarning)
+
+
+def parse_string_types_instead_of_actual_objects(obj):
+    return parse_type_string(obj)
+
+
+class Metric(Artifact):
+    main_score: str = AbstractField()
+    # Override 'prediction_type' with the expected type of predictions
+    # and references.  Example: "List[str]", "List[Dict]"", "string".
+    # If left with default None, a warning will be displayed.
+    # In future versions of unitxt, this will be an error.
+    prediction_type: Union[Type, str] = Any
+
+    reference_field: str = "references"
+    prediction_field: str = "prediction"
+    task_data_field: str = "task_data"
+
+    # Standard metrics can receive multiple references per predictions (in a list)
+    # Some metrics support only a single reference per prediction (one element in the list)
+    single_reference_per_prediction: bool = False
+
+    # Used to store the parsed prediction type and avoid
+    # parsing on every use
+    _parsed_prediction_type = None
+
+    #
+    # Used to add a prefix to all score, except the "score_name" and "score" fields.
+    # This is used to distinguish two scores of the same metrics, operating on different fields of the task
+    #
+    score_prefix: str = ""
+
+    def prepare(self):
+        super().prepare()
+        if isinstance(self.prediction_type, str):
+            self.prediction_type = parse_string_types_instead_of_actual_objects(
+                self.prediction_type
+            )
+
+    @classmethod
+    def process_data_after_load(cls, data):
+        if "prediction_type" in data:
+            data["prediction_type"] = parse_type_string(data["prediction_type"])
+        return data
+
+    def process_data_before_dump(self, data):
+        if "prediction_type" in data:
+            if not isinstance(data["prediction_type"], str):
+                data["prediction_type"] = to_type_string(data["prediction_type"])
+        return data
+
+    def _add_score_prefix(self, score_name):
+        return (
+            self.score_prefix + score_name
+            if score_name not in ["score", "score_name"]
+            else score_name
+        )
+
+    def _add_score_prefixes_to_score_dict(self, scores: Dict[str, Any]):
+        new_scores = {}
+        for score_name, score in scores.items():
+            score_with_prefix = self._add_score_prefix(score_name)
+            new_scores[score_with_prefix] = (
+                score if score_name not in ["score_name"] else self.score_prefix + score
+            )
+        return new_scores
+
+    # for instance scores that only include the raw score names
+    def add_score_score_name_and_score_prefix_to_instance_score(
+        self, instances: List[Dict[str, Any]]
+    ):
+        for instance in instances:
+            if self.main_score not in instance["score"]["instance"]:
+                # possible for global metric, for example, that do not score every instance
+                continue
+
+            if len(self.score_prefix) == 0:
+                instance["score"]["instance"]["score_name"] = self.main_score
+                instance["score"]["instance"]["score"] = instance["score"]["instance"][
+                    self.main_score
+                ]
+
+            else:
+                new_instance_score = {}
+                new_instance_score["score_name"] = self.score_prefix + self.main_score
+                new_instance_score["score"] = instance["score"]["instance"][
+                    self.main_score
+                ]
+
+                for score_name, score in instance["score"]["instance"].items():
+                    if score_name in ["score", "score_name"]:
+                        # already in new_instance_score
+                        continue
+                    if score_name not in self.recently_added_instance_scores:
+                        # copy as is:
+                        new_instance_score[score_name] = score
+                    else:
+                        new_instance_score[self.score_prefix + score_name] = score
+                instance["score"]["instance"] = new_instance_score
+
+    def _validate_references_and_predictions(self, references, predictions):
+        if not isoftype(predictions, List[Any]):
+            raise ValueError(
+                f"Metric {self.get_metric_name()} should receive a list of predictions {self.get_metric_name()}.  Received predictions of type {type(predictions)}: {predictions}"
+            )
+
+        if not isoftype(references, List[Any]):
+            raise ValueError(
+                f"Metric {self.get_metric_name()} should receive a list of predictions. Received references of type {type(references)}: {references}"
+            )
+
+        if len(references) != len(predictions):
+            raise ValueError(
+                f"references size ({len(references)})"
+                f" doesn't mach predictions size ({len(references)})."
+            )
+
+        for reference in references:
+            self._validate_reference(reference)
+
+        for prediction in predictions:
+            self._validate_prediction(prediction)
+
+    def _validate_prediction(self, prediction):
+        if not isoftype(prediction, self.prediction_type):
+            raise ValueError(
+                f"Each prediction is expected to be of type '{to_type_string(self.prediction_type)}' in {self.get_metric_name()} metric. Received prediction of type {type(prediction)}: {prediction}"
+            )
+
+    def _validate_reference(self, reference):
+        if not isoftype(reference, List[Any]):
+            raise ValueError(
+                f"Expecting a list of references for each prediction in {self.get_metric_name()} metric. Received reference of type {type(reference)}: {reference}"
+            )
+        if self.single_reference_per_prediction and not len(reference) == 1:
+            raise ValueError(
+                f"Expecting a list with a single reference per prediction in {self.get_metric_name()} metric. Received a list with multiple references: {reference}"
+            )
+        for ref in reference:
+            if not isoftype(ref, self.prediction_type):
+                raise ValueError(
+                    f"Each reference is expected to be of type '{to_type_string(self.prediction_type)}' in {self.get_metric_name()} metric. Received reference of type {type(ref)}: {ref}"
+                )
+
+    def get_metric_name(self):
+        if self.__id__ is not None:
+            return self.__id__
+        return self.__class__.__name__
+
+    @abstractmethod
+    def disable_confidence_interval_calculation(self):
+        pass
+
+    # needed also be RemoteMetric
+    def consume_stream(
+        self,
+        stream: Stream,
+    ):
+        references_list = []
+        prediction_list = []
+        task_data_list = []
+        instance_list = []
+        for instance in stream:
+            instance = self.verify_instance(instance)
+
+            task_data = (
+                instance[self.task_data_field]
+                if self.task_data_field in instance
+                else {}
+            )
+
+            if self.reference_field == "references":
+                refs = instance["references"]
+            else:
+                refs = task_data[self.reference_field]
+                if not isinstance(refs, list):
+                    refs = [refs]
+            if self.prediction_field == "prediction":
+                pred = instance["prediction"]
+            else:
+                pred = task_data[self.prediction_field]
+
+            references_list.append(refs)
+            prediction_list.append(pred)
+            task_data_list.append(task_data)
+
+            if "score" not in instance:
+                instance["score"] = {"global": {}, "instance": {}}
+            if "instance" not in instance["score"]:
+                instance["score"]["instance"] = {}
+            if "global" not in instance["score"]:
+                instance["score"]["global"] = {}
+            instance_list.append(instance)
+        self._validate_references_and_predictions(references_list, prediction_list)
+        return prediction_list, references_list, task_data_list, instance_list
+
+
+class MetricWithConfidenceInterval(Metric, StreamOperator):
+    # The number of resamples used to estimate the confidence intervals of this metric.
+    # From all over unitxt, use None to disable confidence interval computation.
+    n_resamples: int = None
+    ci_scores: List[str] = None
+
+    # aggregates along the instances, according to all settings
+    aggregator: Aggregator = None
+    score_names: List[str] = None
+
+    # the name to associate with the aggregator, to participate in prefixes for score_names
+    aggregating_function_name: str = ""
+
+    @abstractmethod
+    def compute_each_single_instance(
+        self,
+        references_list: List[List[Any]],
+        prediction_list: List[Any],
+        task_data_list: List[Dict[str, Any]],
+        instance_list: List[Dict[str, Any]],
+    ):
+        pass
+        # also updates instance["score"]["instance"] but not yet prefixed
+
+    def compute_all_instances(
+        self,
+        references_list: List[List[Any]],
+        prediction_list: List[Any],
+        task_data_list: List[Dict[str, Any]],
+        instance_list: List[Dict[str, Any]],
+    ):
+        # We now proceed to calculate global score, still no prefixes and no "score" and "score_name"
+        self.aggregator.set_metric_related_properties(
+            is_serving_global_metric=isinstance(self, GlobalMetric),
+            n_resamples=self.n_resamples,
+            ci_scores=self.ci_scores,
+            main_score=self.main_score,
+            score_prefix=self.score_prefix,
+            aggregating_function_name=self.aggregating_function_name,
+            confidence_level=0.95,
+        )
+
+        # do everything related to global score and CI
+        # also updates the global scores in the instance["score"]["global"] -s
+        # still all score names are non-prefixed
+        self.aggregator.compute_global_score(instance_list)
+
+    def prepare(self):
+        assert self.aggregator is not None
+        assert issubclass(type(self.aggregator), Aggregator)
+        if not hasattr(self, "score_names") or self.score_names is None:
+            self.score_names = [self.main_score]
+        if self.aggregator.score_names is None:
+            self.aggregator.score_names = self.score_names
+        if self.ci_scores is None:
+            self.ci_scores = [self.main_score]
+        self.recently_added_instance_scores = [self.main_score]
+        super().prepare()
+
+    def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
+        (
+            prediction_list,
+            references_list,
+            task_data_list,
+            instance_list,
+        ) = self.consume_stream(stream=stream)
+
+        self.compute_each_single_instance(
+            references_list, prediction_list, task_data_list, instance_list
+        )
+
+        # the following includes the update of global scores in the instances
+        self.compute_all_instances(
+            references_list, prediction_list, task_data_list, instance_list
+        )
+
+        # these, and the instance_scores were kept in their original name (unprefixed) to ease aggregation overthem
+        # so now we complete all these prefixes
+        self.add_score_score_name_and_score_prefix_to_instance_score(instance_list)
+
+        yield from instance_list
+
+    def disable_confidence_interval_calculation(self):
+        self.n_resamples = None
+
+
+class GlobalMetric(MetricWithConfidenceInterval, Aggregator):
+    """A class for computing metrics that require joint calculations over all instances and are not just aggregation of scores of individuals instances.
+
+    For example, macro_F1 requires
+    calculation requires calculation of recall and precision per class, so all instances of the class
+    need to be considered.  Accuracy, on the other hand, is just an average of the accuracy of all the instances.
+    """
+
+    n_resamples = OptionalField(
+        default_factory=lambda: settings.num_resamples_for_global_metrics
+    )
+
+    # calculate scores for single instances
+    process_single_instances = True
+
+    aggregating_function_name = ""
+    # for global metric, the bare score names carry the name of the aggregation
+
+    def prepare(self):
+        if self.aggregator is None:
+            self.aggregator = self
+        self.score_names = [self.main_score]
+        super().prepare()
+
+    def compute_each_single_instance(
+        self,
+        references_list: List[List[Any]],
+        prediction_list: List[Any],
+        task_data_list: List[Dict[str, Any]],
+        instance_list: List[Dict[str, Any]],
+    ):
+        for prediction, references, task_data, instance in zip(
+            prediction_list, references_list, task_data_list, instance_list
+        ):
+            instance_score = None
+
+            # for backward compatibility
+            no_score_value = np.nan
+            if self.process_single_instances:
+                try:
+                    instance_score = self.compute(
+                        [references], [prediction], [task_data]
+                    )
+                except:
+                    no_score_value = None
+            if not instance_score:
+                instance_score = {
+                    "score": no_score_value,
+                    "score_name": self.main_score,
+                }
+
+                if isinstance(self.main_score, str):
+                    instance_score[self.main_score] = no_score_value
+
+            instance["score"]["instance"].update(instance_score)
+
+    def aggregate(self, instances: List[Dict[str, Any]]) -> Dict[str, Any]:
+        predictions, references, task_data, _ = self.consume_stream(stream=instances)
+        return self.compute(references, predictions, task_data)
+
+    @abstractmethod
+    def compute(
+        self,
+        references: List[List[Any]],
+        predictions: List[Any],
+        task_data: List[Any],
+    ) -> dict:
+        """Computes a scores dictionary on a list of references, predictions and input.
+
+        This function is called once per instance, and then another time
+        over all data instances.
+
+        Returns:
+            a dictionary of scores that is set as:
+              the instance scores when called on a single data instance
+              the global score when called on the all data instances
+        """
+        pass
+
+
+class BulkInstanceMetric(MetricWithConfidenceInterval):
+    n_resamples = OptionalField(
+        default_factory=lambda: settings.num_resamples_for_instance_metrics
+    )
+    main_score: str
+    score_names: List[str] = None
+
+    aggregator = Field(default_factory=lambda: MeanAggregator(score_names=None))
+    aggregating_function_name = "mean"
+
+    def prepare(self):
+        if self.main_score is None:
+            self.main_score = "f1"
+        super().prepare()
+        self.ci_scores = list(set(self.ci_scores))
+
+    # just to give implementations of the abstract methods of MetricWithConfidenceInterval
+    # this class uses its own process()
+    def compute_each_single_instance(
+        self,
+        references_list: List[List[Any]],
+        prediction_list: List[Any],
+        task_data_list: List[Dict[str, Any]],
+        instance_list: List[Dict[str, Any]],
+    ):
+        # compute the metric over all refs and preds
+        instance_scores = self.compute(
+            references=references_list,
+            predictions=prediction_list,
+            task_data=task_data_list,
+        )
+        for instance, score in zip(instance_list, instance_scores):
+            instance["score"]["instance"].update(score)
+        # "score_name", and "score"  and prefixes are not yet updated in instance scores
+
+    @abstractmethod
+    def compute(
+        self,
+        references: List[List[Any]],
+        predictions: List[Any],
+        task_data: List[Dict],
+    ) -> List[Dict[str, Any]]:
+        pass
+
+
+class InstanceMetric(MetricWithConfidenceInterval):
+    """Class for metrics for which a global score can be calculated by aggregating the instance scores (possibly with additional instance inputs)."""
+
+    n_resamples = OptionalField(
+        default_factory=lambda: settings.num_resamples_for_instance_metrics
+    )
+
+    aggregator = Field(default_factory=lambda: MeanAggregator(score_names=None))
+    aggregating_function_name = "mean"
+
+    def compute_each_single_instance(
+        self,
+        references_list: List[List[Any]],
+        prediction_list: List[Any],
+        task_data_list: List[Dict[str, Any]],
+        instance_list: List[Dict[str, Any]],
+    ):
+        for prediction, references, task_data, instance in zip(
+            prediction_list, references_list, task_data_list, instance_list
+        ):
+            instance_score = self.compute(
+                references=references, prediction=prediction, task_data=task_data
+            )
+            self.recently_added_instance_scores = list(instance_score.keys())
+            instance["score"]["instance"].update(instance_score)
+
+    @abstractmethod
+    def compute(self, references: List[Any], prediction: Any, task_data: Dict) -> dict:
+        pass

--- a/src/unitxt/dataset.py
+++ b/src/unitxt/dataset.py
@@ -2,8 +2,10 @@ import os
 
 import datasets
 
+from .aggregators import __file__ as _
 from .api import __file__ as _
 from .artifact import __file__ as _
+from .base_metrics import __file__ as _
 from .blocks import __file__ as _
 from .card import __file__ as _
 from .catalog import __file__ as _

--- a/src/unitxt/metric.py
+++ b/src/unitxt/metric.py
@@ -2,8 +2,10 @@ from typing import Dict, Iterable, List
 
 import evaluate
 
+from .aggregators import __file__ as _
 from .api import __file__ as _
 from .artifact import __file__ as _
+from .base_metrics import __file__ as _
 from .blocks import __file__ as _
 from .card import __file__ as _
 from .catalog import __file__ as _

--- a/tests/library/test_metric_utils.py
+++ b/tests/library/test_metric_utils.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 from unitxt.fusion import FixedFusion
 from unitxt.metric_utils import MultiStreamScoreMean
 from unitxt.metrics import Rouge
@@ -12,27 +10,12 @@ class TestMetricUtils(UnitxtTestCase):
     def test_rougel_simple_avg_with_fuse_and_split(self):
         from numpy import nanmean
 
-        class AvgRougeNoBootstrap(Rouge):
-            # no bootstrap whatsoever
-            # hf rouge, for use_aggregator = True:
-            #         if use_aggregator:
-            #             aggregator = scoring.BootstrapAggregator()
-            # and returns a bootstrapped version of the mean score
-            def prepare(self):
-                self.n_resamples = None
-                self.rouge_types = ["rougeL"]
-                self.ci_scores = ["rougeL"]
-                self.hf_metric_fields = ["rougeL"]
-                self.reduction_map = {"mean": ["rougeL"]}
-                self.use_aggregator = False
-                super().prepare()
-
-            def compute(self, references, prediction, task_data: List[Dict]):
-                # single score for a single instance
-                res = super().compute(references, prediction, task_data)["rougeL"]
-                return {"rougeL": res}
-
-        metric = AvgRougeNoBootstrap()
+        metric = Rouge(
+            rouge_types=["rougeL"],
+            ci_scores=["rougeL"],
+            score_names=["rougeL"],
+            n_resamples=None,
+        )
         references = [
             ["hello", "there"],
             ["general kenobi", "general yoda"],


### PR DESCRIPTION


Thus simplified and thereby extended grouping and filtering over to global metrics and to bulk-instance metrics