### PR TITLE
Support dataset field in nested JSON files

### DIFF
--- a/src/unitxt/loaders.py
+++ b/src/unitxt/loaders.py
@@ -488,6 +488,7 @@ class LoadFromIBMCloud(Loader):
         bucket_name: Name of the S3 bucket from which to load data.
         data_dir: Optional directory path within the bucket.
         data_files: Union type allowing either a list of file names or a mapping of splits to file names.
+        data_field: The dataset key for nested JSON file, i.e. when multiple datasets are nested in the same file
         caching: Bool indicating if caching is enabled to avoid re-downloading data.
 
     Example:
@@ -511,6 +512,7 @@ class LoadFromIBMCloud(Loader):
     data_dir: str = None
 
     data_files: Union[Sequence[str], Mapping[str, Union[str, Sequence[str]]]]
+    data_field: str = None
     caching: bool = True
     data_classification_policy = ["proprietary"]
 
@@ -636,10 +638,13 @@ class LoadFromIBMCloud(Loader):
                     )
 
         if isinstance(self.data_files, list):
-            dataset = hf_load_dataset(local_dir, streaming=False)
+            dataset = hf_load_dataset(local_dir, streaming=False, field=self.data_field)
         else:
             dataset = hf_load_dataset(
-                local_dir, streaming=False, data_files=self.data_files
+                local_dir,
+                streaming=False,
+                data_files=self.data_files,
+                field=self.data_field,
             )
 
         return MultiStream.from_iterables(dataset)


### PR DESCRIPTION
Nested JSON dataset is a scenario where multiple datasets are written in a single JSON file, e.g.
```
{
    "dataset1": [
        {
            "question": "q1",
            "answer": "B",
            "choices": ["A", "B", "C", "D"],
        },
        {
            "question": "q2",
            "answer": "D",
            "choices": ["A", "B", "C", "D"],
        }
    ],
    "dataset2": [
        {
            "question": "q1",
            "answer": "B",
            "choices": ["A", "B", "C", "D"],
        },
        {
            "question": "q2",
            "answer": "C",
            "choices": ["A", "B", "C", "D"],
        }
    ]
}
```
HF datasets supports loading datasets in such scenario by using the `field` arg in the loading method, see example in: https://huggingface.co/docs/datasets/v1.11.0/loading_datasets.html#json-files
The `field` argument propagates to the `JsonConfig` data class.

This PR adds the ability to load nested JSON datasets when using the `load_from_ibm_cloud` loader, by adding another argument, usage example:

>   "loader": {
>     "__type__": "load_from_ibm_cloud",
>     "endpoint_url_env": "FMEVAL_COS_URL",
>     "aws_access_key_id_env": "FMEVAL_COS_ACCESS_KEY_ID",
>     "aws_secret_access_key_env": "FMEVAL_COS_SECRET_ACCESS_KEY",
>     "bucket_name": "fm-validation-staging-models-and-datasets",
>     "data_dir": "<The data dir on COS>",
>     "data_field": "<The nested dataset name>",
>     "data_files": [
>       "test.json",
>       "train.json"
>     ]
>   },