### PR TITLE
Fix using OpenAiInferenceEngine for LLMAsJudge

### DIFF
--- a/src/unitxt/llm_as_judge.py
+++ b/src/unitxt/llm_as_judge.py
@@ -144,13 +144,13 @@ class LLMAsJudge(BulkInstanceMetric):
             )
 
         if isinstance(self.inference_model, OpenAiInferenceEngine):
-            if self.format:
+            if self.format and type(self.format) is not SystemFormat:
                 raise ValueError(
                     "Error in 'LLMAsJudge' metric. Inference model 'OpenAiInferenceEngine' does "
                     "not support formatting. Please remove the format definition from the recipe"
                     " (OpenAi Chat API take care of the formatting automatically)."
                 )
-            if self.system_prompt:
+            if self.system_prompt and type(self.system_prompt) is not EmptySystemPrompt:
                 raise ValueError(
                     "Error in 'LLMAsJudge' metric. Inference model 'OpenAiInferenceEngine' does "
                     "not support system prompt. Please remove the system_prompt definition from the recipe"


### PR DESCRIPTION
Currently, `OpenAiInferenceEngine` cannot be used for `LLMAsJudge` because `self.format` and `self.system_prompt` are never `None`, so we always get `ValueError: Error in 'LLMAsJudge' metric. Inference model 'OpenAiInferenceEngine' does not support formatting. Please remove the format definition from the recipe (OpenAi Chat API take care of the formatting automatically).`

Instead, check if `self.format` and `self.system_prompt` are the default values.