### PR TITLE
add score name prefix for judge_raw_output/input in llmaj metric

### DIFF
--- a/src/unitxt/llm_as_judge.py
+++ b/src/unitxt/llm_as_judge.py
@@ -262,14 +262,14 @@ class LLMAsJudge(LLMAsJudgeBase):
 
                 result = {
                     self.main_score: model_a_preference_score,
-                    "judge_raw_output": instance["raw_prediction"],
-                    "judge_raw_input": instance["source"],
+                    f"{self.main_score}_judge_raw_output": instance["raw_prediction"],
+                    f"{self.main_score}_judge_raw_input": instance["source"],
                 }
             else:
                 result = {
                     self.main_score: instance["prediction"],
-                    "judge_raw_output": instance["raw_prediction"],
-                    "judge_raw_input": instance["source"],
+                    f"{self.main_score}_judge_raw_output": instance["raw_prediction"],
+                    f"{self.main_score}_judge_raw_input": instance["source"],
                 }
             results.append(result)
         return results

--- a/src/unitxt/llm_as_judge.py
+++ b/src/unitxt/llm_as_judge.py
@@ -262,14 +262,16 @@ class LLMAsJudge(LLMAsJudgeBase):
 
                 result = {
                     self.main_score: model_a_preference_score,
-                    f"{self.main_score}_judge_raw_output": instance["raw_prediction"],
-                    f"{self.main_score}_judge_raw_input": instance["source"],
+                    f"{self.main_score}__" f"_judge_raw_output": instance[
+                        "raw_prediction"
+                    ],
+                    f"{self.main_score}___judge_raw_input": instance["source"],
                 }
             else:
                 result = {
                     self.main_score: instance["prediction"],
-                    f"{self.main_score}_judge_raw_output": instance["raw_prediction"],
-                    f"{self.main_score}_judge_raw_input": instance["source"],
+                    f"{self.main_score}___judge_raw_output": instance["raw_prediction"],
+                    f"{self.main_score}___judge_raw_input": instance["source"],
                 }
             results.append(result)
         return results

--- a/src/unitxt/llm_as_judge.py
+++ b/src/unitxt/llm_as_judge.py
@@ -262,16 +262,14 @@ class LLMAsJudge(LLMAsJudgeBase):
 
                 result = {
                     self.main_score: model_a_preference_score,
-                    f"{self.main_score}__" f"_judge_raw_output": instance[
-                        "raw_prediction"
-                    ],
-                    f"{self.main_score}___judge_raw_input": instance["source"],
+                    f"{self.main_score}_judge_raw_output": instance["raw_prediction"],
+                    f"{self.main_score}_judge_raw_input": instance["source"],
                 }
             else:
                 result = {
                     self.main_score: instance["prediction"],
-                    f"{self.main_score}___judge_raw_output": instance["raw_prediction"],
-                    f"{self.main_score}___judge_raw_input": instance["source"],
+                    f"{self.main_score}_judge_raw_output": instance["raw_prediction"],
+                    f"{self.main_score}_judge_raw_input": instance["source"],
                 }
             results.append(result)
         return results

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -1693,7 +1693,7 @@ Answer: """,
                 metric_label: 1.0,
                 "score_name": metric_label,
                 "score": 1.0,
-                "judge_raw_input": "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n"
+                f"{metric_label}_judge_raw_input": "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n"
                 "Please act as an impartial judge and "
                 "evaluate the quality of the response "
                 "provided by an AI assistant to the user "
@@ -1715,7 +1715,7 @@ Answer: """,
                 "[[10]]\n"
                 "[The End of Assistant's "
                 "Answer]<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n",
-                "judge_raw_output": "[[10]]",
+                f"{metric_label}_judge_raw_output": "[[10]]",
             }
         ] * 3
         global_target = {


### PR DESCRIPTION
when using multiple llmaj metric, the raw input and output fields get overwritten because they have the same score name. This pr add score name prefix for judge_raw_output/input in llmaj metric