### PR TITLE
make deprecated field print warning message for the right reason

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-08-14T10:01:36Z",
+  "generated_at": "2024-08-21T15:51:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "fa172616e9af3d2a24b5597f264eab963fe76889",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1948,
+        "line_number": 1946,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -21,7 +21,6 @@ from scipy.stats._warnings_errors import DegenerateDataWarning
 from .artifact import Artifact, fetch_artifact
 from .dataclass import (
     AbstractField,
-    DeprecatedField,
     InternalField,
     NonPositionalField,
     OptionalField,
@@ -1425,11 +1424,7 @@ class MetricPipeline(MultiStreamOperator, Metric):
     main_score: str = None
     preprocess_steps: Optional[List[StreamingOperator]] = field(default_factory=list)
     postprocess_steps: Optional[List[StreamingOperator]] = field(default_factory=list)
-    postpreprocess_steps: Optional[List[StreamingOperator]] = DeprecatedField(
-        metadata={
-            "deprecation_msg": "Field 'postpreprocess_steps' is deprecated. Please use 'postprocess_steps' for the same purpose."
-        }
-    )
+    postpreprocess_steps: Optional[List[StreamingOperator]] = None
     metric: Metric = None
 
     def disable_confidence_interval_calculation(self):
@@ -1446,6 +1441,9 @@ class MetricPipeline(MultiStreamOperator, Metric):
         assert isinstance(
             self.metric, Metric
         ), f"'metric' is not set to a Metric class in {self.get_metric_name()} (type{self.metric})"
+        if self.postpreprocess_steps is not None:
+            depr_message = "Field 'postpreprocess_steps' is deprecated. Please use 'postprocess_steps' for the same purpose."
+            warnings.warn(depr_message, DeprecationWarning, stacklevel=2)
 
     def prepare(self):
         super().prepare()

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -42,6 +42,7 @@ General Operators List:
 import copy
 import operator
 import uuid
+import warnings
 import zipfile
 from abc import abstractmethod
 from collections import Counter, defaultdict
@@ -63,7 +64,7 @@ from typing import (
 import requests
 
 from .artifact import Artifact, fetch_artifact
-from .dataclass import DeprecatedField, NonPositionalField, OptionalField
+from .dataclass import NonPositionalField, OptionalField
 from .deprecation_utils import deprecation
 from .dict_utils import dict_delete, dict_get, dict_set, is_subpath
 from .operator import (
@@ -253,13 +254,14 @@ class Set(InstanceOperator):
     """
 
     fields: Dict[str, object]
-    use_query: bool = DeprecatedField(
-        metadata={
-            "deprecation_msg": "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. "
-            "Please remove this field from your code."
-        }
-    )
+    use_query: Optional[bool] = None
     use_deepcopy: bool = False
+
+    def verify(self):
+        super().verify()
+        if self.use_query is not None:
+            depr_message = "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. Please remove this field from your code."
+            warnings.warn(depr_message, DeprecationWarning, stacklevel=2)
 
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
@@ -341,18 +343,16 @@ class InstanceFieldOperator(InstanceOperator):
     field: Optional[str] = None
     to_field: Optional[str] = None
     field_to_field: Optional[Union[List[List[str]], Dict[str, str]]] = None
-    use_query: bool = DeprecatedField(
-        metadata={
-            "deprecation_msg": "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. "
-            "Please remove this field from your code."
-        }
-    )
+    use_query: Optional[bool] = None
     process_every_value: bool = False
     get_default: Any = None
     not_exist_ok: bool = False
 
     def verify(self):
         super().verify()
+        if self.use_query is not None:
+            depr_message = "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. Please remove this field from your code."
+            warnings.warn(depr_message, DeprecationWarning, stacklevel=2)
 
         assert (
             self.field is not None or self.field_to_field is not None
@@ -851,12 +851,13 @@ class ListFieldValues(InstanceOperator):
 
     fields: List[str]
     to_field: str
-    use_query: bool = DeprecatedField(
-        metadata={
-            "deprecation_msg": "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. "
-            "Please remove this field from your code."
-        }
-    )
+    use_query: Optional[bool] = None
+
+    def verify(self):
+        super().verify()
+        if self.use_query is not None:
+            depr_message = "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. Please remove this field from your code."
+            warnings.warn(depr_message, DeprecationWarning, stacklevel=2)
 
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
@@ -883,12 +884,13 @@ class ZipFieldValues(InstanceOperator):
     fields: List[str]
     to_field: str
     longest: bool = False
-    use_query: bool = DeprecatedField(
-        metadata={
-            "deprecation_msg": "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. "
-            "Please remove this field from your code."
-        }
-    )
+    use_query: Optional[bool] = None
+
+    def verify(self):
+        super().verify()
+        if self.use_query is not None:
+            depr_message = "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. Please remove this field from your code."
+            warnings.warn(depr_message, DeprecationWarning, stacklevel=2)
 
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
@@ -955,12 +957,13 @@ class IndexOf(InstanceOperator):
     search_in: str
     index_of: str
     to_field: str
-    use_query: bool = DeprecatedField(
-        metadata={
-            "deprecation_msg": "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. "
-            "Please remove this field from your code."
-        }
-    )
+    use_query: Optional[bool] = None
+
+    def verify(self):
+        super().verify()
+        if self.use_query is not None:
+            depr_message = "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. Please remove this field from your code."
+            warnings.warn(depr_message, DeprecationWarning, stacklevel=2)
 
     def process(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None
@@ -977,12 +980,13 @@ class TakeByField(InstanceOperator):
     field: str
     index: str
     to_field: str = None
-    use_query: bool = DeprecatedField(
-        metadata={
-            "deprecation_msg": "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. "
-            "Please remove this field from your code."
-        }
-    )
+    use_query: Optional[bool] = None
+
+    def verify(self):
+        super().verify()
+        if self.use_query is not None:
+            depr_message = "Field 'use_query' is deprecated. From now on, default behavior is compatible to use_query=True. Please remove this field from your code."
+            warnings.warn(depr_message, DeprecationWarning, stacklevel=2)
 
     def prepare(self):
         if self.to_field is None:

--- a/src/unitxt/task.py
+++ b/src/unitxt/task.py
@@ -1,8 +1,8 @@
+import warnings
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Union
 
 from .artifact import fetch_artifact
-from .dataclass import DeprecatedField
 from .deprecation_utils import deprecation
 from .error_utils import Documentation, UnitxtError, UnitxtWarning
 from .operator import InstanceOperator
@@ -57,18 +57,8 @@ class Task(InstanceOperator):
 
     input_fields: Optional[Union[Dict[str, Type], Dict[str, str], List[str]]] = None
     reference_fields: Optional[Union[Dict[str, Type], Dict[str, str], List[str]]] = None
-    inputs: Union[Dict[str, Type], Dict[str, str], List[str]] = DeprecatedField(
-        default=None,
-        metadata={
-            "deprecation_msg": "The 'inputs' field is deprecated. Please use 'input_fields' instead."
-        },
-    )
-    outputs: Union[Dict[str, Type], Dict[str, str], List[str]] = DeprecatedField(
-        default=None,
-        metadata={
-            "deprecation_msg": "The 'outputs' field is deprecated. Please use 'reference_fields' instead."
-        },
-    )
+    inputs: Optional[Union[Dict[str, Type], Dict[str, str], List[str]]] = None
+    outputs: Optional[Union[Dict[str, Type], Dict[str, str], List[str]]] = None
     metrics: List[str]
     prediction_type: Optional[Union[Type, str]] = None
     augmentable_inputs: List[str] = []
@@ -108,6 +98,16 @@ class Task(InstanceOperator):
             )
 
     def verify(self):
+        if hasattr(self, "inputs") and self.inputs is not None:
+            depr_message = (
+                "The 'inputs' field is deprecated. Please use 'input_fields' instead."
+            )
+            warnings.warn(depr_message, DeprecationWarning, stacklevel=2)
+
+        if hasattr(self, "outputs") and self.outputs is not None:
+            depr_message = "The 'outputs' field is deprecated. Please use 'reference_fields' instead."
+            warnings.warn(depr_message, DeprecationWarning, stacklevel=2)
+
         if self.input_fields is None:
             raise UnitxtError(
                 "Missing attribute in task: 'input_fields' not set.",


### PR DESCRIPTION
Currently in branch `main`, the last `assert` in` test_operators.test_rename`  passes also when `, use_query=True` is removed.