### PR TITLE
feat(metric): support adhoc metric

### DIFF
--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -11,7 +11,6 @@ from .dataclass import (
     AbstractField,
     Dataclass,
     Field,
-    InternalField,
     NonPositionalField,
     fields,
 )
@@ -127,7 +126,9 @@ class Artifact(Dataclass):
     __tags__: Dict[str, str] = NonPositionalField(
         default_factory=dict, required=False, also_positional=False
     )
-    __id__: str = InternalField(default=None, required=False, also_positional=False)
+    __id__: str = NonPositionalField(
+        default=None, required=False, also_positional=False
+    )
 
     data_classification_policy: List[str] = NonPositionalField(
         default=None, required=False, also_positional=False

--- a/src/unitxt/llm_as_judge.py
+++ b/src/unitxt/llm_as_judge.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Literal, Optional
 
 from .api import evaluate, produce
+from .artifact import Artifact
 from .inference import InferenceEngine, OpenAiInferenceEngine
 from .metrics import BulkInstanceMetric
 from .operator import SequentialOperator
@@ -38,6 +39,8 @@ class LLMAsJudge(BulkInstanceMetric):
             instances = []
             for task_data_instance in task_data:
                 template = task_data_instance["metadata"]["template"]
+                if Artifact.is_artifact_dict(template):
+                    template = Artifact.from_dict(template)
                 instance = SequentialOperator(
                     steps=[template, "formats.empty"]
                 ).process_instance(

--- a/tests/library/test_artifact.py
+++ b/tests/library/test_artifact.py
@@ -8,7 +8,6 @@ from unitxt.artifact import (
     reset_artifacts_json_cache,
 )
 from unitxt.catalog import add_to_catalog, get_from_catalog
-from unitxt.dataclass import UnexpectedArgumentError
 from unitxt.logging_utils import get_logger
 from unitxt.metrics import Accuracy, F1Binary
 from unitxt.operator import SequentialOperator
@@ -30,15 +29,6 @@ class TestArtifact(UnitxtTestCase):
         artifact_identifier = "artifact.id.dummy"
         artifact.__id__ = artifact_identifier
         self.assertEqual(artifact_identifier, artifact.__id__)
-
-    def test_artifact_identifier_cannot_be_used_as_keyword_arg(self):
-        """Test that artifact_identifier cannot be set in construction.
-
-        Since it is an internal field, and isn't serialized, it should never be set when
-        constructing an Artifact from kwargs.
-        """
-        with self.assertRaises(UnexpectedArgumentError):
-            Artifact(__id__="artifact.id.dummy")
 
     def test_artifact_identifier_available_for_loaded_artifacts(self):
         artifact_identifier = "tasks.classification.binary"


### PR DESCRIPTION
This will allow to specify metric ad-hoc in recipe, i.e.:
```
      "task": {
        "type": "form_task",
        "inputs": [
          "text_type",
          "classes",
          "input"
        ],
        "outputs": {
          "output": "str"
        },
        "metrics": [
          "metrics.f1_micro",
          "metrics.accuracy",
          {
            "type": "llm_as_judge",
            "name" "metrics.my_custom_metric_defined_ad_hoc"
            "inference_model": {
              "type": "ibm_gen_ai_inference_engine",
              "model_name": "meta-llama/llama-3-70b-instruct",
              "parameters": {
                "max_new_tokens": 252
              }
            },
            "template": "templates.safety.unsafe_content",
            "task": "rating.single_turn",
            "format": "formats.llama3_chat",
            "main_score": "llama_3_70b_instruct_ibm_genai_template_unsafe_content"
          }
        ]
      }
```

The evaluation logic does not take this into account now and would need to be adjusted, however I think it should not be forbidden on the task definition level.

We have our own evaluation function which I can provide as well, however I don't have insight into all the low level details in `MetricOperator` and other places where evaluation can occur so this would be quite time consuming for me to dive into, I'd appreciate any help on this front :)