### PR TITLE
changed input and output of templates to "input_fields" and "reference_ fields" - Non backward compatible

### DIFF
--- a/docs/docs/adding_template.rst
+++ b/docs/docs/adding_template.rst
@@ -77,30 +77,32 @@ Making Your Custom Template
 ----------------------------
 
 In order to make your own template, you need to create a class inheriting from `Template` and
-implementing its two abstract methods:
+implementing its abstract methods:
 
 .. code-block:: python
 
-    @abstractmethod
-    def inputs_to_source(self, inputs: Dict[str, object]) -> Tuple[str, str]:
+     @abstractmethod
+    def input_fields_to_source(self, input_fields: Dict[str, object]) -> str:
+        """Create the textual input for the model from the input fields"""
         pass
 
     @abstractmethod
-    def outputs_to_target_and_references(
-        self, outputs: Dict[str, object]
-    ) -> Tuple[str, List[str]]:
+    def reference_fields_to_target_and_references(self, reference_fields: Dict[str, object]) -> Tuple[str, List[str]]:
+        """Create a list of references from the reference fields. Also returns one of the references
+           as the 'target' - the reference used if the instance is used as a demonstration."
         pass
 
-For instance:
+    
+
+For instance, this templates passes all the input fields to the model as a json string.
+It also formats the references , by taking two of the dataset reference fields the 'top_answer' and 'alternative_answer'.
 
 .. code-block:: python
 
     class MyCustomTemplate(Template):
 
-        def inputs_to_source(self, inputs: Dict[str, object]) -> Tuple[str, str]:
-            return str(inputs) # use all the task inputs fields in their dictionary look
-
-        def outputs_to_target_and_references(
-            self, outputs: Dict[str, object]
-        ) -> Tuple[str, List[str]]:
-            return outputs["label"], [outputs["label"]]
+        def input_fields_to_source(self, inputs_fields: Dict[str, object]) -> str:
+            return json.dumps(inputs_fields) # provide the json string with all fields as the input to the model
+        def reference_fields_to_target_and_references(self, reference_fields: Dict[str, object]) -> Tuple[str, List[str]]
+            return outputs_fields["top_answer"],  # target
+                   [outputs_fields["top_answer"],outputs_fields["alternative_answer"]]   # all references

--- a/src/unitxt/llm_as_judge.py
+++ b/src/unitxt/llm_as_judge.py
@@ -43,7 +43,10 @@ class LLMAsJudge(BulkInstanceMetric):
                 instance = SequentialOperator(
                     steps=[template, "formats.empty"]
                 ).process_instance(
-                    {"inputs": task_data_instance, "outputs": task_data_instance}
+                    {
+                        "input_fields": task_data_instance,
+                        "reference_fields": task_data_instance,
+                    }
                 )
                 instances.append(instance["source"])
                 """

--- a/src/unitxt/task.py
+++ b/src/unitxt/task.py
@@ -34,8 +34,8 @@ class Task(InstanceOperator):
             Will not overwrite values if already provided in a given instance.
 
     The output instance contains three fields:
-        "inputs" whose value is a sub-dictionary of the input instance, consisting of all the fields listed in Arg 'input_fields'.
-        "outputs" -- for the fields listed in Arg "outputs".
+        "input_fields" whose value is a sub-dictionary of the input instance, consisting of all the fields listed in Arg 'input_fields'.
+        "reference_fields" -- for the fields listed in Arg "reference_fields".
         "metrics" -- to contain the value of Arg 'metrics'
     """
 

--- a/src/unitxt/templates.py
+++ b/src/unitxt/templates.py
@@ -95,9 +95,7 @@ class Template(InstanceOperator):
         }
 
     @abstractmethod
-    def input_fields_to_source(
-        self, input_fields: Dict[str, object]
-    ) -> Tuple[str, str]:
+    def input_fields_to_source(self, input_fields: Dict[str, object]) -> str:
         pass
 
     def set_titles(self, data):

--- a/tests/library/test_format_and_template_interaction.py
+++ b/tests/library/test_format_and_template_interaction.py
@@ -8,7 +8,10 @@ from tests.utils import UnitxtTestCase
 
 class TestFormatAndTemplateInteraction(UnitxtTestCase):
     def test_interactions(self):
-        instance = {"inputs": {"question": "what?"}, "outputs": {"answer": "that!"}}
+        instance = {
+            "input_fields": {"question": "what?"},
+            "reference_fields": {"answer": "that!"},
+        }
         target = "that!"
 
         template_separated = InputOutputTemplate(

--- a/tests/library/test_formats.py
+++ b/tests/library/test_formats.py
@@ -11,8 +11,18 @@ class TestFormats(UnitxtTestCase):
         instruction = "solve the math exercises"
 
         demo_instances = [
-            {"source": "1+2", "target": "3", "instruction": instruction, "inputs": {}},
-            {"source": "4-2", "target": "2", "instruction": instruction, "inputs": {}},
+            {
+                "source": "1+2",
+                "target": "3",
+                "instruction": instruction,
+                "input_fields": {},
+            },
+            {
+                "source": "4-2",
+                "target": "2",
+                "instruction": instruction,
+                "input_fields": {},
+            },
         ]
 
         inputs = [
@@ -21,7 +31,7 @@ class TestFormats(UnitxtTestCase):
                 "target": "2",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
                 "target_prefix": "The answer is ",
                 "system_prompt": "You are a smart assistant.",
             },
@@ -30,7 +40,7 @@ class TestFormats(UnitxtTestCase):
                 "target": "5",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
                 "target_prefix": "The answer is ",
                 "system_prompt": "You are a smart assistant.",
             },
@@ -42,12 +52,12 @@ class TestFormats(UnitxtTestCase):
         targets = [
             {
                 "target": "2",
-                "inputs": {},
+                "input_fields": {},
                 "source": "<|system|>\nYou are a smart assistant.\nsolve the math exercises</s>\n<|user|>\n1+2</s>\n<|assistant|>\nThe answer is 3</s>\n<|user|>\n4-2</s>\n<|assistant|>\nThe answer is 2</s>\n<|user|>\n1+1</s>\n<|assistant|>\nThe answer is ",
             },
             {
                 "target": "5",
-                "inputs": {},
+                "input_fields": {},
                 "source": "<|system|>\nYou are a smart assistant.\nsolve the math exercises</s>\n<|user|>\n1+2</s>\n<|assistant|>\nThe answer is 3</s>\n<|user|>\n4-2</s>\n<|assistant|>\nThe answer is 2</s>\n<|user|>\n3+2</s>\n<|assistant|>\nThe answer is ",
             },
         ]
@@ -63,8 +73,18 @@ class TestFormats(UnitxtTestCase):
         instruction = "solve the math exercises"
 
         demo_instances = [
-            {"source": "1+2", "target": "3", "instruction": instruction, "inputs": {}},
-            {"source": "4-2", "target": "2", "instruction": instruction, "inputs": {}},
+            {
+                "source": "1+2",
+                "target": "3",
+                "instruction": instruction,
+                "input_fields": {},
+            },
+            {
+                "source": "4-2",
+                "target": "2",
+                "instruction": instruction,
+                "input_fields": {},
+            },
         ]
 
         inputs = [
@@ -73,28 +93,28 @@ class TestFormats(UnitxtTestCase):
                 "target": "2",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
             },
             {
                 "source": "3+2",
                 "target": "5",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
             },
             {
                 "source": "7-4",
                 "target": "3",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
             },
             {
                 "source": "12-3",
                 "target": "9",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
             },
         ]
 
@@ -108,22 +128,22 @@ class TestFormats(UnitxtTestCase):
         targets = [
             {
                 "target": "2",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: solve the math exercises\n\n1+1\nAgent: ",
             },
             {
                 "target": "5",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: solve the math exercises\n\n3+2\nAgent: ",
             },
             {
                 "target": "3",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: solve the math exercises\n\n7-4\nAgent: ",
             },
             {
                 "target": "9",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: solve the math exercises\n\n12-3\nAgent: ",
             },
         ]
@@ -145,22 +165,22 @@ class TestFormats(UnitxtTestCase):
         targets = [
             {
                 "target": "2",
-                "inputs": {},
+                "input_fields": {},
                 "source": "Instruction: solve the math exercises\n\nUser: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: 1+1\nAgent: ",
             },
             {
                 "target": "5",
-                "inputs": {},
+                "input_fields": {},
                 "source": "Instruction: solve the math exercises\n\nUser: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: 3+2\nAgent: ",
             },
             {
                 "target": "3",
-                "inputs": {},
+                "input_fields": {},
                 "source": "Instruction: solve the math exercises\n\nUser: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: 7-4\nAgent: ",
             },
             {
                 "target": "9",
-                "inputs": {},
+                "input_fields": {},
                 "source": "Instruction: solve the math exercises\n\nUser: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: 12-3\nAgent: ",
             },
         ]
@@ -187,22 +207,22 @@ class TestFormats(UnitxtTestCase):
         targets_no_instruction = [
             {
                 "target": "2",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: 1+1\nAgent: ",
             },
             {
                 "target": "5",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: 3+2\nAgent: ",
             },
             {
                 "target": "3",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: 7-4\nAgent: ",
             },
             {
                 "target": "9",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: 12-3\nAgent: ",
             },
         ]
@@ -218,7 +238,7 @@ class TestFormats(UnitxtTestCase):
             "source": 'This is my sentence: "was so bad"',
             "target": "negative",
             "references": ["negative"],
-            "inputs": {},
+            "input_fields": {},
             "instruction": "classify user sentence by its sentiment to either positive, or negative.",
             "demos": [
                 {
@@ -247,7 +267,7 @@ class TestFormats(UnitxtTestCase):
             "source": 'Instruction:classify user sentence by its sentiment to either positive, or negative.\n\nUser:This is my sentence: "was so not good"\nAgent:negative\n\nUser:This is my sentence: "was so good"\nAgent:positive\n\nUser:This is my sentence: "was so bad"\nAgent:',
             "target": "negative",
             "references": ["negative"],
-            "inputs": {},
+            "input_fields": {},
         }
         self.assertDictEqual(result, target)
 
@@ -256,7 +276,7 @@ class TestFormats(UnitxtTestCase):
             "source": 'This is my sentence: "was so bad"',
             "target": "negative",
             "references": ["negative"],
-            "inputs": {},
+            "input_fields": {},
             "instruction": "classify user sentence by its sentiment to either positive, or negative.",
         }
         system_format = SystemFormat(
@@ -267,7 +287,7 @@ class TestFormats(UnitxtTestCase):
         target = {
             "source": 'Instruction:classify user sentence by its sentiment to either positive, or negative.\n\nUser:This is my sentence: "was so bad"\nAgent:',
             "target": "negative",
-            "inputs": {},
+            "input_fields": {},
             "references": ["negative"],
         }
         self.assertDictEqual(result, target)
@@ -284,7 +304,7 @@ class TestFormats(UnitxtTestCase):
             "source": 'This is my sentence: "was so bad"',
             "target": "negative",
             "references": ["negative"],
-            "inputs": {},
+            "input_fields": {},
             "instruction": "classify user sentence by its sentiment to either positive, or negative.",
             "demos": [
                 {
@@ -307,7 +327,7 @@ class TestFormats(UnitxtTestCase):
             "source": '[INST] <<SYS>>\nclassify user sentence by its sentiment to either positive, or negative.\n\nUser: This is my sentence: "was so not good"\nAgent: negative\n\nUser: This is my sentence: "was so good"\nAgent: positive\n\nUser: This is my sentence: "was so bad"\nAgent: [/INST]',
             "target": "negative",
             "references": ["negative"],
-            "inputs": {},
+            "input_fields": {},
         }
 
         self.assertDictEqual(result, target)
@@ -323,8 +343,18 @@ class TestFormats(UnitxtTestCase):
         instruction = "solve the math exercises"
 
         demo_instances = [
-            {"source": "1+2", "target": "3", "instruction": instruction, "inputs": {}},
-            {"source": "4-2", "target": "2", "instruction": instruction, "inputs": {}},
+            {
+                "source": "1+2",
+                "target": "3",
+                "instruction": instruction,
+                "input_fields": {},
+            },
+            {
+                "source": "4-2",
+                "target": "2",
+                "instruction": instruction,
+                "input_fields": {},
+            },
         ]
 
         inputs = [
@@ -333,50 +363,50 @@ class TestFormats(UnitxtTestCase):
                 "target": "2",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
             },
             {
                 "source": "3+2",
                 "target": "5",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
             },
             {
                 "source": "7-4",
                 "target": "3",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
             },
             {
                 "source": "12-3",
                 "target": "9",
                 "instruction": instruction,
                 "demos": demo_instances,
-                "inputs": {},
+                "input_fields": {},
             },
         ]
 
         targets = [
             {
                 "target": "2",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: solve the math exercises\n\n1+1\nAgent: ",
             },
             {
                 "target": "5",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: solve the math exercises\n\n3+2\nAgent: ",
             },
             {
                 "target": "3",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: solve the math exercises\n\n7-4\nAgent: ",
             },
             {
                 "target": "9",
-                "inputs": {},
+                "input_fields": {},
                 "source": "User: 1+2\nAgent: 3\n\nUser: 4-2\nAgent: 2\n\nUser: solve the math exercises\n\n12-3\nAgent: ",
             },
         ]

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -50,7 +50,7 @@ from unitxt.metrics import (
     TokenOverlap,
     UnsortedListExactMatch,
 )
-from unitxt.test_utils.metrics import apply_metric
+from unitxt.test_utils.metrics import apply_metric, check_scores
 
 from tests.utils import UnitxtTestCase
 
@@ -1150,8 +1150,8 @@ class TestMetrics(UnitxtTestCase):
         )
 
         expected_global_result = {
-            "my_perplexity": 0.05986589565873146,
-            "score": 0.05986589565873146,
+            "my_perplexity": 0.06,
+            "score": 0.06,
             "score_name": "my_perplexity",
         }
 
@@ -1162,18 +1162,21 @@ class TestMetrics(UnitxtTestCase):
             for key, value in global_result.items()
             if key in expected_global_result
         }
-        self.assertDictEqual(global_result, expected_global_result)
 
-        instance_targets = [
+        expected_instance_results = [
             {
-                "my_perplexity": 0.05986589565873146,
-                "score": 0.05986589565873146,
+                "my_perplexity": 0.06,
+                "score": 0.06,
                 "score_name": "my_perplexity",
-                "my_reference_scores": [0.05986589565873146],
+                "my_reference_scores": [0.06],
             }
         ]
-        for output, target in zip(outputs, instance_targets):
-            self.assertDictEqual(output["score"]["instance"], target)
+        check_scores(
+            expected_global_result,
+            expected_instance_results,
+            global_outputs=outputs[0]["score"]["global"],
+            instance_outputs=[outputs[0]["score"]["instance"]],
+        )
 
 
 class TestConfidenceIntervals(UnitxtTestCase):

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -2839,10 +2839,13 @@ class TestApplyMetric(UnitxtTestCase):
         instance = {
             "demos": [
                 {
-                    "inputs": {"text": "was so not good"},
-                    "outputs": {"label": "negative"},
+                    "input_fields": {"text": "was so not good"},
+                    "reference_fields": {"label": "negative"},
                 },
-                {"inputs": {"text": "was so good"}, "outputs": {"label": "positive"}},
+                {
+                    "input_fields": {"text": "was so good"},
+                    "reference_fields": {"label": "positive"},
+                },
             ]
         }
 
@@ -2852,8 +2855,8 @@ class TestApplyMetric(UnitxtTestCase):
         target = {
             "demos": [
                 {
-                    "inputs": {"text": "was so not good"},
-                    "outputs": {"label": "negative"},
+                    "input_fields": {"text": "was so not good"},
+                    "reference_fields": {"label": "negative"},
                     "source": 'This is my sentence: "was so not good"',
                     "target": "negative",
                     "references": ["negative"],
@@ -2861,8 +2864,8 @@ class TestApplyMetric(UnitxtTestCase):
                     "target_prefix": "",
                 },
                 {
-                    "inputs": {"text": "was so good"},
-                    "outputs": {"label": "positive"},
+                    "input_fields": {"text": "was so good"},
+                    "reference_fields": {"label": "positive"},
                     "source": 'This is my sentence: "was so good"',
                     "target": "positive",
                     "references": ["positive"],
@@ -2882,12 +2885,12 @@ class TestApplyMetric(UnitxtTestCase):
         instance = {
             "demos": [
                 {
-                    "inputs": {"text": "who was he?"},
-                    "outputs": {"answer": ["Dan", "Yossi"]},
+                    "input_fields": {"text": "who was he?"},
+                    "reference_fields": {"answer": ["Dan", "Yossi"]},
                 },
                 {
-                    "inputs": {"text": "who was she?"},
-                    "outputs": {"answer": ["Shira", "Yael"]},
+                    "input_fields": {"text": "who was she?"},
+                    "reference_fields": {"answer": ["Shira", "Yael"]},
                 },
             ]
         }
@@ -2898,8 +2901,8 @@ class TestApplyMetric(UnitxtTestCase):
         target = {
             "demos": [
                 {
-                    "inputs": {"text": "who was he?"},
-                    "outputs": {"answer": ["Dan", "Yossi"]},
+                    "input_fields": {"text": "who was he?"},
+                    "reference_fields": {"answer": ["Dan", "Yossi"]},
                     "source": "This is my sentence: who was he?",
                     "target": "Dan",
                     "references": ["Dan", "Yossi"],
@@ -2907,8 +2910,8 @@ class TestApplyMetric(UnitxtTestCase):
                     "target_prefix": "",
                 },
                 {
-                    "inputs": {"text": "who was she?"},
-                    "outputs": {"answer": ["Shira", "Yael"]},
+                    "input_fields": {"text": "who was she?"},
+                    "reference_fields": {"answer": ["Shira", "Yael"]},
                     "source": "This is my sentence: who was she?",
                     "target": "Shira",
                     "references": ["Shira", "Yael"],
@@ -2925,7 +2928,7 @@ class TestApplyMetric(UnitxtTestCase):
             "source": "1+1",
             "target": "2",
             "instruction": "solve the math exercises",
-            "inputs": {},
+            "input_fields": {},
         }
         demos_instances = [
             {"source": "1+2", "target": "3", "instruction": "solve the math exercises"},
@@ -2964,7 +2967,7 @@ Agent:"""
         instance = {
             "source": "1+1",
             "target": "2",
-            "inputs": {},
+            "input_fields": {},
             "instruction": "solve the math exercises",
             "demos": demo_instances,
         }
@@ -2993,7 +2996,7 @@ Agent:"""
             "source": "1+1",
             "target": "2",
             "instruction": "solve the math exercises",
-            "inputs": {},
+            "input_fields": {},
         }
 
         target = """Instruction:solve the math exercises
@@ -3011,7 +3014,7 @@ Agent:"""
         self.assertEqual(instance["source"], target)
 
     def test_model_input_formatter_without_demonstrations_or_instruction(self):
-        instance = {"source": "1+1", "target": "2", "inputs": {}}
+        instance = {"source": "1+1", "target": "2", "input_fields": {}}
         target = """User:1+1
 Agent:"""
 
@@ -3024,7 +3027,12 @@ Agent:"""
         self.assertEqual(instance_out["source"], target)
 
     def test_system_format_without_demonstrations_and_empty_instruction(self):
-        instance = {"source": "1+1", "target": "2", "instruction": "", "inputs": {}}
+        instance = {
+            "source": "1+1",
+            "target": "2",
+            "instruction": "",
+            "input_fields": {},
+        }
 
         target = """User:1+1
 Agent:"""

--- a/tests/library/test_templates.py
+++ b/tests/library/test_templates.py
@@ -27,8 +27,10 @@ class TestTemplates(UnitxtTestCase):
 
         inputs = [
             {
-                "inputs": {"text": "John,: Doe is from New York and works at Goo:gle."},
-                "outputs": {
+                "input_fields": {
+                    "text": "John,: Doe is from New York and works at Goo:gle."
+                },
+                "reference_fields": {
                     "spans_starts": [0, 19, 41],
                     "spans_ends": [10, 27, 48],
                     "labels": ["PER", "LOC", "ORG"],
@@ -36,10 +38,10 @@ class TestTemplates(UnitxtTestCase):
                 },
             },
             {
-                "inputs": {
+                "input_fields": {
                     "text": "John,: Doe is from New York and works at Goo:gle.",
                 },
-                "outputs": {
+                "reference_fields": {
                     "spans_starts": [],
                     "spans_ends": [],
                     "labels": [],
@@ -50,8 +52,10 @@ class TestTemplates(UnitxtTestCase):
 
         targets = [
             {
-                "inputs": {"text": "John,: Doe is from New York and works at Goo:gle."},
-                "outputs": {
+                "input_fields": {
+                    "text": "John,: Doe is from New York and works at Goo:gle."
+                },
+                "reference_fields": {
                     "spans_starts": [0, 19, 41],
                     "spans_ends": [10, 27, 48],
                     "labels": ["PER", "LOC", "ORG"],
@@ -64,10 +68,10 @@ class TestTemplates(UnitxtTestCase):
                 "target_prefix": "",
             },
             {
-                "inputs": {
+                "input_fields": {
                     "text": "John,: Doe is from New York and works at Goo:gle.",
                 },
-                "outputs": {
+                "reference_fields": {
                     "spans_starts": [],
                     "spans_ends": [],
                     "labels": [],
@@ -88,19 +92,19 @@ class TestTemplates(UnitxtTestCase):
 
         inputs = [
             {
-                "inputs": {"text": "hello world"},
-                "outputs": {"labels": ["cat", "dog"]},
+                "input_fields": {"text": "hello world"},
+                "reference_fields": {"labels": ["cat", "dog"]},
             },
             {
-                "inputs": {"text": "hello world"},
-                "outputs": {"labels": ["man", "woman", "dog"]},
+                "input_fields": {"text": "hello world"},
+                "reference_fields": {"labels": ["man", "woman", "dog"]},
             },
         ]
 
         targets = [
             {
-                "inputs": {"text": "hello world"},
-                "outputs": {"labels": ["cat", "dog"]},
+                "input_fields": {"text": "hello world"},
+                "reference_fields": {"labels": ["cat", "dog"]},
                 "source": "hello world",
                 "target": "cat, dog",
                 "references": ["cat, dog"],
@@ -108,8 +112,8 @@ class TestTemplates(UnitxtTestCase):
                 "target_prefix": "",
             },
             {
-                "inputs": {"text": "hello world"},
-                "outputs": {"labels": ["man", "woman", "dog"]},
+                "input_fields": {"text": "hello world"},
+                "reference_fields": {"labels": ["man", "woman", "dog"]},
                 "source": "hello world",
                 "target": "man, woman, dog",
                 "references": ["man, woman, dog"],
@@ -129,15 +133,15 @@ class TestTemplates(UnitxtTestCase):
 
         inputs = [
             {
-                "inputs": {"text": "who was he?"},
-                "outputs": {"answer": ["Dan", "Yossi"]},
+                "input_fields": {"text": "who was he?"},
+                "reference_fields": {"answer": ["Dan", "Yossi"]},
             }
         ]
 
         targets = [
             {
-                "inputs": {"text": "who was he?"},
-                "outputs": {"answer": ["Dan", "Yossi"]},
+                "input_fields": {"text": "who was he?"},
+                "reference_fields": {"answer": ["Dan", "Yossi"]},
                 "source": "This is my sentence: who was he?",
                 "target": target,
                 "references": ["Dan", "Yossi"],
@@ -161,8 +165,8 @@ class TestTemplates(UnitxtTestCase):
             input_format="This is my sentence: {text}", references_field="answer"
         )
         instance = {
-            "inputs": {"text": "who was he?"},
-            "outputs": {"answer": references},
+            "input_fields": {"text": "who was he?"},
+            "reference_fields": {"answer": references},
         }
 
         with self.assertRaises(ValueError) as e:
@@ -191,29 +195,35 @@ class TestTemplates(UnitxtTestCase):
 
         inputs = [
             {
-                "inputs": {"labels": ["positive", "negative"], "text": "hello world"},
-                "outputs": {"label": "positive"},
+                "input_fields": {
+                    "labels": ["positive", "negative"],
+                    "text": "hello world",
+                },
+                "reference_fields": {"label": "positive"},
             },
             {
-                "inputs": {
+                "input_fields": {
                     "labels": ["positive", "negative"],
                     "text": ["hello world\n", "hell"],
                 },
-                "outputs": {"label": "positive"},
+                "reference_fields": {"label": "positive"},
             },
             {
-                "inputs": {
+                "input_fields": {
                     "labels": ["positive", "negative"],
                     "text": ["hello world\n", "hell"],
                 },
-                "outputs": {"label": ["positive", "1"]},
+                "reference_fields": {"label": ["positive", "1"]},
             },
         ]
 
         targets = [
             {
-                "inputs": {"labels": ["positive", "negative"], "text": "hello world"},
-                "outputs": {"label": "positive"},
+                "input_fields": {
+                    "labels": ["positive", "negative"],
+                    "text": "hello world",
+                },
+                "reference_fields": {"label": "positive"},
                 "source": "This is my text:'hello world'",
                 "target": "positive",
                 "references": ["positive"],
@@ -221,11 +231,11 @@ class TestTemplates(UnitxtTestCase):
                 "target_prefix": "Sentiment is: ",
             },
             {
-                "inputs": {
+                "input_fields": {
                     "labels": ["positive", "negative"],
                     "text": ["hello world\n", "hell"],
                 },
-                "outputs": {"label": "positive"},
+                "reference_fields": {"label": "positive"},
                 "source": "This is my text:'hello world\n, hell'",
                 "target": "positive",
                 "references": ["positive"],
@@ -233,11 +243,11 @@ class TestTemplates(UnitxtTestCase):
                 "target_prefix": "Sentiment is: ",
             },
             {
-                "inputs": {
+                "input_fields": {
                     "labels": ["positive", "negative"],
                     "text": ["hello world\n", "hell"],
                 },
-                "outputs": {"label": ["positive", "1"]},
+                "reference_fields": {"label": ["positive", "1"]},
                 "source": "This is my text:'hello world\n, hell'",
                 "target": "positive, 1",
                 "references": ["positive, 1"],
@@ -261,7 +271,7 @@ class TestTemplates(UnitxtTestCase):
         with self.assertRaises(TemplateFormatKeyError) as ke:
             err_input_template.process(inputs[0])
         self.assertEqual(
-            "\"Available inputs are [labels, text] but InputOutputTemplate.input_format format requires a different ones: 'This is my text:'{no_text}''\"",
+            "\"Available input fields are [labels, text] but InputOutputTemplate.input_format format requires a different ones: 'This is my text:'{no_text}''\"",
             str(ke.exception),
         )
 
@@ -271,7 +281,7 @@ class TestTemplates(UnitxtTestCase):
         with self.assertRaises(TemplateFormatKeyError) as ke:
             err_output_template.process(inputs[0])
         self.assertEqual(
-            "\"Available outputs are [label] but InputOutputTemplate.output_format format requires a different ones: '{no_label}'\"",
+            "\"Available reference fields are [label] but InputOutputTemplate.output_format format requires a different ones: '{no_label}'\"",
             str(ke.exception),
         )
 
@@ -286,15 +296,21 @@ class TestTemplates(UnitxtTestCase):
 
         inputs = [
             {
-                "inputs": {"labels": ["positive", "negative"], "text": "hello world"},
-                "outputs": {"label": "positive", "reference": "1"},
+                "input_fields": {
+                    "labels": ["positive", "negative"],
+                    "text": "hello world",
+                },
+                "reference_fields": {"label": "positive", "reference": "1"},
             },
         ]
 
         targets = [
             {
-                "inputs": {"labels": ["positive", "negative"], "text": "hello world"},
-                "outputs": {"label": "positive", "reference": "1"},
+                "input_fields": {
+                    "labels": ["positive", "negative"],
+                    "text": "hello world",
+                },
+                "reference_fields": {"label": "positive", "reference": "1"},
                 "source": "This is my text:'hello world'",
                 "target": "positive",
                 "references": ["1"],
@@ -306,23 +322,25 @@ class TestTemplates(UnitxtTestCase):
         check_operator(template, inputs, targets, tester=self)
 
         with self.assertRaises(KeyError):
-            template.outputs_to_target_and_references(
-                outputs={"label": "positive", "references": "1"}
+            template.reference_fields_to_target_and_references(
+                reference_fields={"label": "positive", "references": "1"}
             )
 
         class ToCoverTemplate(Template):
-            def inputs_to_source(self, inputs: Dict[str, object]) -> Tuple[str, str]:
-                ret = super().inputs_to_source(inputs)
+            def input_fields_to_source(
+                self, inputs: Dict[str, object]
+            ) -> Tuple[str, str]:
+                ret = super().input_fields_to_source(inputs)
                 return (ret, ret)
 
-            def outputs_to_target_and_references(
+            def reference_fields_to_target_and_references(
                 self, outputs: Dict[str, object]
             ) -> Tuple[str, List[str]]:
-                return super().outputs_to_target_and_references(outputs)
+                return super().reference_fields_to_target_and_references(outputs)
 
         to_cover_template = ToCoverTemplate()
-        to_cover_template.inputs_to_source({"a": 1})
-        to_cover_template.outputs_to_target_and_references({"a": 1})
+        to_cover_template.input_fields_to_source({"a": 1})
+        to_cover_template.reference_fields_to_target_and_references({"a": 1})
 
         class ToCoverTemplatesDict(TemplatesDict):
             def verify(self):
@@ -344,7 +362,7 @@ class TestTemplates(UnitxtTestCase):
             "Is text_b of news?": {"text": "text_b", "class": "news"},
         }
         for expected_processed_input, inputs in processed_input_to_inputs.items():
-            processed = template.inputs_to_source(inputs)
+            processed = template.input_fields_to_source(inputs)
             self.assertEqual(expected_processed_input, processed)
 
     def test_yes_no_template_process_input_missing_input_field(self):
@@ -355,9 +373,9 @@ class TestTemplates(UnitxtTestCase):
         )
         with self.assertRaises(TemplateFormatKeyError) as cm:
             wrong_field_name = "wrong_field_name"
-            template.inputs_to_source(inputs={wrong_field_name: ["news"]})
+            template.input_fields_to_source(input_fields={wrong_field_name: ["news"]})
         self.assertEqual(
-            "\"Available inputs are [wrong_field_name] but YesNoTemplate.input_format format requires a different ones: 'Expecting field {class} in input.'\"",
+            "\"Available input fields are [wrong_field_name] but YesNoTemplate.input_format format requires a different ones: 'Expecting field {class} in input.'\"",
             str(cm.exception),
         )
 
@@ -380,7 +398,9 @@ class TestTemplates(UnitxtTestCase):
             yes_answer: {label_field: ["news", "sports"], class_field: "news"},
         }
         for expected_processed_output, outputs in processed_output_to_outputs.items():
-            processed, references = template.outputs_to_target_and_references(outputs)
+            processed, references = template.reference_fields_to_target_and_references(
+                outputs
+            )
             self.assertEqual(expected_processed_output, processed)
             self.assertEqual(references, [expected_processed_output])
 
@@ -397,17 +417,17 @@ class TestTemplates(UnitxtTestCase):
 
         with self.assertRaises(RuntimeError) as cm:
             outputs = {class_field: "news"}
-            template.outputs_to_target_and_references(outputs=outputs)
+            template.reference_fields_to_target_and_references(reference_fields=outputs)
         self.assertEqual(
-            f"Available outputs are {list(outputs.keys())}, missing required label field: '{label_field}'.",
+            f"Available reference_fields are {list(outputs.keys())}, missing required label field: '{label_field}'.",
             str(cm.exception),
         )
 
         with self.assertRaises(RuntimeError) as cm:
             outputs = {label_field: ["news", "sports"]}
-            template.outputs_to_target_and_references(outputs=outputs)
+            template.reference_fields_to_target_and_references(reference_fields=outputs)
         self.assertEqual(
-            f"Available outputs are {list(outputs.keys())}, missing required class field: '{class_field}'.",
+            f"Available reference_fields are {list(outputs.keys())}, missing required class field: '{class_field}'.",
             str(cm.exception),
         )
 
@@ -419,8 +439,8 @@ class TestTemplates(UnitxtTestCase):
                 input_format="", class_field="", label_field="labels"
             )
             with self.assertRaises(RuntimeError) as cm:
-                template.outputs_to_target_and_references(
-                    outputs={"labels": wrong_labels_value}
+                template.reference_fields_to_target_and_references(
+                    reference_fields={"labels": wrong_labels_value}
                 )
             self.assertEqual(
                 f"Unexpected value for gold_class_names: '{wrong_labels_value}'. Expecting a list.",
@@ -439,8 +459,8 @@ class TestTemplates(UnitxtTestCase):
                 input_format="", class_field=class_field, label_field=label_field
             )
             with self.assertRaises(RuntimeError) as cm:
-                template.outputs_to_target_and_references(
-                    outputs={
+                template.reference_fields_to_target_and_references(
+                    reference_fields={
                         label_field: ["news"],
                         class_field: wrong_class_value,
                     }
@@ -462,8 +482,10 @@ class TestTemplates(UnitxtTestCase):
 
         inputs = [
             {
-                "inputs": {"text": "John,: Doe is from New York and works at Goo:gle."},
-                "outputs": {
+                "input_fields": {
+                    "text": "John,: Doe is from New York and works at Goo:gle."
+                },
+                "reference_fields": {
                     "spans_starts": [0, 19, 41],
                     "spans_ends": [10, 27, 48],
                     "labels": ["PER", "PER", "ORG"],
@@ -471,10 +493,10 @@ class TestTemplates(UnitxtTestCase):
                 },
             },
             {
-                "inputs": {
+                "input_fields": {
                     "text": "John,: Doe is from New York and works at Goo:gle.",
                 },
-                "outputs": {
+                "reference_fields": {
                     "spans_starts": [],
                     "spans_ends": [],
                     "labels": [],
@@ -485,8 +507,10 @@ class TestTemplates(UnitxtTestCase):
 
         targets = [
             {
-                "inputs": {"text": "John,: Doe is from New York and works at Goo:gle."},
-                "outputs": {
+                "input_fields": {
+                    "text": "John,: Doe is from New York and works at Goo:gle."
+                },
+                "reference_fields": {
                     "spans_starts": [0, 19, 41],
                     "spans_ends": [10, 27, 48],
                     "labels": ["PER", "PER", "ORG"],
@@ -499,10 +523,10 @@ class TestTemplates(UnitxtTestCase):
                 "target_prefix": "",
             },
             {
-                "inputs": {
+                "input_fields": {
                     "text": "John,: Doe is from New York and works at Goo:gle.",
                 },
-                "outputs": {
+                "reference_fields": {
                     "spans_starts": [],
                     "spans_ends": [],
                     "labels": [],
@@ -523,8 +547,10 @@ class TestTemplates(UnitxtTestCase):
 
         inputs = [
             {
-                "inputs": {"text": "John,: Doe is from New York and works at Goo:gle."},
-                "outputs": {
+                "input_fields": {
+                    "text": "John,: Doe is from New York and works at Goo:gle."
+                },
+                "reference_fields": {
                     "spans_starts": [0, 19, 41],
                     "spans_ends": [10, 27, 48],
                     "labels": ["PER", "PER", "ORG"],
@@ -532,10 +558,10 @@ class TestTemplates(UnitxtTestCase):
                 },
             },
             {
-                "inputs": {
+                "input_fields": {
                     "text": "John,: Doe is from New York and works at Goo:gle.",
                 },
-                "outputs": {
+                "reference_fields": {
                     "spans_starts": [],
                     "spans_ends": [],
                     "labels": [],
@@ -546,8 +572,10 @@ class TestTemplates(UnitxtTestCase):
 
         targets = [
             {
-                "inputs": {"text": "John,: Doe is from New York and works at Goo:gle."},
-                "outputs": {
+                "input_fields": {
+                    "text": "John,: Doe is from New York and works at Goo:gle."
+                },
+                "reference_fields": {
                     "spans_starts": [0, 19, 41],
                     "spans_ends": [10, 27, 48],
                     "labels": ["PER", "PER", "ORG"],
@@ -562,10 +590,10 @@ class TestTemplates(UnitxtTestCase):
                 "target_prefix": "",
             },
             {
-                "inputs": {
+                "input_fields": {
                     "text": "John,: Doe is from New York and works at Goo:gle.",
                 },
-                "outputs": {
+                "reference_fields": {
                     "spans_starts": [],
                     "spans_ends": [],
                     "labels": [],
@@ -662,7 +690,7 @@ class TestTemplates(UnitxtTestCase):
         with self.assertRaises(ValueError) as ve:
             check_operator(template, inputs, targets, tester=self)
         self.assertEqual(
-            "Error processing instance '0' from stream 'test' in MultipleChoiceTemplate due to: \"Available inputs are [numerals, choices, text] but MultipleChoiceTemplate.input_format format requires a different ones: 'Text: {no_text}, Choices: {no_choices}.'\"",
+            "Error processing instance '0' from stream 'test' in MultipleChoiceTemplate due to: \"Available input fields are [numerals, choices, text] but MultipleChoiceTemplate.input_format format requires a different ones: 'Text: {no_text}, Choices: {no_choices}.'\"",
             str(ve.exception),
         )
 
@@ -751,7 +779,7 @@ class TestTemplates(UnitxtTestCase):
         with self.assertRaises(ValueError) as ve:
             check_operator(template, inputs, targets, tester=self)
         self.assertEqual(
-            "Error processing instance '0' from stream 'test' in MultipleChoiceTemplate due to: \"Available inputs are [numerals, choices, text] but MultipleChoiceTemplate.input_format format requires a different ones: 'Text: {no_text}, Choices: {no_choices}.'\"",
+            "Error processing instance '0' from stream 'test' in MultipleChoiceTemplate due to: \"Available input fields are [numerals, choices, text] but MultipleChoiceTemplate.input_format format requires a different ones: 'Text: {no_text}, Choices: {no_choices}.'\"",
             str(ve.exception),
         )
 
@@ -780,15 +808,18 @@ class TestTemplates(UnitxtTestCase):
         self.assertEqual(result, target)
 
     def test_render_template(self):
-        instance = {"inputs": {"text": "was so bad"}, "outputs": {"label": "negative"}}
+        instance = {
+            "input_fields": {"text": "was so bad"},
+            "reference_fields": {"label": "negative"},
+        }
         template = InputOutputTemplate(
             input_format='This is my sentence: "{text}"', output_format="{label}"
         )
 
         result = template.process(instance)
         target = {
-            "inputs": {"text": "was so bad"},
-            "outputs": {"label": "negative"},
+            "input_fields": {"text": "was so bad"},
+            "reference_fields": {"label": "negative"},
             "source": 'This is my sentence: "was so bad"',
             "target": "negative",
             "references": ["negative"],
@@ -802,14 +833,14 @@ class TestTemplates(UnitxtTestCase):
             input_format="This is my sentence: {text}", references_field="answer"
         )
         instance = {
-            "inputs": {"text": "who was he?"},
-            "outputs": {"answer": ["Dan", "Yossi"]},
+            "input_fields": {"text": "who was he?"},
+            "reference_fields": {"answer": ["Dan", "Yossi"]},
         }
 
         result = template.process(instance)
         target = {
-            "inputs": {"text": "who was he?"},
-            "outputs": {"answer": ["Dan", "Yossi"]},
+            "input_fields": {"text": "who was he?"},
+            "reference_fields": {"answer": ["Dan", "Yossi"]},
             "source": "This is my sentence: who was he?",
             "target": "Dan",
             "references": ["Dan", "Yossi"],


### PR DESCRIPTION


This is to continues  the work done on tasks.

Non backward compatible
Template methods changes:

```
inputs_to_instruction_and_target_prefix(self, inputs) ->    input_fields_to_instruction_and_target_prefix(self, input_fields)

inputs_to_source(self, inputs: Dict[str, object]) ->  input_fields_to_source(self, input_fields: Dict[str, object])

outputs_to_target_and_references(self, outputs: Dict[str, object]) -> reference_fields_to_target_and_references(self, reference_fields: Dict[str, object])

preprocess_inputs_and_outputs(   self, inputs: Dict[str, Any], outputs: Dict[str, Any] --> preprocess_input_and_reference_fields(self, input_fields: Dict[str, Any], reference_fields: Dict[str, Any]
   
```