### PR TITLE
Ignore unitxt-venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+unitxt-venv/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,6 @@ To run all the tests:
 ```bash
 python -m unittest
 ```
-Bef
 
 # Repo principles:
 


### PR DESCRIPTION
The [CONTRIBUTING.md](https://github.com/IBM/unitxt/blob/main/CONTRIBUTING.md) tells us to create `unitxt-venv` but it's not included in `.gitignore`.

I also removed a typo.