### PR TITLE
Allow role names to be captialized in SerializeOpenAiFormatDialog

### DIFF
--- a/src/unitxt/dialog_operators.py
+++ b/src/unitxt/dialog_operators.py
@@ -157,13 +157,13 @@ class SerializeOpenAiFormatDialog(SerializeDialog):
                     f"Entry {i} has a non-string 'content': {entry['content']}. The 'content' value must be a string."
                 )
 
-            if entry["role"] not in {"user", "assistant"}:
+            if entry["role"].lower() not in {"user", "assistant"}:
                 raise ValueError(
                     f"Entry {i} has an invalid role: {entry['role']}. Allowed roles are 'user' and 'assistant'."
                 )
 
         first_entry = dialog[0]
-        if first_entry["role"] != "user":
+        if first_entry["role"].lower() != "user":
             raise ValueError(
                 f"First entry role is expected to be 'user' It is  {first_entry['role']}."
             )


### PR DESCRIPTION
Right now the only "user" and "assistant" roles are allowed.  We want to make it case insensitive for it to be flexible in input format.