### PR TITLE
Add CloseTextSampler and FixedIndicesSampler

### DIFF
--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -129,6 +129,9 @@ class Sampler(Artifact):
     ) -> List[Dict[str, object]]:
         pass
 
+    def get_random_generator_based_on_instance(self, instance):
+        return new_random_generator(sub_seed={**instance["input_fields"]})
+
     def filter_source_by_instance(
         self, instances_pool: List[Dict[str, object]], instance: Dict[str, object]
     ) -> List[Dict[str, object]]:
@@ -151,10 +154,10 @@ class RandomSampler(Sampler):
     def sample(
         self,
         instances_pool: List[Dict[str, object]],
-        instance: Optional[Dict[str, object]] = None,
+        instance: Optional[Dict[str, object]],
     ) -> List[Dict[str, object]]:
         instances_pool = list(instances_pool)
-        random_generator = new_random_generator(sub_seed=str(instance))
+        random_generator = self.get_random_generator_based_on_instance(instance)
         return random_generator.sample(instances_pool, self.sample_size)
 
 
@@ -166,7 +169,7 @@ class FixedIndicesSampler(Sampler):
     def sample(
         self,
         instances_pool: List[Dict[str, object]],
-        instance: Optional[Dict[str, object]] = None,
+        instance: Optional[Dict[str, object]],
     ) -> List[Dict[str, object]]:
         num_instances = len(instances_pool)
 
@@ -212,7 +215,7 @@ class CloseTextSampler(Sampler):
             for instance_in_pool in instances_pool
             if dict_get(instance_in_pool, field) in closest_matches
         ]
-        random_generator = new_random_generator(sub_seed=str(instance))
+        random_generator = self.get_random_generator_based_on_instance(instance)
         return random_generator.sample(instances_pool, self.sample_size)
 
 
@@ -297,12 +300,12 @@ class DiverseLabelsSampler(Sampler):
     def sample(
         self,
         instances_pool: List[Dict[str, object]],
-        instance: Optional[Dict[str, object]] = None,
+        instance: Optional[Dict[str, object]],
     ) -> List[Dict[str, object]]:
         if self.labels_cache is None:
             self.labels_cache = self.divide_by_repr(instances_pool)
         all_labels = list(self.labels_cache.keys())
-        random_generator = new_random_generator(sub_seed=str(instance))
+        random_generator = self.get_random_generator_based_on_instance(instance)
         random_generator.shuffle(all_labels)
         from collections import Counter
 

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -343,7 +343,7 @@ class SpreadSplit(InstanceOperatorWithMultiStreamAccess):
                 raise ValueError(
                     f"Size of population to sample from: {len(source_stream)} is smaller than the needed sample_size: {self.sampler.sample_size}."
                 )
-            sampled_instances = self.sampler.sample(source_stream)
+            sampled_instances = self.sampler.sample(source_stream, instance)
             instance[self.target_field] = sampled_instances
             return instance
         except FaultyStreamError as e:

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -164,6 +164,28 @@ class RandomSampler(Sampler):
         return self.random_generator.sample(instances_pool, self.sample_size)
 
 
+class FixedIndicesSampler(Sampler):
+    """Selects a fix set of samples based on a list of indices."""
+
+    indices: List[int]
+
+    def sample(
+        self,
+        instances_pool: List[Dict[str, object]],
+        instance: Optional[Dict[str, object]] = None,
+    ) -> List[Dict[str, object]]:
+        num_instances = len(instances_pool)
+
+        instances = []
+        for index in self.indices:
+            if index >= num_instances:
+                raise ValueError(
+                    f"FixedIndicesSampler 'indices' field contains index ({index}) which is out of bounds of the instance pool ( of size {num_instances})"
+                )
+            instances.append(instances_pool[index])
+        return instances
+
+
 class CloseTextSampler(Sampler):
     """Selects the samples of instances which are the closest textual match to the given instance.
 

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -352,7 +352,7 @@ class StandardRecipe(StandardRecipeWithIndexes):
         demos_taken_from (str, optional): Specifies from where the demos are taken. Default is "train".
         demos_field (str, optional): Field name for demos. Default is "demos".
         demos_removed_from_data (bool, optional): whether to remove the demos from the source data, Default is True
-        sampler (Sampler, optional): Sampler object to be used in the recipe.
+        sampler (Sampler, optional): The Sampler used to select the demonstrations when num_demos > 0.
         steps (List[StreamingOperator], optional): List of StreamingOperator objects to be used in the recipe.
         augmentor (Augmentor) : Augmentor to be used to pseudo randomly augment the source text
         instruction_card_index (int, optional): Index of instruction card to be used

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -58,8 +58,6 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
 
     def before_process_multi_stream(self):
         super().before_process_multi_stream()
-        if self.sampler:  # e.g. when num_demos is 0, the sampler may not be initialized
-            self.sampler.init_new_random_generator()
 
     def verify(self):
         super().verify()

--- a/tests/library/test_api.py
+++ b/tests/library/test_api.py
@@ -125,7 +125,14 @@ class TestAPI(UnitxtTestCase):
 
         target = {
             "metrics": ["metrics.f1_micro", "metrics.accuracy", "metrics.f1_macro"],
-            "source": "Given a premise and hypothesis classify the entailment of the hypothesis to one of entailment, not entailment.\npremise: Steve follows Fred's example in everything. He influences him hugely.\nhypothesis: Steve influences him hugely.\nThe entailment class is entailment\n\npremise: The police arrested all of the gang members. They were trying to stop the drug trade in the neighborhood.\nhypothesis: The police were trying to stop the drug trade in the neighborhood.\nThe entailment class is not entailment\n\npremise: It works perfectly\nhypothesis: It works!\nThe entailment class is ",
+            "source": "Given a premise and hypothesis classify the entailment of the hypothesis to one of entailment, not entailment.\n"
+            "premise: When Tatyana reached the cabin, her mother was sleeping. "
+            "She was careful not to disturb her, undressing and climbing back "
+            "into her berth.\n"
+            "hypothesis: mother was careful not to disturb her, undressing and "
+            "climbing back into her berth.\n"
+            "The entailment class is entailment\n\n"
+            "premise: Steve follows Fred's example in everything. He influences him hugely.\nhypothesis: Steve influences him hugely.\nThe entailment class is entailment\n\npremise: It works perfectly\nhypothesis: It works!\nThe entailment class is ",
             "target": "?",
             "references": ["?"],
             "task_data": '{"text_a": "It works perfectly", '
@@ -164,7 +171,14 @@ class TestAPI(UnitxtTestCase):
 
         target = {
             "metrics": ["metrics.f1_micro", "metrics.accuracy", "metrics.f1_macro"],
-            "source": "Given a premise and hypothesis classify the entailment of the hypothesis to one of entailment, not entailment.\npremise: Steve follows Fred's example in everything. He influences him hugely.\nhypothesis: Steve influences him hugely.\nThe entailment class is entailment\n\npremise: The police arrested all of the gang members. They were trying to stop the drug trade in the neighborhood.\nhypothesis: The police were trying to stop the drug trade in the neighborhood.\nThe entailment class is not entailment\n\npremise: It works perfectly\nhypothesis: It works!\nThe entailment class is ",
+            "source": "Given a premise and hypothesis classify the entailment of the hypothesis to one of entailment, not entailment.\n"
+            "premise: When Tatyana reached the cabin, her mother was sleeping. "
+            "She was careful not to disturb her, undressing and climbing back "
+            "into her berth.\n"
+            "hypothesis: mother was careful not to disturb her, undressing and "
+            "climbing back into her berth.\n"
+            "The entailment class is entailment\n\n"
+            "premise: Steve follows Fred's example in everything. He influences him hugely.\nhypothesis: Steve influences him hugely.\nThe entailment class is entailment\n\npremise: It works perfectly\nhypothesis: It works!\nThe entailment class is ",
             "target": "?",
             "references": ["?"],
             "task_data": '{"text_a": "It works perfectly", '

--- a/tests/library/test_recipe.py
+++ b/tests/library/test_recipe.py
@@ -168,7 +168,54 @@ class TestRecipes(UnitxtTestCase):
 
         target = {
             "metrics": ["metrics.accuracy"],
-            "source": "<<SYS>>\nYou are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\n\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.\n<</SYS>>\n\n\n\n\nUser: The following are multiple choice questions (with answers) about marketing.\n\nThe single group within society that is most vulnerable to reference group influence is:\nA. The older consumer who feels somewhat left out of things.\nB. The married women, many of whom feel a need for stability in their lives.\nC. New immigrants who really want to assimilate into their new culture.\nD. Children, who base most of their buying decisions on outside influences.\nAnswer:\nAgent:  D\n\nUser: The following are multiple choice questions (with answers) about marketing.\n\n Which of the following is an assumption in Maslow's hierarchy of needs?\nA. Needs are dependent on culture and also on social class.\nB. Lower-level needs must be at least partially satisfied before higher needs can affect behaviour.\nC. Needs are not prioritized or arranged in any particular order.\nD. Satisfied needs are motivators, and new needs emerge when current needs remain unmet.\nAnswer:\nAgent:  B\n\nUser: The following are multiple choice questions (with answers) about marketing.\n\nIn an organization, the group of people tasked with buying decisions is referred to as the _______________.\nA. Outsourcing unit.\nB. Procurement centre.\nC. Chief executive unit.\nD. Decision-making unit.\nAnswer:\nAgent:  D\n\n\nUser:The following are multiple choice questions (with answers) about testing.\n\nwhat?\nA. yes\nB. not\nC. maybe\nAnswer:\nAgent:",
+            "source": """<<SYS>>
+You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.
+
+If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.
+<</SYS>>
+
+
+
+
+User: The following are multiple choice questions (with answers) about marketing.
+
+Although the content and quality can be as controlled as direct mail, response rates of this medium are lower because of the lack of a personal address mechanism. This media format is known as:
+A. Care lines.
+B. Direct mail.
+C. Inserts.
+D. Door to door.
+Answer:
+Agent:  D
+
+User: The following are multiple choice questions (with answers) about marketing.
+
+ _____________ is a natural outcome when combining demographic and geographic variables.
+A. Geodemographics
+B. Product differentiation.
+C. ANSOFF matrix.
+D. Brand management.
+Answer:
+Agent:  A
+
+User: The following are multiple choice questions (with answers) about marketing.
+
+In an organization, the group of people tasked with buying decisions is referred to as the _______________.
+A. Outsourcing unit.
+B. Procurement centre.
+C. Chief executive unit.
+D. Decision-making unit.
+Answer:
+Agent:  D
+
+
+User:The following are multiple choice questions (with answers) about testing.
+
+what?
+A. yes
+B. not
+C. maybe
+Answer:
+Agent:""",
             "target": " C",
             "references": [" C"],
             "task_data": '{"topic": "testing",'

--- a/tests/library/test_recipe.py
+++ b/tests/library/test_recipe.py
@@ -544,30 +544,6 @@ class TestRecipes(UnitxtTestCase):
         first_inst = next(iterator)
         self.assertListEqual(["metrics.accuracy"], first_inst["metrics"])
 
-    def test_standard_recipe_with_a_sampler(self):
-        """Check that the sampler is re-initialized before processing a recipe.
-
-        To do so, save the random generator within the sampler before activating the recipe,
-        and compare it to the random generator within the sampler after the revipe was called.
-        The two generators should be different objects, indicating that the sampler was properly
-        re-initialized during the preparation of the recipe.
-        """
-        recipe = StandardRecipeWithIndexes(
-            card="cards.sst2",
-            template_card_index=0,
-            max_train_instances=0,
-            max_test_instances=2,
-            num_demos=1,
-            demos_pool_size=10,
-        )
-        sampler = recipe.card.sampler
-
-        random_generator1 = sampler.random_generator
-        recipe()
-        random_generator2 = sampler.random_generator
-
-        self.assertNotEqual(random_generator1, random_generator2)
-
     def test_standard_recipe_with_a_missing_sampler(self):
         """Check that initializing a recipe with a card that does not have a sampler raises an exception."""
         task_card, _ = copy.deepcopy(fetch_artifact("cards.sst2"))

--- a/tests/library/test_splitters.py
+++ b/tests/library/test_splitters.py
@@ -181,7 +181,7 @@ class TestCloseTextSampler(UnitxtTestCase):
         results = sampler.sample(
             instances, self.new_exemplar("What is the time?", "don't know")
         )
-        self.assertEqual(results, [instances[2], instances[0]])
+        self.assertEqual(results, [instances[0], instances[2]])
 
         num_samples = 1
         sampler = CloseTextSampler(num_samples, field="answer")
@@ -233,14 +233,14 @@ class TestCloseTextSampler(UnitxtTestCase):
         )
         expected_output = """Answer the question.
 Question:
-What's your name, please?
-Answer:
-Mary
-
-Question:
 What is your name?
 Answer:
 John
+
+Question:
+What's your name, please?
+Answer:
+Mary
 
 Question:
 What's your name?

--- a/tests/library/test_splitters.py
+++ b/tests/library/test_splitters.py
@@ -39,7 +39,10 @@ class TestDiverseLabelsSampler(UnitxtTestCase):
                 self.new_exemplar(choices, ["cow"], "Moo1"),
                 self.new_exemplar(choices, ["duck"], "Quack"),
             ]
-            result = sampler.sample(instances)
+            result = sampler.sample(
+                instances,
+                self.new_exemplar(choices, ["any"], "any"),
+            )
 
             from collections import Counter
 
@@ -63,7 +66,10 @@ class TestDiverseLabelsSampler(UnitxtTestCase):
                 self.new_exemplar(choices, ["cow"], "Moo1"),
                 self.new_exemplar(choices, ["duck"], "Quack"),
             ]
-            result = sampler.sample(instances)
+            result = sampler.sample(
+                instances,
+                self.new_exemplar(choices, ["any"], "any"),
+            )
 
             from collections import Counter
 
@@ -83,7 +89,9 @@ class TestDiverseLabelsSampler(UnitxtTestCase):
                 self.new_exemplar(choices, ["dog"], "Bark2"),
                 self.new_exemplar(choices, ["duck"], "Quack"),
             ]
-            result = sampler.sample(instances)
+            result = sampler.sample(
+                instances, self.new_exemplar(choices, ["any"], "any")
+            )
             from collections import Counter
 
             counts = Counter()
@@ -181,7 +189,7 @@ class TestCloseTextSampler(UnitxtTestCase):
         results = sampler.sample(
             instances, self.new_exemplar("What is the time?", "don't know")
         )
-        self.assertEqual(results, [instances[0], instances[2]])
+        self.assertEqual(results, [instances[2], instances[0]])
 
         num_samples = 1
         sampler = CloseTextSampler(num_samples, field="answer")
@@ -211,6 +219,7 @@ class TestCloseTextSampler(UnitxtTestCase):
                 {"question": "In which country is Paris located?", "answer": "France"},
                 {"question": "At what time do we they eat dinner?", "answer": "22:00"},
                 {"question": "What's your name, please?", "answer": "Mary"},
+                {"question": "Is this your car?", "answer": "yes"},
                 {"question": "What is your name?", "answer": "Sunny"},
             ],
             "test": [
@@ -227,7 +236,7 @@ class TestCloseTextSampler(UnitxtTestCase):
         dataset = load_dataset(
             card=card,
             template="templates.qa.open.title",
-            demos_pool_size=4,
+            demos_pool_size=5,
             num_demos=2,
             sampler=CloseTextSampler(field="question"),
         )
@@ -266,10 +275,10 @@ class TestFixedIndicesSampler(UnitxtTestCase):
             self.new_exemplar("What's the time?", "22:00"),
             self.new_exemplar("What is your name, please?", "Mary"),
         ]
-
+        instance = self.new_exemplar("What's your name?", "don't know")
         sampler = FixedIndicesSampler(indices=[2, 0])
 
-        results = sampler.sample(instances)
+        results = sampler.sample(instances, instance)
         self.assertEqual(results, [instances[2], instances[0]])
 
     def test_out_of_bound_sample(self):
@@ -278,9 +287,10 @@ class TestFixedIndicesSampler(UnitxtTestCase):
             self.new_exemplar("In which country is Paris located?", "France"),
         ]
 
+        instance = self.new_exemplar("What's your name?", "don't know")
         sampler = FixedIndicesSampler(indices=[2])
         with self.assertRaises(ValueError) as cm:
-            sampler.sample(instances)
+            sampler.sample(instances, instance)
         self.assertIn(
             "FixedIndicesSampler 'indices' field contains index (2) which is out of bounds of the instance pool ( of size 2)",
             str(cm.exception),


### PR DESCRIPTION
CloseTextSampler -  returns demos that are textually close to the current instance.
FixedIndicesSampler - return fixed demos based on indices in the train pool

Also fixed a bug in reproducibility of demos by making sure randomization is based on instance, and being global (so it is shared with ther instances)