### PR TITLE
Expanded template support for safety cards

### DIFF
--- a/prepare/cards/safety/bbq.py
+++ b/prepare/cards/safety/bbq.py
@@ -31,7 +31,7 @@ for dataset_name in [
             ListFieldValues(fields=["ans0", "ans1", "ans2"], to_field="choices"),
         ],
         task="tasks.qa.multiple_choice.with_context",
-        templates=["templates.qa.multiple_choice.with_context.match"],
+        templates="templates.qa.multiple_choice.with_context.all",
         __description__="Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
         __tags__={
             "languages": ["english"],
@@ -39,7 +39,7 @@ for dataset_name in [
         },
     )
 
-    test_card(card, strict=False, demos_taken_from="test", num_demos=0)
+    test_card(card, strict=False)
     add_to_catalog(card, "cards.safety.bbq." + dataset_name, overwrite=True)
 
 settings.allow_unverified_code = orig_settings

--- a/prepare/cards/safety/truthful_qa.py
+++ b/prepare/cards/safety/truthful_qa.py
@@ -22,7 +22,11 @@ card = TaskCard(
         IndexOf(search_in="labels", index_of="_label", to_field="answer"),
     ],
     task="tasks.qa.multiple_choice.open",
-    templates=["templates.qa.multiple_choice.helm"],
+    templates=[
+        "templates.qa.multiple_choice.helm",
+        "templates.qa.multiple_choice.match",
+        "templates.qa.multiple_choice.lm_eval_harness",
+    ],
     __description__="TruthfulQA is a benchmark to measure whether a language model is truthful in generating answers to questions. The benchmark comprises 817 questions that span 38 categories, including health, law, finance and politics. Questions are crafted so that some humans would answer falsely due to a false belief or misconception. To perform well, models must avoid generating false answers learned from imitating human texts.",
     __tags__={
         "languages": ["english"],

--- a/prepare/cards/safety/truthful_qa.py
+++ b/prepare/cards/safety/truthful_qa.py
@@ -1,5 +1,5 @@
 from unitxt import add_to_catalog
-from unitxt.blocks import LoadHF, TaskCard
+from unitxt.blocks import LoadHF, TaskCard, TemplatesList
 from unitxt.operators import Copy, IndexOf, Set
 from unitxt.splitters import RenameSplits
 from unitxt.test_utils.card import test_card
@@ -22,11 +22,12 @@ card = TaskCard(
         IndexOf(search_in="labels", index_of="_label", to_field="answer"),
     ],
     task="tasks.qa.multiple_choice.open",
-    templates=[
-        "templates.qa.multiple_choice.helm",
-        "templates.qa.multiple_choice.match",
-        "templates.qa.multiple_choice.lm_eval_harness",
-    ],
+    templates=TemplatesList(
+        [
+            "templates.qa.multiple_choice.helm",
+            "templates.qa.multiple_choice.match",
+        ]
+    ),
     __description__="TruthfulQA is a benchmark to measure whether a language model is truthful in generating answers to questions. The benchmark comprises 817 questions that span 38 categories, including health, law, finance and politics. Questions are crafted so that some humans would answer falsely due to a false belief or misconception. To perform well, models must avoid generating false answers learned from imitating human texts.",
     __tags__={
         "languages": ["english"],

--- a/prepare/cards/safety/truthful_qa.py
+++ b/prepare/cards/safety/truthful_qa.py
@@ -22,7 +22,7 @@ card = TaskCard(
         IndexOf(search_in="labels", index_of="_label", to_field="answer"),
     ],
     task="tasks.qa.multiple_choice.open",
-    templates=["templates.qa.multiple_choice.match"],
+    templates=["templates.qa.multiple_choice.helm"],
     __description__="TruthfulQA is a benchmark to measure whether a language model is truthful in generating answers to questions. The benchmark comprises 817 questions that span 38 categories, including health, law, finance and politics. Questions are crafted so that some humans would answer falsely due to a false belief or misconception. To perform well, models must avoid generating false answers learned from imitating human texts.",
     __tags__={
         "languages": ["english"],

--- a/prepare/templates/qa/multiple_choice/templates.py
+++ b/prepare/templates/qa/multiple_choice/templates.py
@@ -212,6 +212,18 @@ add_to_catalog(
     overwrite=True,
 )
 
+add_to_catalog(
+    MultipleChoiceTemplate(
+        input_format="Question: {question}\n{choices}\n",
+        target_prefix="Answer: ",
+        target_field="answer",
+        choices_separator="\n",
+        postprocessors=["processors.first_character"],
+    ),
+    "templates.qa.multiple_choice.helm",
+    overwrite=True,
+)
+
 # lm_eval_harness
 
 input_format = "Question: {question}\nChoices:\n{choices}\nAnswer:"

--- a/src/unitxt/catalog/cards/safety/bbq/Age.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Age.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/Disability_status.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Disability_status.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/Gender_identity.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Gender_identity.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/Nationality.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Nationality.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/Physical_appearance.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Physical_appearance.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/Race_ethnicity.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Race_ethnicity.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/Race_x_SES.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Race_x_SES.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/Race_x_gender.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Race_x_gender.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/Religion.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Religion.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/SES.json
+++ b/src/unitxt/catalog/cards/safety/bbq/SES.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/bbq/Sexual_orientation.json
+++ b/src/unitxt/catalog/cards/safety/bbq/Sexual_orientation.json
@@ -32,9 +32,7 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.with_context",
-    "templates": [
-        "templates.qa.multiple_choice.with_context.match"
-    ],
+    "templates": "templates.qa.multiple_choice.with_context.all",
     "__description__": "Bias Benchmark for QA (BBQ), a dataset of question sets that highlight attested social biases against people belonging to protected classes along nine social dimensions relevant for U.S. English-speaking contexts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/truthful_qa.json
+++ b/src/unitxt/catalog/cards/safety/truthful_qa.json
@@ -37,7 +37,9 @@
     ],
     "task": "tasks.qa.multiple_choice.open",
     "templates": [
-        "templates.qa.multiple_choice.helm"
+        "templates.qa.multiple_choice.helm",
+        "templates.qa.multiple_choice.match",
+        "templates.qa.multiple_choice.lm_eval_harness"
     ],
     "__description__": "TruthfulQA is a benchmark to measure whether a language model is truthful in generating answers to questions. The benchmark comprises 817 questions that span 38 categories, including health, law, finance and politics. Questions are crafted so that some humans would answer falsely due to a false belief or misconception. To perform well, models must avoid generating false answers learned from imitating human texts.",
     "__tags__": {

--- a/src/unitxt/catalog/cards/safety/truthful_qa.json
+++ b/src/unitxt/catalog/cards/safety/truthful_qa.json
@@ -36,11 +36,13 @@
         }
     ],
     "task": "tasks.qa.multiple_choice.open",
-    "templates": [
-        "templates.qa.multiple_choice.helm",
-        "templates.qa.multiple_choice.match",
-        "templates.qa.multiple_choice.lm_eval_harness"
-    ],
+    "templates": {
+        "__type__": "templates_list",
+        "items": [
+            "templates.qa.multiple_choice.helm",
+            "templates.qa.multiple_choice.match"
+        ]
+    },
     "__description__": "TruthfulQA is a benchmark to measure whether a language model is truthful in generating answers to questions. The benchmark comprises 817 questions that span 38 categories, including health, law, finance and politics. Questions are crafted so that some humans would answer falsely due to a false belief or misconception. To perform well, models must avoid generating false answers learned from imitating human texts.",
     "__tags__": {
         "languages": [

--- a/src/unitxt/catalog/cards/safety/truthful_qa.json
+++ b/src/unitxt/catalog/cards/safety/truthful_qa.json
@@ -37,7 +37,7 @@
     ],
     "task": "tasks.qa.multiple_choice.open",
     "templates": [
-        "templates.qa.multiple_choice.match"
+        "templates.qa.multiple_choice.helm"
     ],
     "__description__": "TruthfulQA is a benchmark to measure whether a language model is truthful in generating answers to questions. The benchmark comprises 817 questions that span 38 categories, including health, law, finance and politics. Questions are crafted so that some humans would answer falsely due to a false belief or misconception. To perform well, models must avoid generating false answers learned from imitating human texts.",
     "__tags__": {

--- a/src/unitxt/catalog/templates/qa/multiple_choice/helm.json
+++ b/src/unitxt/catalog/templates/qa/multiple_choice/helm.json
@@ -1,0 +1,10 @@
+{
+    "__type__": "multiple_choice_template",
+    "input_format": "Question: {question}\n{choices}\n",
+    "target_prefix": "Answer: ",
+    "target_field": "answer",
+    "choices_separator": "\n",
+    "postprocessors": [
+        "processors.first_character"
+    ]
+}


### PR DESCRIPTION
Added additional applicable templates to the BBQ and TruthfulQA cards.
TruthfulQA now matches the HELM implementation.