### PR TITLE
Fixed issues with fresh install

### DIFF
--- a/prepare/metrics/code_mixing_detection.py
+++ b/prepare/metrics/code_mixing_detection.py
@@ -1,4 +1,3 @@
-import torch
 from unitxt import add_to_catalog
 from unitxt.logging_utils import get_logger
 from unitxt.metrics import IsCodeMixed
@@ -35,9 +34,9 @@ global_target = {
 
 metric = IsCodeMixed()
 
-if not torch.cuda.is_available() and not torch.backends.mps.is_available():
-    logger.info("no gpu available, cannot test metric")
-else:
+# Because the metric requires downloading very large model (multiple >10GBs), only run
+# the test when explicitly requested.
+if __name__ == "__main__":
     outputs = test_metric(
         metric=metric,
         predictions=examples,

--- a/src/unitxt/test_utils/metrics.py
+++ b/src/unitxt/test_utils/metrics.py
@@ -147,6 +147,12 @@ def test_evaluate(
     task_data: Optional[List[dict]],
     metric_name: str,
 ):
+    if settings.test_metric_disable:
+        logger.info(
+            "test_evaluate() functionality is disabled because unitxt.settings.test_metric_disable=True or UNITXT_TEST_METRIC_DISABLE environment variable is set"
+        )
+        return
+
     evaluation_result, global_outputs = evaluate(
         task_data, metric_names=[metric_name], compute_conf_intervals=True
     )


### PR DESCRIPTION
There were two problems that prevented running 

python utils/prepare_all_artifacts.py

on fresh installs.

evaluate_metric - should not be run if test_metric_disable is True (because prepare/verify method are not called).
This is simulate to test_metric.

Code_mixing_detection.py should not require torch in imports.