### PR TITLE
Check if unitxt_pkg is None

### DIFF
--- a/src/unitxt/settings_utils.py
+++ b/src/unitxt/settings_utils.py
@@ -161,8 +161,8 @@ if Constants.is_uninitilized():
     constants.metric_file = os.path.join(os.path.dirname(__file__), "metric.py")
     constants.local_catalog_path = os.path.join(os.path.dirname(__file__), "catalog")
     unitxt_pkg = importlib.util.find_spec("unitxt")
-    constants.package_dir = os.path.dirname(unitxt_pkg.origin)
     if unitxt_pkg and unitxt_pkg.origin:
+        constants.package_dir = os.path.dirname(unitxt_pkg.origin)
         constants.default_catalog_path = os.path.join(constants.package_dir, "catalog")
     else:
         constants.default_catalog_path = constants.local_catalog_path


### PR DESCRIPTION
When using HuggingFace APIs to load datasets and metrics, the unitxt_pkg is None. Check it before accessing its properties. The current code breaks the installation approach documented here: https://www.unitxt.ai/en/latest/docs/lm_eval.html#installation.