### PR TITLE
Simplify HF vs Direct APIs

### DIFF
--- a/src/unitxt/dataset.py
+++ b/src/unitxt/dataset.py
@@ -19,7 +19,6 @@ from .file_utils import __file__ as _
 from .formats import __file__ as _
 from .fusion import __file__ as _
 from .generator_utils import __file__ as _
-from .hf_utils import verify_versions_compatibility
 from .inference import __file__ as _
 from .instructions import __file__ as _
 from .llm_as_judge import __file__ as _
@@ -69,16 +68,9 @@ class Dataset(datasets.GeneratorBasedBuilder):
     def generators(self):
         if not hasattr(self, "_generators") or self._generators is None:
             if is_package_installed("unitxt"):
-                verify_versions_compatibility("dataset", self.VERSION)
-
-                from unitxt.dataset_utils import (
-                    get_dataset_artifact as get_dataset_artifact_installed,
+                logger.warning(
+                    "Loading Unitxt dataset with HuggingFace API and not installed version ..."
                 )
-
-                logger.info("Loading with installed unitxt library...")
-                dataset = get_dataset_artifact_installed(self.config.name)
-            else:
-                logger.info("Loading with huggingface unitxt copy...")
                 dataset = get_dataset_artifact(self.config.name)
 
             self._generators = dataset()

--- a/src/unitxt/hf_utils.py
+++ b/src/unitxt/hf_utils.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from datasets.utils.py_utils import get_imports
 
-from .deprecation_utils import compare_versions
 from .file_utils import get_all_files_in_dir
 
 
@@ -18,31 +17,3 @@ def get_missing_imports(file, exclude=None):
     return [
         i for i in required_modules if i not in imported_modules and i not in exclude
     ]
-
-
-class UnitxtVersionsConflictError(ValueError):
-    def __init__(self, error_in: str, hf_unitxt_version, installed_unitxt_version):
-        assert hf_unitxt_version != installed_unitxt_version
-        if compare_versions(hf_unitxt_version, installed_unitxt_version) == 1:
-            msg = f"Located locally installed Unitxt version {installed_unitxt_version} that is older than the Huggingface Unitxt {error_in} version {hf_unitxt_version}. Please either (1) update the local Unitxt package or (2) uninstall the local unitxt package (3) remove the calls to the  Huggingface {error_in} API and use only the direct Unitxt APIs."
-        if compare_versions(hf_unitxt_version, installed_unitxt_version) == -1:
-            msg = f"Located locally installed Unitxt version {installed_unitxt_version} that is newer than the Huggingface Unitxt {error_in} version {hf_unitxt_version}. Please either (1) force-reload the {error_in} version or (2) downgrade the locally installed Unitxt version to {error_in} version or (3) uninstall the locally installed Unitxt, if you are not using the direct Unitxt APIs"
-        msg += "For more details see: https://unitxt.readthedocs.io/en/latest/docs/installation.html"
-        super().__init__(msg)
-
-
-def get_installed_version():
-    from unitxt.settings_utils import get_constants as installed_get_constants
-
-    return installed_get_constants().version
-
-
-def verify_versions_compatibility(hf_asset_type, hf_asset_version):
-    _verify_versions(hf_asset_type, get_installed_version(), hf_asset_version)
-
-
-def _verify_versions(hf_asset_type, installed_version, hf_asset_version):
-    if installed_version != hf_asset_version:
-        raise UnitxtVersionsConflictError(
-            hf_asset_type, hf_asset_version, installed_version
-        )

--- a/src/unitxt/metric.py
+++ b/src/unitxt/metric.py
@@ -19,12 +19,12 @@ from .file_utils import __file__ as _
 from .formats import __file__ as _
 from .fusion import __file__ as _
 from .generator_utils import __file__ as _
-from .hf_utils import verify_versions_compatibility
 from .inference import __file__ as _
 from .instructions import __file__ as _
 from .llm_as_judge import __file__ as _
 from .loaders import __file__ as _
 from .logging_utils import __file__ as _
+from .logging_utils import get_logger
 from .metric_utils import UNITXT_METRIC_SCHEMA, _compute
 from .metrics import __file__ as _
 from .normalizers import __file__ as _
@@ -55,6 +55,7 @@ from .validate import __file__ as _
 from .version import __file__ as _
 
 constants = get_constants()
+logger = get_logger()
 
 
 class Metric(evaluate.Metric):
@@ -79,18 +80,9 @@ class Metric(evaluate.Metric):
         split_name: str = "all",
     ):
         if is_package_installed("unitxt"):
-            verify_versions_compatibility("metric", self.VERSION)
-
-            from unitxt.metric_utils import _compute as _compute_installed
-
-            return _compute_installed(
-                predictions=predictions,
-                references=references,
-                flatten=flatten,
-                split_name=split_name,
-                calc_confidence_intervals=self.calc_confidence_intervals,
+            logger.warning(
+                "Unitxt metrics loaded from HuggingFace version and not from local installation of unitxt"
             )
-
         return _compute(
             predictions=predictions,
             references=references,


### PR DESCRIPTION
When using HF APIs only the HF version code and catalog will be used