### PR TITLE
Remove import pkg_resources from utils

### DIFF
--- a/src/unitxt/hf_utils.py
+++ b/src/unitxt/hf_utils.py
@@ -24,10 +24,10 @@ class UnitxtVersionsConflictError(ValueError):
     def __init__(self, error_in: str, hf_unitxt_version, installed_unitxt_version):
         assert hf_unitxt_version != installed_unitxt_version
         if compare_versions(hf_unitxt_version, installed_unitxt_version) == 1:
-            msg = f"Located locally installed Unitxt version {installed_unitxt_version} that is older than the Unitxt {error_in} version {hf_unitxt_version}. Please either (1) update the local Unitxt package or (2) uninstall the local unitxt package (3) remove the calls to the Unitxt {error_in} API and use only the direct Unitxt APIs."
+            msg = f"Located locally installed Unitxt version {installed_unitxt_version} that is older than the Huggingface Unitxt {error_in} version {hf_unitxt_version}. Please either (1) update the local Unitxt package or (2) uninstall the local unitxt package (3) remove the calls to the  Huggingface {error_in} API and use only the direct Unitxt APIs."
         if compare_versions(hf_unitxt_version, installed_unitxt_version) == -1:
-            msg = f"Located locally installed Unitxt version {installed_unitxt_version} that is newer than Unitxt {error_in} version {hf_unitxt_version}. Please either (1) force-reload the {error_in} version or (2) downgrade the locally installed Unitxt version to {error_in} version or (3) uninstall the locally installed Unitxt, if you are not using the direct Unitxt APIs"
-        msg = "For more details see: https://unitxt.readthedocs.io/en/latest/docs/installation.html"
+            msg = f"Located locally installed Unitxt version {installed_unitxt_version} that is newer than the Huggingface Unitxt {error_in} version {hf_unitxt_version}. Please either (1) force-reload the {error_in} version or (2) downgrade the locally installed Unitxt version to {error_in} version or (3) uninstall the locally installed Unitxt, if you are not using the direct Unitxt APIs"
+        msg += "For more details see: https://unitxt.readthedocs.io/en/latest/docs/installation.html"
         super().__init__(msg)
 
 

--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -26,8 +26,8 @@ class PackageRequirementsMixin(Artifact):
         default_factory=list
     )
 
-    def verify(self):
-        super().verify()
+    def prepare(self):
+        super().prepare()
         self.check_missing_requirements()
 
     def check_missing_requirements(self, requirements=None):

--- a/src/unitxt/utils.py
+++ b/src/unitxt/utils.py
@@ -4,8 +4,6 @@ import os
 from functools import lru_cache
 from typing import Any, Dict
 
-import pkg_resources
-
 from .text_utils import is_made_of_sub_strings
 
 
@@ -68,11 +66,8 @@ def is_package_installed(package_name):
     Returns:
     - bool: True if the package is installed, False otherwise.
     """
-    try:
-        pkg_resources.get_distribution(package_name)
-        return True
-    except pkg_resources.DistributionNotFound:
-        return False
+    unitxt_pkg = importlib.util.find_spec(package_name)
+    return unitxt_pkg is not None
 
 
 def is_module_available(module_name):


### PR DESCRIPTION
This is so minimal requirement installation will still work.

Also changed to missing requirements will be reported before the requirements are used.