### PR TITLE
fixed scigen post-processor

### DIFF
--- a/prepare/cards/scigen.py
+++ b/prepare/cards/scigen.py
@@ -27,7 +27,9 @@ card = TaskCard(
         ),
     ],
     task="tasks.generation.from_pair[metrics=[metrics.llm_as_judge.rating.llama_3_70b_instruct_ibm_genai_template_table2text_single_turn_with_reference]]",
-    templates="templates.generation.from_pair.all",
+    templates=[
+        "templates.generation.from_pair.default[postprocessors=[processors.lower_case]]"
+    ],
     __description__="SciGen is a dataset for the task of reasoning-aware data-to-text generation. It consists of tables from scientific articles(mostly containing numerical values) and their corresponding text descriptions.",
     __tags__={
         "modality": "table",

--- a/src/unitxt/catalog/cards/scigen.json
+++ b/src/unitxt/catalog/cards/scigen.json
@@ -40,7 +40,9 @@
         }
     ],
     "task": "tasks.generation.from_pair[metrics=[metrics.llm_as_judge.rating.llama_3_70b_instruct_ibm_genai_template_table2text_single_turn_with_reference]]",
-    "templates": "templates.generation.from_pair.all",
+    "templates": [
+        "templates.generation.from_pair.default[postprocessors=[processors.lower_case]]"
+    ],
     "__description__": "SciGen is a dataset for the task of reasoning-aware data-to-text generation. It consists of tables from scientific articles(mostly containing numerical values) and their corresponding text descriptions.",
     "__tags__": {
         "modality": "table",


### PR DESCRIPTION
There was an issue with post-processor for Scigen. Previously used template "templates.generation.from_pair.all" had a post-processor "processors.take_first_non_empty_line" which was ignoring all but first line from the generated text. This is not intended behaviour. Hence modified the template input in task-card to override post-processor from task-card itself.