### PR TITLE
Instruction in SystemFormet demo support.

### DIFF
--- a/src/unitxt/formats.py
+++ b/src/unitxt/formats.py
@@ -131,7 +131,7 @@ class SystemFormat(BaseFormat):
 
     """
 
-    demo_format: str = "{instruction}\\N{source}\\N{target_prefix}{target}\n\n"  #  example: "User: {source}\nAgent: {target}\n\n"
+    demo_format: str = "{source}\\N{target_prefix}{target}\n\n"  #  example: "User: {source}\nAgent: {target}\n\n"
     model_input_format: str = (
         "{system_prompt}\\N{instruction}\\N{demos}{source}\\N{target_prefix}"
     )

--- a/src/unitxt/formats.py
+++ b/src/unitxt/formats.py
@@ -131,7 +131,7 @@ class SystemFormat(BaseFormat):
 
     """
 
-    demo_format: str = "{source}\\N{target_prefix}{target}\n\n"  #  example: "User: {source}\nAgent: {target}\n\n"
+    demo_format: str = "{instruction}\\N{source}\\N{target_prefix}{target}\n\n"  #  example: "User: {source}\nAgent: {target}\n\n"
     model_input_format: str = (
         "{system_prompt}\\N{instruction}\\N{demos}{source}\\N{target_prefix}"
     )
@@ -182,6 +182,7 @@ class SystemFormat(BaseFormat):
                 target_prefix=demo_target_prefix,
                 source=demo_source,
                 target=demo_target,
+                instruction=instruction,
                 **self.format_args,
             )
             demos_string += demo_str


### PR DESCRIPTION
In this PR, I'm introducing the ability to add instructions to the demo section in SystemFormat class. 

This can sometimes be useful when working with prompts that follow the multi-turn convention:
```
<|start_of_role|>user<|end_of_role|>{{Instruction}}
{{ICL_Q1}}
<|end_of_text|>
<|start_of_role|>assistant<|end_of_role|>{{ICL_A1}}
<|end_of_text|>
<|start_of_role|>user<|end_of_role|>{{Instruction}}
{{ICL_Q2}}
<|end_of_text|>
<|start_of_role|>assistant<|end_of_role|>{{ICL_A2}}
<|end_of_text|>
<|start_of_role|>user<|end_of_role|>{{Instruction}}
{{ICL_Q3}}
<|end_of_text|>
<|start_of_role|>assistant<|end_of_role|>{{ICL_A3}}
<|end_of_text|>
<|start_of_role|>assistant<|end_of_role|>
```
 especially when using templates that separate instructions from the input format.