### PR TITLE
fix(cos loader): account for slashes in cos file name

### DIFF
--- a/src/unitxt/loaders.py
+++ b/src/unitxt/loaders.py
@@ -617,7 +617,7 @@ class LoadFromIBMCloud(Loader):
                         object_key,
                         local_dir + "/" + os.path.basename(temp_file.name),
                     )
-                    os.rename(
+                    os.renames(
                         local_dir + "/" + os.path.basename(temp_file.name),
                         local_dir + "/" + data_file,
                     )


### PR DESCRIPTION
FIX: `renames` instead of `rename` to account for slashes in data_file

If the destination path includes directories that do not exist, ﻿os.renames will create those intermediate directories.
