### PR TITLE
try to deep as little as possible

### DIFF
--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -1,4 +1,5 @@
 import re
+from copy import deepcopy
 from typing import Any, List, Tuple
 
 from .text_utils import construct_dict_str
@@ -225,11 +226,11 @@ def dict_delete(
 # if query includes * then return a list of values reached by all paths that match the query
 # flake8: noqa: C901
 def get_values(
-    current_element: Any, query: List[str], index_into_query: int
+    current_element: Any, query: List[str], index_into_query: int, deep_copy: bool
 ) -> Tuple[bool, Any]:
     # going down from current_element through query[index_into_query].
     if index_into_query == 0:
-        return (True, current_element)
+        return (True, current_element if not deep_copy else deepcopy(current_element))
 
     # index_into_query < 0
     component = query[index_into_query]
@@ -244,7 +245,9 @@ def get_values(
             sub_elements = current_element
         for sub_element in sub_elements:
             try:
-                success, val = get_values(sub_element, query, index_into_query + 1)
+                success, val = get_values(
+                    sub_element, query, index_into_query + 1, deep_copy
+                )
                 if success:
                     to_ret.append(val)
             except:
@@ -257,7 +260,7 @@ def get_values(
         component = int(component)
     try:
         success, new_val = get_values(
-            current_element[component], query, index_into_query + 1
+            current_element[component], query, index_into_query + 1, deep_copy
         )
         if success:
             return (True, new_val)
@@ -378,25 +381,29 @@ def set_values(
 
 
 # the returned values are ordered by the lexicographic order of the paths leading to them
+# when use_deep_copy is True, the value returned is a deep copy of the value found in dic
 def dict_get(
     dic: dict,
     query: str,
     not_exist_ok: bool = False,
     default: Any = None,
+    use_deep_copy: bool = False,
 ):
     if len(query.strip()) == 0:
-        return dic
+        return dic if not use_deep_copy else deepcopy(dic)
 
     if dic is None:
         raise ValueError("Can not get any value from a dic that is None")
 
     if isinstance(dic, dict) and query.strip() in dic:
-        return dic[query.strip()]
+        return dic[query.strip()] if not use_deep_copy else deepcopy(dic[query.strip()])
 
     components = validate_query_and_break_to_components(query)
     if len(components) > 1:
         try:
-            success, values = get_values(dic, components, -1 * len(components))
+            success, values = get_values(
+                dic, components, -1 * len(components), use_deep_copy
+            )
             if success:
                 return values
         except Exception as e:
@@ -413,7 +420,7 @@ def dict_get(
 
     # len(components) == 1
     if components[0] in dic:
-        return dic[components[0]]
+        return dic[components[0]] if not use_deep_copy else deepcopy(dic[components[0]])
 
     if not_exist_ok:
         return default

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -1,5 +1,4 @@
 import re
-from copy import deepcopy
 from typing import Any, List, Tuple
 
 from .text_utils import construct_dict_str
@@ -226,11 +225,11 @@ def dict_delete(
 # if query includes * then return a list of values reached by all paths that match the query
 # flake8: noqa: C901
 def get_values(
-    current_element: Any, query: List[str], index_into_query: int, deep_copy: bool
+    current_element: Any, query: List[str], index_into_query: int
 ) -> Tuple[bool, Any]:
     # going down from current_element through query[index_into_query].
     if index_into_query == 0:
-        return (True, current_element if not deep_copy else deepcopy(current_element))
+        return (True, current_element)
 
     # index_into_query < 0
     component = query[index_into_query]
@@ -245,9 +244,7 @@ def get_values(
             sub_elements = current_element
         for sub_element in sub_elements:
             try:
-                success, val = get_values(
-                    sub_element, query, index_into_query + 1, deep_copy
-                )
+                success, val = get_values(sub_element, query, index_into_query + 1)
                 if success:
                     to_ret.append(val)
             except:
@@ -260,7 +257,7 @@ def get_values(
         component = int(component)
     try:
         success, new_val = get_values(
-            current_element[component], query, index_into_query + 1, deep_copy
+            current_element[component], query, index_into_query + 1
         )
         if success:
             return (True, new_val)
@@ -381,29 +378,25 @@ def set_values(
 
 
 # the returned values are ordered by the lexicographic order of the paths leading to them
-# when use_deep_copy is True, the value returned is a deep copy of the value found in dic
 def dict_get(
     dic: dict,
     query: str,
     not_exist_ok: bool = False,
     default: Any = None,
-    use_deep_copy: bool = False,
 ):
     if len(query.strip()) == 0:
-        return dic if not use_deep_copy else deepcopy(dic)
+        return dic
 
     if dic is None:
         raise ValueError("Can not get any value from a dic that is None")
 
     if isinstance(dic, dict) and query.strip() in dic:
-        return dic[query.strip()] if not use_deep_copy else deepcopy(dic[query.strip()])
+        return dic[query.strip()]
 
     components = validate_query_and_break_to_components(query)
     if len(components) > 1:
         try:
-            success, values = get_values(
-                dic, components, -1 * len(components), use_deep_copy
-            )
+            success, values = get_values(dic, components, -1 * len(components))
             if success:
                 return values
         except Exception as e:
@@ -420,7 +413,7 @@ def dict_get(
 
     # len(components) == 1
     if components[0] in dic:
-        return dic[components[0]] if not use_deep_copy else deepcopy(dic[components[0]])
+        return dic[components[0]]
 
     if not_exist_ok:
         return default

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -350,7 +350,7 @@ class InstanceFieldOperator(InstanceOperator):
     process_every_value: bool = False
     get_default: Any = None
     not_exist_ok: bool = False
-    use_deep_copy: bool = False
+    use_deepcopy: bool = False
 
     def verify(self):
         super().verify()
@@ -440,7 +440,6 @@ class InstanceFieldOperator(InstanceOperator):
                     from_field,
                     default=self.get_default,
                     not_exist_ok=self.not_exist_ok,
-                    use_deep_copy=self.use_deep_copy,
                 )
             except Exception as e:
                 raise ValueError(
@@ -1063,7 +1062,9 @@ class Copy(FieldOperator):
     """
 
     def process_value(self, value: Any) -> Any:
-        # deep copy is already dealt with in process(instance) that invokes this method
+        # deep copy is dealt with only here:
+        if self.use_deepcopy:
+            return deepcopy(value)
         return value
 
 
@@ -1813,7 +1814,7 @@ class ApplyMetric(StreamOperator, ArtifactFetcherMixin):
         keys_to_restore = set(first_instance.keys()).difference({"score"})
         multi_stream = MultiStream({"tmp": stream})
         multi_stream = CopyFields(
-            field_to_field={k: f"{k}_orig" for k in keys_to_restore}, use_deep_copy=True
+            field_to_field={k: f"{k}_orig" for k in keys_to_restore}, use_deepcopy=True
         )(multi_stream)
 
         for metric_name in metric_names:

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1828,7 +1828,8 @@ class ApplyMetric(StreamOperator, ArtifactFetcherMixin):
 
             multi_stream = metric(multi_stream)
             multi_stream = CopyFields(
-                field_to_field={f"{k}_orig": k for k in keys_to_restore}
+                field_to_field={f"{k}_orig": k for k in keys_to_restore},
+                use_deepcopy=True,
             )(multi_stream)
 
         multi_stream = RemoveFields(fields=[f"{k}_orig" for k in keys_to_restore])(

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -39,7 +39,6 @@ General Operators List:
 ------------------------
 """
 
-import copy
 import operator
 import uuid
 import zipfile
@@ -1064,10 +1063,8 @@ class Copy(FieldOperator):
     """
 
     def process_value(self, value: Any) -> Any:
-        if self.use_deep_copy:
-            return copy.deepcopy(value)
+        # deep copy is already dealt with in process(instance) that invokes this method
         return value
-        #
 
 
 @deprecation(version="2.0.0", alternative=Copy)

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -77,6 +77,21 @@ class TestDictUtils(UnitxtTestCase):
         with self.assertRaises(ValueError):
             dict_get(dic, "a/g/0")
 
+    def test_nested_get_with_deep_copy(self):
+        instance = {"predictions": {"a": 3, "b": 4}}
+        val = dict_get(instance, "predictions")
+        dict_set(instance, "predictions_orig", val)
+        instance["predictions"]["a"] = 10
+        # without deep copy, predictions_orig simply points at predictions
+        self.assertEqual(10, instance["predictions_orig"]["a"])
+
+        instance = {"predictions": {"a": 3, "b": 4}}
+        val = dict_get(instance, "predictions", use_deep_copy=True)
+        dict_set(instance, "predictions_orig", val)
+        instance["predictions"]["a"] = 10
+        # with deep copy, predictions_orig is a different object from predictions
+        self.assertEqual(3, instance["predictions_orig"]["a"])
+
     def test_query_get(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}
         self.assertEqual(dict_get(dic, "a/*/b"), [1, 2])

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -77,21 +77,6 @@ class TestDictUtils(UnitxtTestCase):
         with self.assertRaises(ValueError):
             dict_get(dic, "a/g/0")
 
-    def test_nested_get_with_deep_copy(self):
-        instance = {"predictions": {"a": 3, "b": 4}}
-        val = dict_get(instance, "predictions")
-        dict_set(instance, "predictions_orig", val)
-        instance["predictions"]["a"] = 10
-        # without deep copy, predictions_orig simply points at predictions
-        self.assertEqual(10, instance["predictions_orig"]["a"])
-
-        instance = {"predictions": {"a": 3, "b": 4}}
-        val = dict_get(instance, "predictions", use_deep_copy=True)
-        dict_set(instance, "predictions_orig", val)
-        instance["predictions"]["a"] = 10
-        # with deep copy, predictions_orig is a different object from predictions
-        self.assertEqual(3, instance["predictions_orig"]["a"])
-
     def test_query_get(self):
         dic = {"a": [{"b": 1}, {"b": 2}]}
         self.assertEqual(dict_get(dic, "a/*/b"), [1, 2])

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -2261,7 +2261,7 @@ label (str):
         instance = {"predictions": {"a": 3, "b": 4}}
         ms = MultiStream.from_iterables({"tmp": [instance]})
         copyoperator = Copy(
-            field="predictions", to_field="predictions_orig", use_deep_copy=True
+            field="predictions", to_field="predictions_orig", use_deepcopy=True
         )
         ms = copyoperator(ms)
         instance2 = next(iter(ms["tmp"]))

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -2248,6 +2248,27 @@ label (str):
             tester=self,
         )
 
+    def test_copy_with_deep_copy(self):
+        instance = {"predictions": {"a": 3, "b": 4}}
+        ms = MultiStream.from_iterables({"tmp": [instance]})
+        copyoperator = Copy(field="predictions", to_field="predictions_orig")
+        ms = copyoperator(ms)
+        instance2 = next(iter(ms["tmp"]))
+        self.assertDictEqual(instance2["predictions_orig"], instance2["predictions"])
+        instance2["predictions"]["a"] = 10
+        self.assertEqual(10, instance2["predictions_orig"]["a"])
+        # and with use_deep_copy = true:
+        instance = {"predictions": {"a": 3, "b": 4}}
+        ms = MultiStream.from_iterables({"tmp": [instance]})
+        copyoperator = Copy(
+            field="predictions", to_field="predictions_orig", use_deep_copy=True
+        )
+        ms = copyoperator(ms)
+        instance2 = next(iter(ms["tmp"]))
+        self.assertDictEqual(instance2["predictions_orig"], instance2["predictions"])
+        instance2["predictions"]["a"] = 10
+        self.assertEqual(3, instance2["predictions_orig"]["a"])
+
     def test_label_encoder(self):
         inputs = [
             {"prediction": "red", "references": ["red", "blue"]},


### PR DESCRIPTION
Until that metric that modifies 'predictions' is crucified, an attempt to reduce the damage it causes for performance.
My hope is that the removal of `instace=deepcopy(instance)` from `FieldOperator`, which is executed also for each `Rename`, for example, will bear significant fruits, in terms of performance.