### PR TITLE
Fix missing deep copy in MapInstanceValues

### DIFF
--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -207,8 +207,10 @@ class MapInstanceValues(InstanceOperator):
 
     def get_mapped_value(self, instance, key, mapper, val):
         val_as_str = str(val)  # make sure the value is a string
-        if val_as_str in mapper:
-            return mapper[val_as_str]
+        if (
+            val_as_str in mapper
+        ):  # must deep copy value to avoide external modification to the mapped value (e.g. if it is a list)
+            return copy.deepcopy(mapper[val_as_str])
         if self.strict:
             raise KeyError(
                 f"value '{val}' in instance '{instance}' is not found in mapper '{mapper}', associated with field '{key}'."

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -136,8 +136,8 @@ class MapInstanceValues(InstanceOperator):
     it maps values of instances in a stream using predefined mappers.
 
     Attributes:
-        mappers (Dict[str, Dict[str, str]]): The mappers to use for mapping instance values.
-            Keys are the names of the fields to be mapped, and values are dictionaries
+        mappers (Dict[str, Dict[str, Any]]): The mappers to use for mapping instance values.
+            Keys are the names of the fields to undergo mapping, and values are dictionaries
             that define the mapping from old values to new values.
         strict (bool): If True, the mapping is applied strictly. That means if a value
             does not exist in the mapper, it will raise a KeyError. If False, values

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -209,7 +209,7 @@ class MapInstanceValues(InstanceOperator):
         val_as_str = str(val)  # make sure the value is a string
         if (
             val_as_str in mapper
-        ):  # must deep copy value to avoide external modification to the mapped value (e.g. if it is a list)
+        ):  # must deep copy value to avoid external modification to the mapped value (e.g. if it is a list)
             return copy.deepcopy(mapper[val_as_str])
         if self.strict:
             raise KeyError(

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -168,6 +168,41 @@ class TestOperators(UnitxtTestCase):
             targets=targets,
         )
 
+    def test_map_instance_values_with_non_str_returned_value(self):
+        inputs = [
+            {"a": 1, "b": 2},
+            {"a": 2, "b": 3},
+        ]
+
+        targets = [
+            {"a": {"word": 4, "words": [5, 6, 7]}, "b": 2},
+            {"a": ["bye", "ciao", [0, 1, 2]], "b": 3},
+        ]
+
+        operator = MapInstanceValues(
+            mappers={
+                "a": {
+                    "1": {"word": 4, "words": [5, 6, 7]},
+                    "2": ["bye", "ciao", [0, 1, 2]],
+                }
+            }
+        )
+        outputs = check_operator(
+            operator=operator,
+            inputs=inputs,
+            targets=targets,
+        )
+
+        # tweak the returned values in outputs:
+        outputs[0]["a"]["words"][0] = 5000
+        outputs[1]["a"][2] = []
+        # and run operator again, to verify that its mapper have not changed
+        check_operator(
+            operator=operator,
+            inputs=inputs,
+            targets=targets,
+        )
+
     def test_from_iterables_and_iterable_source(self):
         input_ms = {
             "train": [{"a": "1"}, {"b": "2"}, {"a": "3"}],


### PR DESCRIPTION
If the value we map to is a list, we must deepcopy the value, otherwise external  changes to the list effect the value of the mapper .