### PR TITLE
Add string to context id in rag

### DIFF
--- a/prepare/tasks/rag/response_generation.py
+++ b/prepare/tasks/rag/response_generation.py
@@ -7,7 +7,7 @@ add_to_catalog(
     Task(
         input_fields={
             "contexts": "List[str]",
-            "contexts_ids": "List[int]",
+            "contexts_ids": "Union[List[int],List[str]]",
             "question": "str",
         },
         reference_fields={"reference_answers": "List[str]"},

--- a/src/unitxt/catalog/tasks/rag/response_generation.json
+++ b/src/unitxt/catalog/tasks/rag/response_generation.json
@@ -2,7 +2,7 @@
     "__type__": "task",
     "input_fields": {
         "contexts": "List[str]",
-        "contexts_ids": "List[int]",
+        "contexts_ids": "Union[List[int],List[str]]",
         "question": "str"
     },
     "reference_fields": {


### PR DESCRIPTION
some RAG datasets has a hash instead of an int context id