### PR TITLE
Add generic inference engine to allow dynamic selection by the user

### DIFF
--- a/examples/run_generic_inference_engine.py
+++ b/examples/run_generic_inference_engine.py
@@ -1,0 +1,20 @@
+from unitxt import get_logger, produce
+from unitxt.inference import GenericInferenceEngine
+
+if __name__ == "__main__":
+    generic_engine = GenericInferenceEngine(
+        default="engines.ibm_gen_ai.llama_3_8b_instruct"
+    )
+    recipe = "card=cards.almost_evil,template=templates.qa.open.simple,demos_pool_size=0,num_demos=0"
+    instances = [
+        {"question": "How many days there are in a week", "answers": ["7"]},
+        {
+            "question": "If a ate an apple in the morning, and one in the evening, how many apples did I eat?",
+            "answers": ["2"],
+        },
+    ]
+    dataset = produce(instances, recipe)
+
+    predictions = generic_engine.infer(dataset)
+
+    get_logger().info(predictions)

--- a/prepare/engines/ibm_genai/llama3.py
+++ b/prepare/engines/ibm_genai/llama3.py
@@ -1,0 +1,11 @@
+from unitxt.catalog import add_to_catalog
+from unitxt.inference import IbmGenAiInferenceEngine
+
+model_list = ["meta-llama/llama-3-8b-instruct", "meta-llama/llama-3-70b-instruct"]
+
+for model in model_list:
+    model_label = model.split("/")[1].replace("-", "_").replace(".", ",").lower()
+    inference_model = IbmGenAiInferenceEngine(
+        model_name=model, max_new_tokens=2048, random_seed=42
+    )
+    add_to_catalog(inference_model, f"engines.ibm_gen_ai.{model_label}", overwrite=True)

--- a/prepare/engines/ollama/llama2.py
+++ b/prepare/engines/ollama/llama2.py
@@ -1,0 +1,5 @@
+from unitxt.catalog import add_to_catalog
+from unitxt.inference import OllamaInferenceEngine
+
+inference_model = OllamaInferenceEngine(model_name="llama2")
+add_to_catalog(inference_model, "engines.ollama.llama2", overwrite=True)

--- a/src/unitxt/catalog/engine/generic.json
+++ b/src/unitxt/catalog/engine/generic.json
@@ -1,0 +1,6 @@
+{
+    "__type__": "generic_inference_engine",
+    "kwargs": {
+        "model_name": "meta-llama/llama-3-70b-instruct"
+    }
+}

--- a/src/unitxt/catalog/engine/generic.json
+++ b/src/unitxt/catalog/engine/generic.json
@@ -1,6 +1,0 @@
-{
-    "__type__": "generic_inference_engine",
-    "kwargs": {
-        "model_name": "meta-llama/llama-3-70b-instruct"
-    }
-}

--- a/src/unitxt/catalog/engines/ibm_gen_ai/llama_3_70b_instruct.json
+++ b/src/unitxt/catalog/engines/ibm_gen_ai/llama_3_70b_instruct.json
@@ -1,0 +1,6 @@
+{
+    "__type__": "ibm_gen_ai_inference_engine",
+    "model_name": "meta-llama/llama-3-70b-instruct",
+    "max_new_tokens": 2048,
+    "random_seed": 42
+}

--- a/src/unitxt/catalog/engines/ibm_gen_ai/llama_3_8b_instruct.json
+++ b/src/unitxt/catalog/engines/ibm_gen_ai/llama_3_8b_instruct.json
@@ -1,0 +1,6 @@
+{
+    "__type__": "ibm_gen_ai_inference_engine",
+    "model_name": "meta-llama/llama-3-8b-instruct",
+    "max_new_tokens": 2048,
+    "random_seed": 42
+}

--- a/src/unitxt/catalog/engines/ollama/llama2.json
+++ b/src/unitxt/catalog/engines/ollama/llama2.json
@@ -1,0 +1,4 @@
+{
+    "__type__": "ollama_inference_engine",
+    "model_name": "llama2"
+}


### PR DESCRIPTION
The generic inference engine enables users to set the actual inference engine dynamically via the inference_engine environment variable. Additionally, the class includes a default parameter, which specifies the inference engine to use if the environment variable is not set.

For example, when the inference_engine variable is not set, the engine will
 default to ibm_gen_ai.llama_3_8b_instruct. However, if
inference_engine=ollama.llama2 is set, it will switch to the Ollama model.

This update allows lm-eval users to run the UniTXT dataset with LLMaaJ using any supported inference engine.