### PR TITLE
Typos in the rst files

### DIFF
--- a/docs/blog/vision_robustness.rst
+++ b/docs/blog/vision_robustness.rst
@@ -1,5 +1,5 @@
 .. title:: If Your LLM sees White Noise, Try Asking Differently: Revealing AI’s Text and Image Sensitivities with Unitxt
-.. authors:: Elron Bandel and Nimrod Shabtay
+.. sectionauthor:: Elron Bandel and Nimrod Shabtay
 .. date:: 2024-11-01
 
 ============================

--- a/docs/docs/adding_dataset.rst
+++ b/docs/docs/adding_dataset.rst
@@ -55,7 +55,7 @@ We use the `bleu` metric for a reference-based evaluation.
         metrics=["metrics.bleu"],
     ),
 
-We have many predefined tasks in the catalog's :ref:`Tasks section <catalog.tasks>`.
+We have many predefined tasks in the catalog's :ref:`Tasks section <dir_catalog.tasks>`.
 
 If a catalogued task fits your use case, you may reference it by name:
 
@@ -117,11 +117,11 @@ The template also verbalizes the reference fields as gold references.  In Unitxt
 In this example, the `translation` field is taken, as is, as a gold reference.
 However, in other cases, the output field may undergo some transformations.
 
-If using a predefined task, you can choose from the corresponding templates available in the catalog's :ref:`Templates section <catalog.templates>`.
+If using a predefined task, you can choose from the corresponding templates available in the catalog's :ref:`Templates section <dir_catalog.templates>`.
 
 .. note::
 
-   Use the :ref:`comprehensive guide on templates  <templates>` for more templates features.
+   Use the :ref:`comprehensive guide on templates  <adding_template>` for more templates features.
 
 Alternatively, you can define your custom templates:
 

--- a/docs/docs/adding_metric.rst
+++ b/docs/docs/adding_metric.rst
@@ -31,7 +31,7 @@ For example:
             ],
     )
 
-You can see the full list of built in metrics  :ref:`Metrics section <catalog.tasks>`.
+You can see the full list of built in metrics  :ref:`Metrics section <dir_catalog.metrics>`.
 In this section we will understand Unitxt metrics and learn how to add new metrics.
 
 
@@ -135,7 +135,7 @@ Metric Base Classes
 As described in the previous section, a metric generate a set of scores per instance (called `instance` scores),
 and a set of scores over all instances (called `global` scores).
 
-Unitxt has several base classes :ref:`Metric <metrics>` class that simplify the creation of metrics, depending on how the
+Unitxt has several base classes :class:`Metric <unitxt.metrics>` class that simplify the creation of metrics, depending on how the
 scores are calculated.
 
 ``InstanceMetric` - Class for metrics in which the global scores are be calculated by aggregating the instance scores.

--- a/docs/docs/adding_operator.rst
+++ b/docs/docs/adding_operator.rst
@@ -26,7 +26,7 @@ cast field values, uppercase string fields, or translate text between languages.
 
 Unitxt comes with a large collection of built in operators - that were design to cover most common requirements of dataset processing.
 
-The list of available operators can be found in the :ref:`operators <operators>` section.
+The list of available operators can be found in the :ref:`operators <dir_catalog.operators>` section.
 
 Built in operators have some benefits:
 
@@ -37,7 +37,7 @@ Built in operators have some benefits:
 
 It is recommended to use existing operators when possible. 
 
-However, if a highly specific or uncommon operation is needed that existing operators do not cover, and it is unlikely to be reused, you can use :ref:`ExecuteExpression <operators.ExecuteExpression>`  or :ref:`FilterByExpression <operators.FilterByExpression>`operators:
+However, if a highly specific or uncommon operation is needed that existing operators do not cover, and it is unlikely to be reused, you can use :class:`ExecuteExpression <unitxt.operators.ExecuteExpression>` or :class:`FilterByExpression <unitxt.operators.FilterByExpression>` operators:
 
 .. code-block:: python
 

--- a/docs/docs/adding_operator.rst
+++ b/docs/docs/adding_operator.rst
@@ -26,7 +26,7 @@ cast field values, uppercase string fields, or translate text between languages.
 
 Unitxt comes with a large collection of built in operators - that were design to cover most common requirements of dataset processing.
 
-The list of available operators can be found in the :ref:`operators <dir_catalog.operators>` section.
+The list of available operators can be found in the :ref:`operators <operators_list>` section.
 
 Built in operators have some benefits:
 

--- a/docs/docs/adding_template.rst
+++ b/docs/docs/adding_template.rst
@@ -9,11 +9,11 @@ Templates ✨
 =====================================
 
 In this section you learn how to add a Template. Templates are the way for unitxt to take your task data and verbalize the task instructions to the model.
-The templates made by the community can be found in the catalog :ref:`templates section <catalog.templates>`
-and the documentation for the base classes used for templates can be found here: :ref:`Templates Documentation<templates>`
+The templates made by the community can be found in the catalog :ref:`templates section <dir_catalog.templates>`
+and the documentation for the base classes used for templates can be found here: :class:`Templates Documentation <unitxt.templates>`
 
 Unitxt Prompt Structure
-----------------------------
+-----------------------
 
 .. _prompt_layout:
 .. image:: ../../assets/prompt_layout.png
@@ -78,7 +78,7 @@ becomes the string reference "happy,angry", and it is expected that the model wi
 Post Processors
 ---------------
 
-The template also defines the post processing steps applied to the output predictions of the model before they are passed to the :ref:`Metrics <metric>`.
+The template also defines the post processing steps applied to the output predictions of the model before they are passed to the :ref:`Metrics <adding_metric>`.
 Typically, the post processors applied both to the model prediction and to the references. 
 For example, we could use the ``processors.lower_case`` processor to lowercase both the model predictions and references,
 so the metric computation will ignore case. 
@@ -123,7 +123,7 @@ Here we see how we can lowercase only the model prediction.
         ]
     )
 
-You can see all the available predefined post processors in the catalog (:ref:`Processor <processors>`.)
+You can see all the available predefined post processors in the catalog (:ref:`Processor <dir_catalog.processors>`.)
 
 Templates for Special Cases
 ----------------------------
@@ -141,7 +141,7 @@ There are different templates for different types of data. For example, for data
 
 The template uses the list of values in the dataset field defined by the ``references_field`` attribute to define all the references.
 
-You can see all the available predefined templates here: :ref:`Templates Documentation<templates>`.
+You can see all the available predefined templates here: :ref:`Templates Documentation <dir_catalog.templates>`.
 
 Making Your Custom Template
 ----------------------------

--- a/docs/docs/data_classification_policy.rst
+++ b/docs/docs/data_classification_policy.rst
@@ -1,4 +1,4 @@
-.. _data_classification_policy
+.. _data_classification_policy:
 
 .. note::
 

--- a/docs/docs/examples.rst
+++ b/docs/docs/examples.rst
@@ -170,7 +170,7 @@ This example demonstrates how to evaluate a user model on the Arena Hard benchma
 
 `Example code <https://github.com/IBM/unitxt/blob/main/examples/evaluate_a_model_using_arena_hard.py>`_
 
-Related documentation: :ref:`Evaluate a Model on Arena Hard Benchmark <arena_hard_evaluation>`, :ref:`Inference Engines <inference>`.
+Related documentation: :ref:`Evaluate a Model on Arena Hard Benchmark <dir_catalog.cards.arena_hard>`, :ref:`Inference Engines <inference>`.
 
 Evaluate a judge model performance judging the Arena Hard Benchmark
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -180,7 +180,7 @@ The model is evaluated on its capability to give a judgment that is in correlati
 
 `Example code <https://github.com/IBM/unitxt/blob/main/examples/evaluate_a_judge_model_capabilities_on_arena_hard.py>`_
 
-Related documentation: :ref:`Evaluate a Model on Arena Hard Benchmark <arena_hard_evaluation>`, :ref:`Inference Engines <inference>`.
+Related documentation: :ref:`Evaluate a Model on Arena Hard Benchmark <dir_catalog.cards.arena_hard>`, :ref:`Inference Engines <inference>`.
 
 Evaluate using ensemble of LLM as a judge metrics
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/docs/examples.rst
+++ b/docs/docs/examples.rst
@@ -28,7 +28,7 @@ This approach is faster than using Huggingface APIs.
 
 `Example code <https://github.com/IBM/unitxt/blob/main/examples/evaluate_existing_dataset_with_install.py>`_
 
-Related documentation: :ref:`Installation <installation>` , :ref:`WNLI dataset card in catalog <catalog.cards.wnli>`, :ref:`Relation template in catalog <catalog.templates.classification.multi_class.relation.default>`, :ref:`Inference Engines <inference>`.
+Related documentation: :ref:`Installation <install_unitxt>` , :ref:`WNLI dataset card in catalog <catalog.cards.wnli>`, :ref:`Relation template in catalog <catalog.templates.classification.multi_class.relation.default>`, :ref:`Inference Engines <inference>`.
 
 
 Evaluate a custom dataset

--- a/docs/docs/glossary.rst
+++ b/docs/docs/glossary.rst
@@ -54,7 +54,7 @@ Data-Task Card
 Typically, it includes data wrangling actions, e.g., renaming fields,
 filtering data instances, modifying values, train/test/val splitting etc.
 
-The catalog contains predefined data-task cards for various datasets :ref:`here <catalog.cards>`.
+The catalog contains predefined data-task cards for various datasets :ref:`here <dir_catalog.cards>`.
 
 .. _data_evaluation_pipeline:
 
@@ -109,7 +109,7 @@ Following the example in the  :ref:`figure <prompt_structure>`, the Unitxt forma
 "**classify the sentence: ``I like toast''**", and adds three things: the system prompt "**<SYS>You are a helpful agent</SYS>**",
 the Instruction-User-Agent schema cues, and the two presented demonstrations.
 
-The catalog contains predefined formats :ref:`here <catalog.formats>`.
+The catalog contains predefined formats :ref:`here <dir_catalog.formats>`.
 
 .. _inference_engine:
 
@@ -145,7 +145,7 @@ Post processors
 ----------------
 
 **Post Processors** are a set of  :ref:`operators <operator>` that de-verbalizes both the string model predictions and string references,
-and converts them to the types required by the :ref:`metrics <metric>`.  Each :ref:`template <template>` defines the
+and converts them to the types required by the :ref:`metrics <adding_metric>`.  Each :ref:`template <template>` defines the
 set of post processors that are appropriate for it.   For example, post processors in a binary classification
 template could remove trailing whitespace, take the first word, convert `Yes` to `1` , and all other values to `0`.
 
@@ -159,7 +159,7 @@ The inference process used to generated the prediction can be done with an Unitx
 framework or code.  The predictions over all instances are  passed to the evaluation pipeline, together with the original dataset.
 
 The textual predictions returned by the model are processed by the :ref:`Template <template>`'s :ref:`Post Processors <post_processors>`
-before being passed to the :ref:`Metrics <metric>`.  The post processors convert the textual prediction to the
+before being passed to the :ref:`Metrics <adding_metric>`.  The post processors convert the textual prediction to the
 type required by the metrics. For example, `Yes` and `No` values could be first normalized to `yes` and `no` and then converted
 into `0.0` and `1.0`.
 
@@ -189,7 +189,7 @@ It is expect that the model will get a perfect score from the metrics if the mod
 is equal to one of the references.
 
 The textual references are processed by the :ref:`Template <template>`'s :ref:`Post Processors <post_processors>`
-before being passed to the :ref:`Metrics <metric>`.  The post processor converts the textual representation
+before being passed to the :ref:`Metrics <adding_metric>`.  The post processor converts the textual representation
 of the references to the type required by the metrics. For example, `Yes` and `No`
 values could be converted into `0.0` and `1`.
 
@@ -239,7 +239,7 @@ A Unitxt **Task** follows the formal definition of an NLP task, such as multi-la
 A task is defined by its standard interface -- namely, input and output fields -- and by its evaluation metrics.
 Given a dataset, its contents are standardized into the fields defined by an appropriate task by a :ref:`Data-Task Card <data_task_card>`.
 
-The catalog contains predefined tasks :ref:`here <catalog.tasks>`.
+The catalog contains predefined tasks :ref:`here <dir_catalog.tasks>`.
 
 .. _template:
 
@@ -263,7 +263,7 @@ Having the de-verbalization steps defined within the template enables templates 
 The templates, datasets and tasks in Unitxt are not exclusively tied.
 Each task can harness multiple templates and a template can be used for different datasets.
 
-The catalog contains predefined templates :ref:`here <catalog.templates>`. :ref:`Tasks section <catalog.tasks>`
+The catalog contains predefined templates :ref:`here <dir_catalog.templates>`. :ref:`Tasks section <dir_catalog.tasks>`
 
 .. _verbalization:
 
@@ -290,6 +290,6 @@ Serialization
 --------------
 
 Is the process of taking a specific field of a task a converting it into a string.
-This process is controlled by the :ref:`Serializer <serializers>`.
+This process is controlled by the :ref:`Serializer <types_and_serializers>`.
 Unlike the verbalization which is task specific, namely putting into words an input of a specific task, the serialization
 has nothing to do with task, and is just based on the type of the field.

--- a/docs/docs/glossary.rst
+++ b/docs/docs/glossary.rst
@@ -17,7 +17,7 @@ Almost all Unitxt classes inherit from the Artifact class.
 Catalog
 -------
 All Unitxt artifacts -- recipes, data-task cards, templates, pre-processing operators, formats and metrics --
-can be stored in the **:ref:`Unitxt Catalog <catalog>`.**
+can be stored in the :ref:`Unitxt Catalog <dir_catalog>`.
 
 In addition to the open-source catalog, which can be found in the documentation, users can choose to define a private catalog.
 This enables teams and organizations to harness the open Unitxt Catalog while upholding organizational requirements for additional proprietary artifacts.

--- a/docs/docs/helm.rst
+++ b/docs/docs/helm.rst
@@ -10,7 +10,7 @@ Running Unitxt with HELM
    :width: 75%
    :align: center
 
-Unitxt can be integrated with :ref:`HELM <https://github.com/stanford-crfm/helm/>`, enabling you to select and evaluate models from the extensive HELM models catalog with data recipes created by Unitxt.
+Unitxt can be integrated with `HELM <https://github.com/stanford-crfm/helm/>`_, enabling you to select and evaluate models from the extensive HELM models catalog with data recipes created by Unitxt.
 
 First, install HELM at version v0.5.0 or later:
 

--- a/docs/docs/operators.rst
+++ b/docs/docs/operators.rst
@@ -1,3 +1,6 @@
+.. _operators_list:
+
+==============
 Operators List
 ==============
 

--- a/docs/docs/rag_support.rst
+++ b/docs/docs/rag_support.rst
@@ -59,7 +59,7 @@ RAG evaluation is performed using both automatic `reference-based` and `referenc
 .. _context_relevance:
 
 Context-Relevance
--------
+-----------------
 This is a reference-less metric gauging the relevance of the retrieved texts to answering the user question. The metric range is [0, 1], where higher is better. 
 
 * Motivation and Approach 
@@ -75,6 +75,7 @@ By computing ``Context Relevance`` over results from different vector stores and
 We employ a small LLM - ``google/flan-t-5-small`` - that is known to show strong results in a faithfulness assessment, and we prompt it with the instruction ``Generate a question based on the given content:`` followed by one retrieved text at a time. As the model generates the question iteratively, token by token, we employ a teacher forcing strategy that uses the tokens from the actual question as ground truth. Thus, at each step, the model uses the ground-truth tokens as input rather than the output from previous steps, and predicts the probability of generating the next ground-truth token. The geometric mean over these probabilities defines the perplexity of the retrieved text.
 
 * Limitations and Future Plans
+
 In future releases we will add a list of complementary metrics ``Context Relevance @ K`` for $K = {1, 3, 5, ...}$ that are computed by averaging the perplexity scores of the top-K retrieved texts. This will be useful for assessing the ranking of the retrieval. After all, normally in RAG applications only the top results from the search are passed to the LLM for generating an answer.
 
 -----
@@ -108,6 +109,7 @@ Faithfulness
 This is a reference-less metric gauging the groundedness of the generated answer in the retrieved texts. The metric range is [0, 1], where higher is better.
 
 * Motivation and Approach
+
 We based our approach on `Adlakha et. al (2023) <https://arxiv.org/abs/2307.16877>`_ - "Evaluating Correctness and Faithfulness of Instruction-Following Models for Question Answering", which found that fast and inexpensive lexical analysis can provide a relatively high correlation with human judgement on faithfulness. 
 
 Table 4 from the paper is provided below, showing that the `K-Precision` lexical approach is close to GPT-4. The main advantage of lexical strategies over the LLM as a Judge strategy is that they are easy to implement, fast to run, and inexpensive to deploy (in other words, they do not require GPUs). 
@@ -119,11 +121,13 @@ Table 4 from the paper is provided below, showing that the `K-Precision` lexical
 
 
 * Implementation Details
+
 The `K-Precision` ("Knowledge Precision") metric that is mentioned in the paper has been part of public open source projects for a long time, and now it is also adopted in the Unitxt package for computing faithfulness scores. 
 
 The metric is essentially token precision: we count how many of the generated tokens in the system response are included in the context retrieved from the index.
 
 * Limitations and Future Plans
+
 Lexical strategies look at words in isolation, ignoring word order and context. This is clearly a suboptimal approach that can lead to inaccurate assessments in many cases. We plan to switch to a more robust LLM as a Judge approach once we have models that can offer a better trade-off between speed, cost and quality. 
 
 ------------
@@ -131,7 +135,7 @@ Lexical strategies look at words in isolation, ignoring word order and context. 
 .. _answer_reward:
 
 Answer Reward
-------------
+-------------
 This is a reference-less metric that predicts which generated answer is better judged by a human, given a question. The metric range is [0, 1], where higher is better.
 
 * Motivation and Approach

--- a/docs/docs/tutorials.rst
+++ b/docs/docs/tutorials.rst
@@ -15,6 +15,7 @@ Tutorials ✨
    adding_operator
    adding_metric
    data_classification_policy
+   ../modules
    rag_support
    multimodality
    operators

--- a/src/unitxt/augmentors.py
+++ b/src/unitxt/augmentors.py
@@ -83,12 +83,9 @@ class AugmentPrefixSuffix(TextAugmentor):
     r"""Augments the input by prepending and appending randomly selected (typically, whitespace) patterns.
 
     Args:
-     prefixes, suffixes (list or dict) : the potential (typically, whitespace) patterns to select from.
-        The dictionary version allows the specification relative weights for the different patterns.
+     prefixes, suffixes (list or dict) : the potential patterns (typically, whitespace) to select from. The dictionary version allows the specification relative weights for the different patterns.
      prefix_len, suffix_len (positive int) : The added prefix or suffix will be of a certain length.
-     remove_existing_whitespaces : Clean any existing leading and trailing whitespaces.
-        The strings made of repetitions of the selected pattern(s) are then prepended and/or appended to the potentially
-        trimmed input.
+     remove_existing_whitespaces : Clean any existing leading and trailing whitespaces. The strings made of repetitions of the selected pattern(s) are then prepended and/or appended to the potentially trimmed input.
      If only either just prefixes or just suffixes are needed, set the other to None.
 
     Examples:

--- a/src/unitxt/loaders.py
+++ b/src/unitxt/loaders.py
@@ -1,7 +1,7 @@
 """This section describes unitxt loaders.
 
 Loaders: Generators of Unitxt Multistreams from existing date sources
-==============================================================
+=====================================================================
 
 Unitxt is all about readily preparing of any given data source for feeding into any given language model, and then,
 post-processing the model's output, preparing it for any given evaluator.
@@ -16,14 +16,14 @@ All these loaders inherit from Loader, and hence, implementing a loader to expan
 straightforward.
 
 Available Loaders Overview:
-    - :ref:`LoadHF <unitxt.loaders.LoadHF>` - Loads data from HuggingFace Datasets.
-    - :ref:`LoadCSV <unitxt.loaders.LoadCSV>` - Imports data from CSV (Comma-Separated Values) files.
-    - :ref:`LoadFromKaggle <unitxt.loaders.LoadFromKaggle>` - Retrieves datasets from the Kaggle community site.
-    - :ref:`LoadFromIBMCloud <unitxt.loaders.LoadFromIBMCloud>` - Fetches datasets hosted on IBM Cloud.
-    - :ref:`LoadFromSklearn <unitxt.loaders.LoadFromSklearn>` - Loads datasets available through the sklearn library.
-    - :ref:`MultipleSourceLoader <unitxt.loaders.MultipleSourceLoader>` - Combines data from multiple different sources.
-    - :ref:`LoadFromDictionary <unitxt.loaders.LoadFromDictionary>` - Loads data from a user-defined Python dictionary.
-    - :ref:`LoadFromHFSpace <unitxt.loaders.LoadFromHFSpace>` - Downloads and loads data from HuggingFace Spaces.
+    - :class:`LoadHF <unitxt.loaders.LoadHF>` - Loads data from HuggingFace Datasets.
+    - :class:`LoadCSV <unitxt.loaders.LoadCSV>` - Imports data from CSV (Comma-Separated Values) files.
+    - :class:`LoadFromKaggle <unitxt.loaders.LoadFromKaggle>` - Retrieves datasets from the Kaggle community site.
+    - :class:`LoadFromIBMCloud <unitxt.loaders.LoadFromIBMCloud>` - Fetches datasets hosted on IBM Cloud.
+    - :class:`LoadFromSklearn <unitxt.loaders.LoadFromSklearn>` - Loads datasets available through the sklearn library.
+    - :class:`MultipleSourceLoader <unitxt.loaders.MultipleSourceLoader>` - Combines data from multiple different sources.
+    - :class:`LoadFromDictionary <unitxt.loaders.LoadFromDictionary>` - Loads data from a user-defined Python dictionary.
+    - :class:`LoadFromHFSpace <unitxt.loaders.LoadFromHFSpace>` - Downloads and loads data from HuggingFace Spaces.
 
 
 

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -483,14 +483,12 @@ class StandardRecipe(StandardRecipeWithIndexes):
         sampler (Sampler, optional): The Sampler used to select the demonstrations when num_demos > 0.
         steps (List[StreamingOperator], optional): List of StreamingOperator objects to be used in the recipe.
         augmentor (Augmentor) : Augmentor to be used to pseudo randomly augment the source text
-        instruction_card_index (int, optional): Index of instruction card to be used
-            for preparing the recipe.
-        template_card_index (int, optional): Index of template card to be used for
-            preparing the recipe.
+        instruction_card_index (int, optional): Index of instruction card to be used for preparing the recipe.
+        template_card_index (int, optional): Index of template card to be used for preparing the recipe.
 
     Methods:
         prepare(): This overridden method is used for preparing the recipe
-            by arranging all the steps, refiners, and renderers in a sequential manner.
+        by arranging all the steps, refiners, and renderers in a sequential manner.
 
     Raises:
         AssertionError: If both template and template_card_index are specified at the same time.

--- a/src/unitxt/text_utils.py
+++ b/src/unitxt/text_utils.py
@@ -137,7 +137,8 @@ def construct_dict_as_yaml_lines(d, indent_delta=2) -> List[str]:
         if len(d) == 0:
             return ["{}"]
         for key, val in d.items():
-            res.append(key + ": ")
+            printable_key = f'"{key}"' if (" " in key) or (key == "") else key
+            res.append(printable_key + ": ")
             yaml_for_val = construct_dict_as_yaml_lines(val, indent_delta=indent_delta)
             assert len(yaml_for_val) > 0
             if is_simple(val):


### PR DESCRIPTION
Fixed many broken links. E.g.:

Before:
![image](https://github.com/user-attachments/assets/f264bd01-6d53-4cee-864f-33d9338abbb1)

After:
![image](https://github.com/user-attachments/assets/019e99e4-95ca-473a-abd2-db144b8c1de3)

linking to [this page](https://www.unitxt.ai/en/latest/catalog/catalog.__dir__.html) 
