### PR TITLE
Fix llama_3_ibm_genai_generic_template

### DIFF
--- a/prepare/metrics/llm_as_judge/rating/llama_3_ibm_genai_generic_template.py
+++ b/prepare/metrics/llm_as_judge/rating/llama_3_ibm_genai_generic_template.py
@@ -6,7 +6,7 @@ from unitxt.inference import (
 from unitxt.llm_as_judge import LLMAsJudge
 
 model = "meta-llama/llama-3-70b-instruct"
-format = "formats.llama3_chat"
+format = "formats.llama3_instruct"
 template = "templates.response_assessment.rating.generic_single_turn"
 task = "rating.single_turn"
 

--- a/src/unitxt/catalog/metrics/llm_as_judge/rating/llama_3_70b_instruct_ibm_genai_template_generic_single_turn.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/rating/llama_3_70b_instruct_ibm_genai_template_generic_single_turn.json
@@ -10,6 +10,6 @@
     },
     "template": "templates.response_assessment.rating.generic_single_turn",
     "task": "rating.single_turn",
-    "format": "formats.llama3_chat",
+    "format": "formats.llama3_instruct",
     "main_score": "llama_3_70b_instruct_ibm_genai_template_generic_single_turn"
 }


### PR DESCRIPTION
This [example](https://github.com/IBM/unitxt/blob/main/examples/evaluate_dataset_by_llm_as_judge_no_install.py) is failing for me because the metric can not find the `llama3_chat` format.

According to [this discussion](https://github.com/IBM/unitxt/pull/950#discussion_r1657537711) the `llama3_chat` and `llama3_instruct` formats are the same.

I changed the format and the example works for me now.