### PR TITLE
Add inference engines to the catalog

### DIFF
--- a/prepare/engines/cross_provider/llama3.py
+++ b/prepare/engines/cross_provider/llama3.py
@@ -1,0 +1,13 @@
+from unitxt.catalog import add_to_catalog
+from unitxt.inference import CrossProviderInferenceEngine
+
+model_list = ["meta-llama/llama-3-8b-instruct", "meta-llama/llama-3-70b-instruct"]
+
+for model in model_list:
+    model_label = model.split("/")[1].replace("-", "_").replace(".", ",").lower()
+    inference_model = CrossProviderInferenceEngine(
+        model=model, provider="watsonx", max_tokens=2048, seed=42
+    )
+    add_to_catalog(
+        inference_model, f"engines.cross_provider.{model_label}", overwrite=True
+    )

--- a/prepare/engines/openai/gpt4o.py
+++ b/prepare/engines/openai/gpt4o.py
@@ -1,0 +1,7 @@
+from unitxt.catalog import add_to_catalog
+from unitxt.inference import OpenAiInferenceEngine
+
+model_name = "gpt-4o"
+model_label = model_name.replace("-", "_").lower()
+inference_model = OpenAiInferenceEngine(model_name=model_name, max_tokens=2048, seed=42)
+add_to_catalog(inference_model, f"engines.openai.{model_label}", overwrite=True)

--- a/prepare/engines/rits/llama3.py
+++ b/prepare/engines/rits/llama3.py
@@ -1,0 +1,13 @@
+from unitxt.catalog import add_to_catalog
+from unitxt.inference import RITSInferenceEngine
+
+model_list = [
+    "meta-llama/Llama-3.1-8B-Instruct",
+    "meta-llama/llama-3-1-70b-instruct",
+    "meta-llama/llama-3-1-405b-instruct-fp8",
+]
+
+for model in model_list:
+    model_label = model.split("/")[1].replace("-", "_").replace(",", "_").lower()
+    inference_model = RITSInferenceEngine(model_name=model, max_tokens=2048, seed=42)
+    add_to_catalog(inference_model, f"engines.rits.{model_label}", overwrite=True)

--- a/src/unitxt/catalog/engines/cross_provider/llama_3_70b_instruct.json
+++ b/src/unitxt/catalog/engines/cross_provider/llama_3_70b_instruct.json
@@ -1,0 +1,7 @@
+{
+    "__type__": "cross_provider_inference_engine",
+    "model": "meta-llama/llama-3-70b-instruct",
+    "provider": "watsonx",
+    "max_tokens": 2048,
+    "seed": 42
+}

--- a/src/unitxt/catalog/engines/cross_provider/llama_3_8b_instruct.json
+++ b/src/unitxt/catalog/engines/cross_provider/llama_3_8b_instruct.json
@@ -1,0 +1,7 @@
+{
+    "__type__": "cross_provider_inference_engine",
+    "model": "meta-llama/llama-3-8b-instruct",
+    "provider": "watsonx",
+    "max_tokens": 2048,
+    "seed": 42
+}

--- a/src/unitxt/catalog/engines/openai/gpt_4o.json
+++ b/src/unitxt/catalog/engines/openai/gpt_4o.json
@@ -1,0 +1,6 @@
+{
+    "__type__": "open_ai_inference_engine",
+    "model_name": "gpt-4o",
+    "max_tokens": 2048,
+    "seed": 42
+}

--- a/src/unitxt/catalog/engines/rits/llama_3/1_8b_instruct.json
+++ b/src/unitxt/catalog/engines/rits/llama_3/1_8b_instruct.json
@@ -1,0 +1,6 @@
+{
+    "__type__": "rits_inference_engine",
+    "model_name": "meta-llama/Llama-3.1-8B-Instruct",
+    "max_tokens": 2048,
+    "seed": 42
+}

--- a/src/unitxt/catalog/engines/rits/llama_3_1_405b_instruct_fp8.json
+++ b/src/unitxt/catalog/engines/rits/llama_3_1_405b_instruct_fp8.json
@@ -1,0 +1,6 @@
+{
+    "__type__": "rits_inference_engine",
+    "model_name": "meta-llama/llama-3-1-405b-instruct-fp8",
+    "max_tokens": 2048,
+    "seed": 42
+}

--- a/src/unitxt/catalog/engines/rits/llama_3_1_70b_instruct.json
+++ b/src/unitxt/catalog/engines/rits/llama_3_1_70b_instruct.json
@@ -1,0 +1,6 @@
+{
+    "__type__": "rits_inference_engine",
+    "model_name": "meta-llama/llama-3-1-70b-instruct",
+    "max_tokens": 2048,
+    "seed": 42
+}


### PR DESCRIPTION
This PR adds RITS, OpenAI and CrossProvider examples to the catalog to the previously existing ones BAM and Watsonx.