### PR TITLE
DeepSeek-Coder format and system prompt

### DIFF
--- a/prepare/formats/models/deepseek_coder.py
+++ b/prepare/formats/models/deepseek_coder.py
@@ -1,0 +1,12 @@
+from unitxt.catalog import add_to_catalog
+from unitxt.formats import SystemFormat
+
+# DeepSeek-Coder format and system prompt according to: https://github.com/deepseek-ai/deepseek-coder
+
+format = SystemFormat(
+    demo_format="### Instruction:\n{source}\n## Response:\n{target_prefix}{target}\n<EOT>\n",
+    model_input_format="{system_prompt}\n{demos}### Instruction:\n{source}\n### Response:\n{target_prefix}",
+)
+
+
+add_to_catalog(format, "formats.deepseek_coder", overwrite=True)

--- a/prepare/system_prompts/models/deepseek_coder.py
+++ b/prepare/system_prompts/models/deepseek_coder.py
@@ -1,0 +1,13 @@
+from unitxt.catalog import add_to_catalog
+from unitxt.system_prompts import TextualSystemPrompt
+
+# DeepSeek-Coder format and system prompt according to: https://github.com/deepseek-ai/deepseek-coder
+
+system_prompt = TextualSystemPrompt(
+    "You are an AI programming assistant, utilizing the DeepSeek Coder "
+    "model, developed by DeepSeek Company, and you only answer questions "
+    "related to computer science. For politically sensitive questions, "
+    "security and privacy issues, and other non-computer science questions, "
+    "you will refuse to answer."
+)
+add_to_catalog(system_prompt, "system_prompts.models.deepseek_coder", overwrite=True)

--- a/src/unitxt/catalog/formats/deepseek_coder.json
+++ b/src/unitxt/catalog/formats/deepseek_coder.json
@@ -1,0 +1,5 @@
+{
+    "__type__": "system_format",
+    "demo_format": "### Instruction:\n{source}\n## Response:\n{target_prefix}{target}\n<EOT>\n",
+    "model_input_format": "{system_prompt}\n{demos}### Instruction:\n{source}\n### Response:\n{target_prefix}"
+}

--- a/src/unitxt/catalog/system_prompts/models/deepseek_coder.json
+++ b/src/unitxt/catalog/system_prompts/models/deepseek_coder.json
@@ -1,0 +1,4 @@
+{
+    "__type__": "textual_system_prompt",
+    "text": "You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer."
+}


### PR DESCRIPTION
Adding a format and a system prompt for DeepSeek-Coder family of models (v1) based on the prompt template shown here: https://github.com/deepseek-ai/deepseek-coder
I couldn't find any existing format that was the same or similar. I've tested these on two tasks, and they seem to work well and improve the results compared with no format or system prompt.