### PR TITLE
Fix duplicate column deletion bug in pandas serializer

### DIFF
--- a/src/unitxt/struct_data_operators.py
+++ b/src/unitxt/struct_data_operators.py
@@ -207,6 +207,12 @@ class SerializeTableAsDFLoader(SerializeTable):
 
         assert header and rows, "Incorrect input table format"
 
+        # Fix duplicate columns, ensuring the first occurrence has no suffix
+        header = [
+            f"{col}_{header[:i].count(col)}" if header[:i].count(col) > 0 else col
+            for i, col in enumerate(header)
+        ]
+
         # Create a pandas DataFrame
         df = pd.DataFrame(rows, columns=header)
 


### PR DESCRIPTION
If column appear twice it just delete it, now it will give it a suffix _1, _2 etc