### PR TITLE
Update operators.py --- copy edits (grammar, consistency, clarity) - take 2

### DIFF
--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -14,9 +14,9 @@ To enhance the functionality of Unitxt, users are encouraged to develop custom o
 This can be achieved by inheriting from any of the existing operators listed below or from one of the fundamental :class:`base operators<unitxt.operator>`.
 The primary task in any operator development is to implement the `process` function, which defines the unique manipulations the operator will perform.
 
-General or Specelized Operators
+General or Specialized Operators
 --------------------------------
-Some operators are specielized in specific data or specific operations such as:
+Some operators are specialized in specific data or specific operations such as:
 
 - :class:`loaders<unitxt.loaders>` for accessing data from various sources.
 - :class:`splitters<unitxt.splitters>` for fixing data splits.
@@ -28,12 +28,12 @@ Some operators are specielized in specific data or specific operations such as:
 - :class:`span_labeling_operators<unitxt.span_labeling_operators>` for handling strings.
 - :class:`fusion<unitxt.fusion>` for fusing and mixing datasets.
 
-Other specelized operators are used by unitxt internally:
+Other specialized operators are used by unitxt internally:
 
 - :class:`templates<unitxt.templates>` for verbalizing data examples.
 - :class:`formats<unitxt.formats>` for preparing data for models.
 
-The rest of this section is dedicated for general operators.
+The rest of this section is dedicated to general operators.
 
 General Operators List:
 ------------------------
@@ -777,7 +777,7 @@ class Apply(InstanceOperator):
     Args:
         function (str): name of function.
         to_field (str): the field to store the result
-        additional arguments are field names passed to the function
+        any additional arguments are field names whose values will be passed directly to the function specified
 
     Examples:
     Store in field  "b" the uppercase string of the value in field "a"


### PR DESCRIPTION
In addition to fixing typos for the word "specialized" and changed "dedicated for" to "dedicated to" -- I also adjusted something that seemed to render differently than planned --

The auto docs said
"additional arguments are field names passed to the function" 

but it showed up on the web page as
"(additional arguments are field names passed to the) - name of function" 

-- it seemed to render this way since the word "function" was at the end.

Incorporating Yoav's new suggested text for clarity, I also switched the final words so that it didn't end with the word function, which seemed to be picked up there by the parser.

I hope this renders better. We can check by looking at the operators.html page on the resulting documentation website after this commit is approved, and if it doesn't work tweak from there.

Please review. Thanks!