### PR TITLE
Update operators.py - documentation changes

### DIFF
--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -14,9 +14,9 @@ To enhance the functionality of Unitxt, users are encouraged to develop custom o
 This can be achieved by inheriting from any of the existing operators listed below or from one of the fundamental :class:`base operators<unitxt.operator>`.
 The primary task in any operator development is to implement the `process` function, which defines the unique manipulations the operator will perform.
 
-General or Specelized Operators
+General or Specialized Operators
 --------------------------------
-Some operators are specielized in specific data or specific operations such as:
+Some operators are specialized in specific data or specific operations such as:
 
 - :class:`loaders<unitxt.loaders>` for accessing data from various sources.
 - :class:`splitters<unitxt.splitters>` for fixing data splits.
@@ -28,12 +28,12 @@ Some operators are specielized in specific data or specific operations such as:
 - :class:`span_labeling_operators<unitxt.span_labeling_operators>` for handling strings.
 - :class:`fusion<unitxt.fusion>` for fusing and mixing datasets.
 
-Other specelized operators are used by unitxt internally:
+Other specialized operators are used by unitxt internally:
 
 - :class:`templates<unitxt.templates>` for verbalizing data examples.
 - :class:`formats<unitxt.formats>` for preparing data for models.
 
-The rest of this section is dedicated for general operators.
+The rest of this section is dedicated to general operators.
 
 General Operators List:
 ------------------------
@@ -777,7 +777,7 @@ class Apply(InstanceOperator):
     Args:
         function (str): name of function.
         to_field (str): the field to store the result
-        additional arguments are field names passed to the function
+        any additional arguments are field names whose values will be passed to the function specified
 
     Examples:
     Store in field  "b" the uppercase string of the value in field "a"


### PR DESCRIPTION
These are all documentation changes:
* spelling of specialized
* dedicated to (instead of dedicated for)
* adjusted a documentation comment including Yoav's suggested text -- made it so that the word "function" was not at the end of the sentence, as it seemed to be originally interpreted as a keyword rather than a documentation comment. When the word function was at the end, the word function was taken out of the parentheses on the docs web page and this did not seem intended. Hope this fixes it. Please review these final changes - thanks