### PR TITLE
Add OptionSelectingByLogProbsInferenceEngine

### DIFF
--- a/src/unitxt/inference.py
+++ b/src/unitxt/inference.py
@@ -8,7 +8,7 @@ import uuid
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from datasets import DatasetDict
-from tqdm import tqdm
+from tqdm import tqdm, trange
 
 from .artifact import Artifact, fetch_artifact
 from .dataclass import InternalField, NonPositionalField
@@ -383,16 +383,95 @@ class OllamaInferenceEngine(InferenceEngine, PackageRequirementsMixin):
         return [element["message"]["content"] for element in result]
 
 
+class OptionSelectingByLogProbsInferenceEngine():
+    """OptionSelectingByLogProbsInferenceEngine inference engine is used to select an option based on the logprobs of an options list conditioned by a prompt.
+    The inference engines that inherit from this class must implement `get_token_count` and `get_options_log_probs`
+    """
+    @abc.abstractmethod
+    def get_token_count(self, dataset):
+        """Get the token count of the source key of each dict of the dataset.
+        Add to each instance in the data a "token_count" field.
+        Args:
+            dataset (List[Dict[str, Any]]): A list of dictionaries, each representing a data instance.
+
+        Returns:
+            List[int]: The token count of the texts
+        """
+
+    @abc.abstractmethod
+    def get_options_log_probs(self, dataset):
+        """Get the token logprobs of the options of the key task_data.options of each dict of the dataset.
+
+        Add to each instance in the data a "options_log_prob" field, which is a dict with str as key and a list of {text: str, logprob:float}.
+
+        Args:
+            dataset (List[Dict[str, Any]]): A list of dictionaries, each representing a data instance.
+
+        Returns:
+            List[int]: The token count of the texts
+        """
+
+    def select(self, dataset: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+
+        """ Calculate most likely labels based on log probabilities for a set of fixed completions """
+        dataset_with_token_counts = self.get_token_count(dataset)
+        token_counts = [d['token_count'] for d in dataset_with_token_counts]
+        
+        # pass in the token count so we only return the option score
+        dataset_with_options = [{
+            'source': instance['source'] + option, 
+            'task_data': {'token_count': token_count}
+        } for instance, token_count in zip(dataset, token_counts) for option in instance['task_data']['options']]
+        
+        dataset_with_options_logprobs: list[list[dict[str, float | str]]] = self.get_options_log_probs(dataset_with_options)
+
+        dataset_iterator = iter(dataset_with_options_logprobs)
+        
+        for instance in dataset:
+            tokens_with_logprob_list = []
+            # get the input tokens for the completions of the current resp_idx
+            for _ in instance["task_data"]["options"]:
+                tokens_with_logprob = next(dataset_iterator)['prediction']
+                tokens_with_logprob_list.append(tokens_with_logprob)
+            # we start comparing all the options, e.g. if there are five options the value will be [0,1,2,3,4]
+            to_compare_indexes = list(range(len(instance['task_data']['options'])))
+            # token_with_logprob_comp is the logprobs and the text of the tokens
+            # for each of the options at a specific index
+            for token_with_logprob_comp in zip(*tokens_with_logprob_list):
+                tokens_comp = [t['text'] for t in token_with_logprob_comp]
+                logprobs_comp = [t['logprob'] for t in token_with_logprob_comp]
+                # Find the maximum value by comparing the logprob of the nth token of non-discarded options
+                index_max = max(((val, idx) for idx, val in enumerate(logprobs_comp) if idx in to_compare_indexes), key=lambda x: x[0])[1]
+                # get the token of the biggest logprob
+                token_value_with_max_logprob = tokens_comp[index_max]
+                # check that the token is not repeated in the non-discarded options
+                count = tokens_comp.count(token_value_with_max_logprob)
+                if count > 1:
+                    # multiple tokens with same max logprob, we need to continue iterating
+                    to_compare_indexes = [index for index, token_value in enumerate(tokens_comp) if token_value == token_value_with_max_logprob]
+                    continue
+                # we got the index of the maximum log_prob that doesn't have a duplicated token value at other index
+                break
+
+            if len(to_compare_indexes) > 1:
+                # multiple options are either equal or have the same token values prefix
+                # choose the first
+                index_max = to_compare_indexes[0]
+
+            instance['prediction'] = instance["task_data"]["options"][index_max]
+        return dataset
+    
 class IbmGenAiInferenceEngine(
     InferenceEngine,
     IbmGenAiInferenceEngineParamsMixin,
     PackageRequirementsMixin,
     LogProbInferenceEngine,
+    OptionSelectingByLogProbsInferenceEngine,
 ):
     label: str = "ibm_genai"
     model_name: str
     _requirements_list = {
-        "genai": "Install ibm-genai package using 'pip install --upgrade ibm-generative-ai"
+        "ibm-generative-ai": "Install ibm-genai package using 'pip install --upgrade ibm-generative-ai"
     }
     data_classification_policy = ["public", "proprietary"]
     parameters: Optional[IbmGenAiInferenceEngineParams] = None
@@ -498,6 +577,47 @@ class IbmGenAiInferenceEngine(
             )
         return predict_result
 
+    def get_token_count(self, dataset):
+        texts = [instance['source'] for instance in dataset]
+        token_counts = list(tqdm([result.token_count for response in self.client.text.tokenization.create(
+                model_id=self.model_name,
+                input=texts,
+                execution_options={'ordered': True}) for result in response.results],
+            desc='Tokenizing',
+            total=len(texts)))
+        for i, token_count in enumerate(token_counts):
+            dataset[i]['token_count'] = token_count
+        return dataset
+
+    def get_options_log_probs(self, dataset):
+        """Add to each instance in the data a "options_log_prob" field, which is a dict with str as key and a list of {text: str, logprob:float}"""
+        from genai.schema import TextGenerationParameters, TextGenerationReturnOptions
+        
+        texts = [x['source'] for x in dataset]
+
+        responses = tqdm(
+            self.client.text.generation.create(
+                model_id=self.model_name,
+                inputs=texts,
+                execution_options={"ordered": True},
+                parameters=TextGenerationParameters(
+                    max_new_tokens = 1,
+                    return_options=TextGenerationReturnOptions(
+                        input_tokens=True,
+                        token_logprobs=True
+                    ),
+                    # random_seed=self.random_state
+                )),
+            total=len(texts),
+            desc="Completions"
+        )
+
+        scores = [[{'text': token.text, 'logprob': token.logprob} for token in response.results[0].input_tokens] for response in responses]
+
+
+        for instance, score in zip(dataset, scores):
+            instance['prediction'] = score[instance['task_data']['token_count']-1:]
+        return dataset
 
 class OpenAiInferenceEngineParamsMixin(Artifact):
     frequency_penalty: Optional[float] = None
@@ -807,6 +927,7 @@ class WMLInferenceEngine(
     WMLInferenceEngineParamsMixin,
     PackageRequirementsMixin,
     LogProbInferenceEngine,
+    OptionSelectingByLogProbsInferenceEngine,
 ):
     """Runs inference using ibm-watsonx-ai.
 
@@ -1013,6 +1134,56 @@ class WMLInferenceEngine(
             )
         return predict_result
 
+    def get_token_count(self, dataset):
+        from ibm_watsonx_ai.foundation_models import ModelInference
+
+        texts = [instance['source'] for instance in dataset]
+
+        model = ModelInference(
+            model_id=self.model_name,
+            deployment_id=self.deployment_id,
+            api_client=self._client,
+        )
+
+        for i in trange(len(texts), desc="Tokenizing"):
+            response = model.tokenize(prompt=texts[i], return_tokens=True)['result']
+            dataset[i]['token_count'] = response['token_count']
+
+        return dataset
+
+    def get_options_log_probs(self, dataset):
+        """Add to each instance in the data a "options_log_prob" field, which is a dict with str as key and a list of {text: str, logprob:float}"""
+        from ibm_watsonx_ai.foundation_models import ModelInference
+        model = ModelInference(
+            model_id=self.model_name,
+            deployment_id=self.deployment_id,
+            api_client=self._client,
+        )
+        
+        texts = [x['source'] for x in dataset]
+
+        responses = list(tqdm(
+            model.generate(
+                prompt=texts,
+                params={
+                    'decoding_method':'greedy',
+                    'max_new_tokens': 1, 
+                    'return_options': {
+                        'input_tokens': True,
+                        'token_logprobs': True
+                    },
+                }
+            ),
+            total=len(texts),
+            desc="Completions"
+        ))
+        import json
+
+        scores = [[{'text': token['text'], 'logprob': token['logprob'] if 'logprob' in token else 1} for token in response['results'][0]['input_tokens']] for response in responses]
+
+        for instance, score in zip(dataset, scores):
+            instance['prediction'] = score[instance['task_data']['token_count']-1:]
+        return dataset
 
 def get_images_without_text(instance):
     return extract_images(instance["source"], instance)


### PR DESCRIPTION
- Add `OptionSelectingByLogProbsInferenceEngine`, an inference engine that is used to select an option based on the logprobs of an options list conditioned by a prompt.
- Implement `OptionSelectingByLogProbsInferenceEngine` in `WMLInferenceEngine` and `IbmGenAiInferenceEngine` inference engines.
- Add a test under `inference.test_inference_engine.TestInferenceEngine.test_option_selecting_by_log_prob_inference_engines`.

Command to run the test:
```bash
export GENAI_KEY="" && WML_PROJECT_ID="" && export WML_APIKEY="" && export WML_URL="https://us-south.ml.cloud.ibm.com" && python -m unittest tests.inference.test_inference_engine.TestInferenceEngine.test_option_selecting_by_log_prob_inference_engines
```

This inference engine is intended to be used to integrate [EvalAssist](https://llm-judge.bx.cloud9.ibm.com/) evaluators.