### PR TITLE
Support enumeration answer format in multiple choice template

### DIFF
--- a/src/unitxt/templates.py
+++ b/src/unitxt/templates.py
@@ -455,6 +455,7 @@ class MultipleChoiceTemplate(Template):
     target_prefix: str = ""
     choices_field: str = "choices"
     target_field: str = "label"
+    target_matching_mode: str = "choice_text"
     choices_separator: str = ", "
     source_choice_format: str = "{choice_numeral}. {choice_text}"
     target_choice_format: str = "{choice_numeral}"
@@ -554,7 +555,10 @@ class MultipleChoiceTemplate(Template):
 
         if not isinstance(target, int):
             try:
-                target = reference_fields[self.choices_field].index(target)
+                if self.target_matching_mode == "enumeration":
+                    target = self.enumerator.index(target)
+                else:
+                    target = reference_fields[self.choices_field].index(target)
             except ValueError as e:
                 raise UnitxtError(
                     f"MultipleChoiceTemplate could not locate textual target '{target}' in choices list: {reference_fields[self.choices_field]}",

--- a/tests/library/test_templates.py
+++ b/tests/library/test_templates.py
@@ -993,30 +993,41 @@ class TestTemplates(UnitxtTestCase):
 
     def test_multiple_choice_template_with_enumeration_target_mode(self):
         template = MultipleChoiceTemplate(
-            input_format="Text: {text}, Choices: {choices}.", enumerator="capitals", target_matching_mode="enumeration"
+            input_format="Text: {text}, Choices: {choices}.",
+            enumerator="capitals",
+            target_matching_mode="enumeration",
         )
 
         choices = ["Marry", "Bob", "Sam", "Alfred"]
         inputs = [
             {
-                "input_fields": {"choices": choices, "text": "Which name is the longest?"},
+                "input_fields": {
+                    "choices": choices,
+                    "text": "Which name is the longest?",
+                },
                 "reference_fields": {"choices": choices, "label": "D"},
             },
             {
-                "input_fields": {"choices": choices, "text": "Sam is older than Bob and Alfred, Marry is the older than Sam, who is the oldest?"},
+                "input_fields": {
+                    "choices": choices,
+                    "text": "Sam is older than Bob and Alfred, Marry is the older than Sam, who is the oldest?",
+                },
                 "reference_fields": {"choices": choices, "label": "A"},
-            }
+            },
         ]
 
         targets = [
             {
-                "input_fields": {"choices": choices, "text": "Which name is the longest?"},
+                "input_fields": {
+                    "choices": choices,
+                    "text": "Which name is the longest?",
+                },
                 "reference_fields": {
                     "choices": choices,
                     "label": "D",
                     "options": ["A", "B", "C", "D"],
                 },
-                "source": f"Text: Which name is the longest?, Choices: A. Marry, B. Bob, C. Sam, D. Alfred.",
+                "source": "Text: Which name is the longest?, Choices: A. Marry, B. Bob, C. Sam, D. Alfred.",
                 "target": "D",
                 "references": ["D"],
                 "instruction": "",
@@ -1024,23 +1035,25 @@ class TestTemplates(UnitxtTestCase):
                 "postprocessors": ["processors.to_string_stripped"],
             },
             {
-                "input_fields": {"choices": choices, "text": "Sam is older than Bob and Alfred, Marry is the older than Sam, who is the oldest?"},
+                "input_fields": {
+                    "choices": choices,
+                    "text": "Sam is older than Bob and Alfred, Marry is the older than Sam, who is the oldest?",
+                },
                 "reference_fields": {
                     "choices": choices,
                     "label": "A",
                     "options": ["A", "B", "C", "D"],
                 },
-                "source": f"Text: Sam is older than Bob and Alfred, Marry is the older than Sam, who is the oldest?, Choices: A. Marry, B. Bob, C. Sam, D. Alfred.",
+                "source": "Text: Sam is older than Bob and Alfred, Marry is the older than Sam, who is the oldest?, Choices: A. Marry, B. Bob, C. Sam, D. Alfred.",
                 "target": "A",
                 "references": ["A"],
                 "instruction": "",
                 "target_prefix": "",
                 "postprocessors": ["processors.to_string_stripped"],
-            }
+            },
         ]
 
         check_operator(template, inputs, targets, tester=self)
-
 
     def test_key_val_template_simple(self):
         template = KeyValTemplate()

--- a/tests/library/test_templates.py
+++ b/tests/library/test_templates.py
@@ -991,6 +991,57 @@ class TestTemplates(UnitxtTestCase):
             str(ve.exception),
         )
 
+    def test_multiple_choice_template_with_enumeration_target_mode(self):
+        template = MultipleChoiceTemplate(
+            input_format="Text: {text}, Choices: {choices}.", enumerator="capitals", target_matching_mode="enumeration"
+        )
+
+        choices = ["Marry", "Bob", "Sam", "Alfred"]
+        inputs = [
+            {
+                "input_fields": {"choices": choices, "text": "Which name is the longest?"},
+                "reference_fields": {"choices": choices, "label": "D"},
+            },
+            {
+                "input_fields": {"choices": choices, "text": "Sam is older than Bob and Alfred, Marry is the older than Sam, who is the oldest?"},
+                "reference_fields": {"choices": choices, "label": "A"},
+            }
+        ]
+
+        targets = [
+            {
+                "input_fields": {"choices": choices, "text": "Which name is the longest?"},
+                "reference_fields": {
+                    "choices": choices,
+                    "label": "D",
+                    "options": ["A", "B", "C", "D"],
+                },
+                "source": f"Text: Which name is the longest?, Choices: A. Marry, B. Bob, C. Sam, D. Alfred.",
+                "target": "D",
+                "references": ["D"],
+                "instruction": "",
+                "target_prefix": "",
+                "postprocessors": ["processors.to_string_stripped"],
+            },
+            {
+                "input_fields": {"choices": choices, "text": "Sam is older than Bob and Alfred, Marry is the older than Sam, who is the oldest?"},
+                "reference_fields": {
+                    "choices": choices,
+                    "label": "A",
+                    "options": ["A", "B", "C", "D"],
+                },
+                "source": f"Text: Sam is older than Bob and Alfred, Marry is the older than Sam, who is the oldest?, Choices: A. Marry, B. Bob, C. Sam, D. Alfred.",
+                "target": "A",
+                "references": ["A"],
+                "instruction": "",
+                "target_prefix": "",
+                "postprocessors": ["processors.to_string_stripped"],
+            }
+        ]
+
+        check_operator(template, inputs, targets, tester=self)
+
+
     def test_key_val_template_simple(self):
         template = KeyValTemplate()
 


### PR DESCRIPTION
The current Multiple Choice Template supports 2 answer formats:
1. The full answer, which was converted to the index
2. The answer index, which must be passed as an int

This PR adds the ability to also provide the enumeration representation the answer, e.g. for 

> Which name is the longest?, Choices: A. Marry, B. Bob, C. Sam, D. Alfred.

Users can specify "D" as the correct answer

The default behavior is kept