### PR TITLE
fix - building test is not working. The reason is that opendatasets p…

### DIFF
--- a/requirements/tests.rqr
+++ b/requirements/tests.rqr
@@ -2,6 +2,7 @@ bert_score
 transformers
 sentence_transformers
 ibm-cos-sdk
+kaggle==1.6.14
 opendatasets
 httpretty~=1.1.4
 editdistance


### PR DESCRIPTION
…oints to kaggle without version, and currently kaggle-1.6.15 fails. We fix the version of kaggle to be 1.6.14 as a fix