### PR TITLE
Better separate HF from Unitxt in loading HF datasets, to gain a more comparable loading time for non-eager and eager execution

### DIFF
--- a/performance/card_profiler.py
+++ b/performance/card_profiler.py
@@ -75,7 +75,7 @@ class CardProfiler:
         ms = recipe.verbalization.process(ms)
         return recipe.finalize.process(ms)
 
-    def profiler_print_first_dicts(self, ms: MultiStream, card_name: str):
+    def profiler_list_all_streams(self, ms: MultiStream, card_name: str):
         logger.info(
             f"The multistream generated for card '{card_name}' has {len(ms)} streams of the following lengths:"
         )
@@ -89,7 +89,7 @@ class CardProfiler:
         ms = self.profiler_metadata_and_standardization(ms, recipe)
         ms = self.profiler_processing_demos_metadata(ms, recipe)
         ms = self.profiler_verbalize_and_finalize(ms, recipe)
-        self.profiler_print_first_dicts(ms, card_name)
+        self.profiler_list_all_streams(ms, card_name)
 
 
 def profile_from_cards():
@@ -159,16 +159,14 @@ def main():
         pst.strip_dirs()
         pst.sort_stats("name")  # sort by function name
         pst.print_stats(
-            "profiler_do_the_profiling|profiler_load_by_recipe|load_data|stream_dataset|load_dataset"
+            "profiler_do_the_profiling|profiler_load_by_recipe|load_data|stream_dataset|load_dataset|load_iterables"
         )
         s = f.getvalue()
         assert s.split("\n")[7].split()[3] == "cumtime"
         tot_time = find_cummtime_of("profiler_do_the_profiling", "card_profiler.py", s)
         load_time = find_cummtime_of("profiler_load_by_recipe", "card_profiler.py", s)
-        just_load_no_initial_ms_time = round(
-            find_cummtime_of("stream_dataset", "loaders.py", s)
-            + find_cummtime_of("load_dataset", "loaders.py", s),
-            3,
+        just_load_no_initial_ms_time = find_cummtime_of(
+            "load_iterables", "loaders.py", s
         )
         diff = round(tot_time - just_load_no_initial_ms_time, 3)
 

--- a/src/unitxt/loaders.py
+++ b/src/unitxt/loaders.py
@@ -461,12 +461,19 @@ class LoadFromIBMCloud(Loader):
 
     Args:
         endpoint_url_env: Environment variable name for the IBM Cloud endpoint URL.
+
         aws_access_key_id_env: Environment variable name for the AWS access key ID.
+
         aws_secret_access_key_env: Environment variable name for the AWS secret access key.
+
         bucket_name: Name of the S3 bucket from which to load data.
+
         data_dir: Optional directory path within the bucket.
+
         data_files: Union type allowing either a list of file names or a mapping of splits to file names.
+
         data_field: The dataset key for nested JSON file, i.e. when multiple datasets are nested in the same file
+
         caching: Bool indicating if caching is enabled to avoid re-downloading data.
 
     Example:

--- a/utils/.secrets.baseline
+++ b/utils/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "src/unitxt/loaders.py",
         "hashed_secret": "840268f77a57d5553add023cfa8a4d1535f49742",
         "is_verified": false,
-        "line_number": 493,
+        "line_number": 487,
         "is_secret": false
       }
     ],
@@ -184,5 +184,5 @@
       }
     ]
   },
-  "generated_at": "2024-12-09T15:45:50Z"
+  "generated_at": "2024-12-12T11:44:14Z"
 }


### PR DESCRIPTION
Currently, `Load Time` reported in the performance test summary is the cumulative time spent in `loader.load_data()` .  This is good for all types of loaders. 
However, still within `Loader.load_data()`, immediately following the download of the dataset (from HF, for example, in case of `LoadHF`), comes `MultiStream.from_iterables`, the first introduction of the downloaded data into unitxt's recipe. In this introduction, eager-execution differs in its action from non-eager-execution: 
In eager-mode, unitxt loops over **each and every instance**, to include it into the `ListStream`s constituting the  `MultiStream` being generated. Whereas in the non-eager mode, unitxt just creates generators, for the `GeneratorStream`s constituting the `MultiStream` generated in this case, and returns from `load_data()`.

Now, with `load_iterables` recently introduced into `loaders.py` by @elronbandel , we can clearly fetch net load time of datasets, excluding the introduction of each and every instance into unitxt that is only done in eager mode.

Here are demonstrating snakeviz-s:
I tweaked `card_prifler` to only go through load and list streams of the cards (skipping over all preprocessing steps, and verbalization, etc).
For eager mode, more time is spent in `Loader.load_data()` than in `LoaderHF.load_iterables`:
![image](https://github.com/user-attachments/assets/4823aa42-b355-4e73-96c1-8a63f5ee1b78)

in `stream.DynamicStream.__post_init__` we find the time spent in the above gap:
![image](https://github.com/user-attachments/assets/5f7085dc-0f42-4f6e-be8d-3dd77262271b)


Whereas for non-eager mode -- the same (the time to generate the generators is unnoticeable):
![image](https://github.com/user-attachments/assets/a9de5048-2d04-4f8e-a614-5e7e038f4882)

