### PR TITLE
Scarebleu metric: remove mecab_ko and mecab_ko_dic from metric requir…

### DIFF
--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -4565,8 +4565,7 @@ class NormalizedSacrebleu(HuggingfaceMetric):
     scaled_fields = ["sacrebleu", "precisions"]
     hf_additional_input_fields_pass_one_value = ["tokenize"]
     _requirements_list = {
-        "mecab_ko": KO_ERROR_MESSAGE,
-        "mecab_ko_dic": KO_ERROR_MESSAGE,
+        "sacrebleu": "Additional dependencies required. To install them, run: `pip install sacrebleu`."
     }
 
 


### PR DESCRIPTION
…ement list

The pakcages relevent only to Koren or Japanees. In case of need, HF metric will raise the exception. From the other side, sacrebleu itslef wasn't part fo the requirement list