### PR TITLE
Reduce error message clutter

### DIFF
--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -427,7 +427,7 @@ class InstanceOperator(StreamOperator):
                 raise e
             else:
                 raise ValueError(
-                    f"Error processing instance '{_index}' from stream '{stream_name}' in {self.__class__.__name__} due to: {e}"
+                    f"Error processing instance '{_index}' from stream '{stream_name}' in {self.__class__.__name__} due to the exception above."
                 ) from e
 
     def _process_instance(

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -190,7 +190,7 @@ class MapInstanceValues(InstanceOperator):
             if value is not None:
                 if (self.process_every_value is True) and (not isinstance(value, list)):
                     raise ValueError(
-                        f"'process_every_field' == True is allowed only when all fields which have mappers, i.e., {list(self.mappers.keys())} are lists. Instance = {instance}"
+                        f"'process_every_field' == True is allowed only when for fields whose values are lists, but value of field '{key}' is '{value}'"
                     )
                 if isinstance(value, list) and self.process_every_value:
                     for i, val in enumerate(value):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -454,7 +454,7 @@ class InstanceFieldOperator(InstanceOperator):
                     old_value = self.get_default
             except Exception as e:
                 raise ValueError(
-                    f"Failed to get '{from_field}' from {instance} due to : {e}"
+                    f"Failed to get '{from_field}' from {instance} due to the exception above."
                 ) from e
             try:
                 if self.process_every_value:
@@ -466,7 +466,7 @@ class InstanceFieldOperator(InstanceOperator):
                     new_value = self.process_instance_value(old_value, instance)
             except Exception as e:
                 raise ValueError(
-                    f"Failed to process '{from_field}' from {instance} due to : {e}"
+                    f"Failed to process '{from_field}' from {instance} due to the exception above."
                 ) from e
             dict_set(
                 instance,

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -190,7 +190,7 @@ class MapInstanceValues(InstanceOperator):
             if value is not None:
                 if (self.process_every_value is True) and (not isinstance(value, list)):
                     raise ValueError(
-                        f"'process_every_field' == True is allowed only when for fields whose values are lists, but value of field '{key}' is '{value}'"
+                        f"'process_every_field' == True is allowed only for fields whose values are lists, but value of field '{key}' is '{value}'"
                     )
                 if isinstance(value, list) and self.process_every_value:
                     for i, val in enumerate(value):
@@ -211,7 +211,7 @@ class MapInstanceValues(InstanceOperator):
             return recursive_copy(mapper[val_as_str])
         if self.strict:
             raise KeyError(
-                f"value '{val}' in field '{key}' is not found in mapper '{mapper}'"
+                f"value '{val_as_str}', the string representation of the value in field '{key}', is not found in mapper '{mapper}'"
             )
         return val
 
@@ -977,7 +977,7 @@ class CastFields(InstanceOperator):
             if self.process_every_value:
                 assert isinstance(
                     value, list
-                ), f"'process_every_value' can be set to True only for fields that contain lists, the contents of field '{field_name}' is of type '{type(value)}'"
+                ), f"'process_every_field' == True is allowed only for fields whose values are lists, but value of field '{field_name}' is '{value}'"
                 casted_value = self._cast_multiple(value, type, field_name)
             else:
                 casted_value = self._cast_single(value, type, field_name)
@@ -1194,13 +1194,13 @@ class FilterByConditionBasedOnFields(FilterByCondition):
                 instance_key = dict_get(instance, key)
             except ValueError as ve:
                 raise ValueError(
-                    f"Required filter field ('{key}') in FilterByCondition is not found in {instance.keys()} of instance"
+                    f"Required filter field ('{key}') in FilterByCondition is not found in instance"
                 ) from ve
             try:
                 instance_value = dict_get(instance, value)
             except ValueError as ve:
                 raise ValueError(
-                    f"Required filter field ('{value}') in FilterByCondition is not found in {instance.keys()} of instance"
+                    f"Required filter field ('{value}') in FilterByCondition is not found in instance"
                 ) from ve
             if self.condition == "in":
                 if instance_key not in instance_value:

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -211,7 +211,7 @@ class MapInstanceValues(InstanceOperator):
             return recursive_copy(mapper[val_as_str])
         if self.strict:
             raise KeyError(
-                f"value '{val}' in instance '{instance}' is not found in mapper '{mapper}', associated with field '{key}'."
+                f"value '{val}' in field '{key}' is not found in mapper '{mapper}'"
             )
         return val
 
@@ -454,7 +454,7 @@ class InstanceFieldOperator(InstanceOperator):
                     old_value = self.get_default
             except Exception as e:
                 raise ValueError(
-                    f"Failed to get '{from_field}' from {instance} due to the exception above."
+                    f"Failed to get '{from_field}' from instance due to the exception above."
                 ) from e
             try:
                 if self.process_every_value:
@@ -466,7 +466,7 @@ class InstanceFieldOperator(InstanceOperator):
                     new_value = self.process_instance_value(old_value, instance)
             except Exception as e:
                 raise ValueError(
-                    f"Failed to process '{from_field}' from {instance} due to the exception above."
+                    f"Failed to process field '{from_field}' from instance due to the exception above."
                 ) from e
             dict_set(
                 instance,
@@ -977,7 +977,7 @@ class CastFields(InstanceOperator):
             if self.process_every_value:
                 assert isinstance(
                     value, list
-                ), f"'process_every_value' can be set to True only for fields that contain lists, whereas in instance {instance}, the contents of field '{field_name}' is of type '{type(value)}'"
+                ), f"'process_every_value' can be set to True only for fields that contain lists, the contents of field '{field_name}' is of type '{type(value)}'"
                 casted_value = self._cast_multiple(value, type, field_name)
             else:
                 casted_value = self._cast_single(value, type, field_name)
@@ -1154,7 +1154,7 @@ class FilterByCondition(StreamOperator):
                 instance_key = dict_get(instance, key)
             except ValueError as ve:
                 raise ValueError(
-                    f"Required filter field ('{key}') in FilterByCondition is not found in {instance}"
+                    f"Required filter field ('{key}') in FilterByCondition is not found in instance."
                 ) from ve
             if self.condition == "in":
                 if instance_key not in value:
@@ -1194,13 +1194,13 @@ class FilterByConditionBasedOnFields(FilterByCondition):
                 instance_key = dict_get(instance, key)
             except ValueError as ve:
                 raise ValueError(
-                    f"Required filter field ('{key}') in FilterByCondition is not found in {instance}"
+                    f"Required filter field ('{key}') in FilterByCondition is not found in {instance.keys()} of instance"
                 ) from ve
             try:
                 instance_value = dict_get(instance, value)
             except ValueError as ve:
                 raise ValueError(
-                    f"Required filter field ('{value}') in FilterByCondition is not found in {instance}"
+                    f"Required filter field ('{value}') in FilterByCondition is not found in {instance.keys()} of instance"
                 ) from ve
             if self.condition == "in":
                 if instance_key not in instance_value:
@@ -1551,7 +1551,7 @@ class SplitByNestedGroup(MultiStreamOperator):
             for instance in stream:
                 if self.field_name_of_group not in instance:
                     raise ValueError(
-                        f"Field {self.field_name_of_group} is missing from instance {instance}"
+                        f"Field {self.field_name_of_group} is missing from instance. Available fields: {instance.keys()}"
                     )
                 signature = (
                     stream_name

--- a/src/unitxt/test_utils/operators.py
+++ b/src/unitxt/test_utils/operators.py
@@ -29,7 +29,7 @@ def apply_operator(
 def check_operator_exception(
     operator: StreamingOperator,
     inputs: List[dict],
-    exception_text,
+    exception_texts,
     tester=None,
 ):
     assert isoftype(operator, StreamingOperator), "operator must be an Operator"
@@ -39,15 +39,17 @@ def check_operator_exception(
     try:
         apply_operator(operator, inputs)
     except Exception as e:
-        if tester is not None:
-            tester.assertEqual(str(e), exception_text)
-        elif str(e) != exception_text:
-            raise AssertionError(
-                f"Expected exception text : {exception_text}. Got : {e}"
-            ) from e
+        for exception_text in exception_texts:
+            if tester is not None:
+                tester.assertEqual(str(e), exception_text)
+            elif str(e) != exception_text:
+                raise AssertionError(
+                    f"Expected exception text : {exception_text}. Got : {e}"
+                ) from e
+            e = e.__cause__
         return
 
-    raise AssertionError(f"Did not receive expected exception {exception_text}")
+    raise AssertionError(f"Did not receive expected exception: {exception_texts[0]}")
 
 
 def check_operator(

--- a/tests/library/test_augmentors.py
+++ b/tests/library/test_augmentors.py
@@ -94,17 +94,20 @@ class TestOperators(UnitxtTestCase):
         inputs = [{"input_fields": {"text": text}}]
         operator = AugmentWhitespace()
         operator.set_fields(["text"])
-        exception_text = "Error processing instance '0' from stream 'test' in AugmentWhitespace due to: Error augmenting value 'None' from 'input_fields/text' in instance: {'input_fields': {'text': None}}"
+        exception_texts = [
+            "Error processing instance '0' from stream 'test' in AugmentWhitespace due to the exception above.",
+            "Error augmenting value 'None' from 'input_fields/text' in instance: {'input_fields': {'text': None}}",
+        ]
 
         try:
             check_operator_exception(
                 operator,
                 inputs,
-                exception_text=exception_text,
+                exception_texts=exception_texts,
                 tester=self,
             )
         except Exception as e:
             self.assertEqual(
                 str(e),
-                "Did not receive expected exception Error processing instance '0' from stream 'test' in AugmentWhitespace due to: Error augmenting value 'None' from 'input_fields/text' in instance: {'input_fields': {'text': None}}",
+                "Did not receive expected exception: Error processing instance '0' from stream 'test' in AugmentWhitespace due to the exception above.",
             )

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -106,7 +106,7 @@ class TestOperators(UnitxtTestCase):
             inputs=[{"a": "3", "b": "4"}],
             exception_texts=[
                 "Error processing instance '0' from stream 'test' in MapInstanceValues due to the exception above.",
-                "\"value '3' in instance '{'a': '3', 'b': '4'}' is not found in mapper '{'1': 'hi', '2': 'bye'}', associated with field 'a'.\"",
+                "\"value '3' in field 'a' is not found in mapper '{'1': 'hi', '2': 'bye'}'\"",
             ],
             tester=self,
         )
@@ -137,7 +137,7 @@ class TestOperators(UnitxtTestCase):
             inputs=[{"a": [1, 2, 3, 4], "b": 2}],
             exception_texts=[
                 "Error processing instance '0' from stream 'test' in MapInstanceValues due to the exception above.",
-                "\"value '3' in instance '{'a': ['hi', 'bye', 3, 4], 'b': 2}' is not found in mapper '{'1': 'hi', '2': 'bye'}', associated with field 'a'.\"",
+                "\"value '3' in field 'a' is not found in mapper '{'1': 'hi', '2': 'bye'}'\"",
             ],
             tester=self,
         )
@@ -336,7 +336,9 @@ class TestOperators(UnitxtTestCase):
             tester=self,
         )
 
-        exception_text = "Required filter field ('d') in FilterByCondition is not found in {'a': 1, 'b': {'c': 2}}"
+        exception_text = (
+            "Required filter field ('d') in FilterByCondition is not found in instance."
+        )
         check_operator_exception(
             operator=FilterByCondition(values={"d": "5"}, condition="eq"),
             inputs=inputs,
@@ -507,7 +509,7 @@ class TestOperators(UnitxtTestCase):
             )
         self.assertEqual(
             str(cm.exception),
-            "Required filter field ('c') in FilterByCondition is not found in {'a': 1, 'b': 2}",
+            "Required filter field ('c') in FilterByCondition is not found in instance.",
         )
         with self.assertRaises(Exception) as ne:
             check_operator(
@@ -623,7 +625,7 @@ class TestOperators(UnitxtTestCase):
         ]
         exception_texts = [
             "Error processing instance '0' from stream 'test' in Intersect due to the exception above.",
-            "Failed to process 'label' from {'label': 'b'} due to the exception above.",
+            "Failed to process field 'label' from instance due to the exception above.",
             "The value in field is not a list but 'b'",
         ]
         check_operator_exception(
@@ -718,7 +720,7 @@ class TestOperators(UnitxtTestCase):
         ]
         exception_texts = [
             "Error processing instance '0' from stream 'test' in RemoveValues due to the exception above.",
-            "Failed to process 'label' from {'label': 'b'} due to the exception above.",
+            "Failed to process field 'label' from instance due to the exception above.",
             "The value in field is not a list but 'b'",
         ]
         check_operator_exception(
@@ -730,7 +732,7 @@ class TestOperators(UnitxtTestCase):
 
         exception_texts = [
             "Error processing instance '0' from stream 'test' in RemoveValues due to the exception above.",
-            "Failed to get 'label2' from {'label': 'b'} due to the exception above.",
+            "Failed to get 'label2' from instance due to the exception above.",
             """query "label2" did not match any item in dict:
 label (str):
     b

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -95,7 +95,7 @@ class TestOperators(UnitxtTestCase):
             inputs=inputs,
             exception_texts=[
                 "Error processing instance '0' from stream 'test' in MapInstanceValues due to the exception above.",
-                "'process_every_field' == True is allowed only when for fields whose values are lists, but value of field 'a' is '1'",
+                "'process_every_field' == True is allowed only for fields whose values are lists, but value of field 'a' is '1'",
             ],
             tester=self,
         )
@@ -106,7 +106,7 @@ class TestOperators(UnitxtTestCase):
             inputs=[{"a": "3", "b": "4"}],
             exception_texts=[
                 "Error processing instance '0' from stream 'test' in MapInstanceValues due to the exception above.",
-                "\"value '3' in field 'a' is not found in mapper '{'1': 'hi', '2': 'bye'}'\"",
+                "\"value '3', the string representation of the value in field 'a', is not found in mapper '{'1': 'hi', '2': 'bye'}'\"",
             ],
             tester=self,
         )
@@ -137,7 +137,7 @@ class TestOperators(UnitxtTestCase):
             inputs=[{"a": [1, 2, 3, 4], "b": 2}],
             exception_texts=[
                 "Error processing instance '0' from stream 'test' in MapInstanceValues due to the exception above.",
-                "\"value '3' in field 'a' is not found in mapper '{'1': 'hi', '2': 'bye'}'\"",
+                "\"value '3', the string representation of the value in field 'a', is not found in mapper '{'1': 'hi', '2': 'bye'}'\"",
             ],
             tester=self,
         )

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -93,7 +93,10 @@ class TestOperators(UnitxtTestCase):
         check_operator_exception(
             operator=MapInstanceValues(mappers=mappers, process_every_value=True),
             inputs=inputs,
-            exception_text="Error processing instance '0' from stream 'test' in MapInstanceValues due to: 'process_every_field' == True is allowed only when all fields which have mappers, i.e., ['a'] are lists. Instance = {'a': '1', 'b': '2'}",
+            exception_texts=[
+                "Error processing instance '0' from stream 'test' in MapInstanceValues due to the exception above.",
+                "'process_every_field' == True is allowed only when all fields which have mappers, i.e., ['a'] are lists. Instance = {'a': '1', 'b': '2'}",
+            ],
             tester=self,
         )
 
@@ -101,7 +104,10 @@ class TestOperators(UnitxtTestCase):
         check_operator_exception(
             operator=MapInstanceValues(mappers=mappers),
             inputs=[{"a": "3", "b": "4"}],
-            exception_text="Error processing instance '0' from stream 'test' in MapInstanceValues due to: \"value '3' in instance '{'a': '3', 'b': '4'}' is not found in mapper '{'1': 'hi', '2': 'bye'}', associated with field 'a'.\"",
+            exception_texts=[
+                "Error processing instance '0' from stream 'test' in MapInstanceValues due to the exception above.",
+                "\"value '3' in instance '{'a': '3', 'b': '4'}' is not found in mapper '{'1': 'hi', '2': 'bye'}', associated with field 'a'.\"",
+            ],
             tester=self,
         )
 
@@ -129,7 +135,10 @@ class TestOperators(UnitxtTestCase):
         check_operator_exception(
             operator=MapInstanceValues(mappers=mappers, process_every_value=True),
             inputs=[{"a": [1, 2, 3, 4], "b": 2}],
-            exception_text="Error processing instance '0' from stream 'test' in MapInstanceValues due to: \"value '3' in instance '{'a': ['hi', 'bye', 3, 4], 'b': 2}' is not found in mapper '{'1': 'hi', '2': 'bye'}', associated with field 'a'.\"",
+            exception_texts=[
+                "Error processing instance '0' from stream 'test' in MapInstanceValues due to the exception above.",
+                "\"value '3' in instance '{'a': ['hi', 'bye', 3, 4], 'b': 2}' is not found in mapper '{'1': 'hi', '2': 'bye'}', associated with field 'a'.\"",
+            ],
             tester=self,
         )
         # Test mapping of lists to lists
@@ -331,13 +340,13 @@ class TestOperators(UnitxtTestCase):
         check_operator_exception(
             operator=FilterByCondition(values={"d": "5"}, condition="eq"),
             inputs=inputs,
-            exception_text=exception_text,
+            exception_texts=[exception_text],
             tester=self,
         )
         check_operator_exception(
             operator=FilterByExpression(expression="d['e'] == 5"),
             inputs=inputs,
-            exception_text="name 'd' is not defined",
+            exception_texts=["name 'd' is not defined"],
             tester=self,
         )
 
@@ -447,7 +456,9 @@ class TestOperators(UnitxtTestCase):
                 error_on_filtered_all=True,
             ),
             inputs=inputs,
-            exception_text="FilterByExpression filtered out every instance in stream 'test'. If this is intended set error_on_filtered_all=False",
+            exception_texts=[
+                "FilterByExpression filtered out every instance in stream 'test'. If this is intended set error_on_filtered_all=False"
+            ],
             tester=self,
         )
 
@@ -534,16 +545,14 @@ class TestOperators(UnitxtTestCase):
         check_operator(operator=operator, inputs=inputs, targets=targets, tester=self)
         operator = ExecuteExpression(expression="f'{a} {b}'", to_field="c")
         check_operator(operator=operator, inputs=inputs, targets=targets, tester=self)
-        with self.assertRaises(ValueError) as ve:
-            check_operator(
-                operator=operator,
-                inputs=[{"x": 2, "y": 3}],
-                targets=targets,
-                tester=self,
-            )
-        self.assertEqual(
-            "Error processing instance '0' from stream 'test' in ExecuteExpression due to: name 'a' is not defined",
-            str(ve.exception),
+        check_operator_exception(
+            operator=operator,
+            inputs=[{"x": 2, "y": 3}],
+            exception_texts=[
+                "Error processing instance '0' from stream 'test' in ExecuteExpression due to the exception above.",
+                "name 'a' is not defined",
+            ],
+            tester=self,
         )
 
         inputs = [{"json_string": '{"A":"a_value", "B":"b_value"}'}]
@@ -612,11 +621,15 @@ class TestOperators(UnitxtTestCase):
         inputs = [
             {"label": "b"},
         ]
-        exception_text = "Error processing instance '0' from stream 'test' in Intersect due to: Failed to process 'label' from {'label': 'b'} due to : The value in field is not a list but 'b'"
+        exception_texts = [
+            "Error processing instance '0' from stream 'test' in Intersect due to the exception above.",
+            "Failed to process 'label' from {'label': 'b'} due to the exception above.",
+            "The value in field is not a list but 'b'",
+        ]
         check_operator_exception(
             operator=Intersect(field="label", allowed_values=["c"]),
             inputs=inputs,
-            exception_text=exception_text,
+            exception_texts=exception_texts,
             tester=self,
         )
 
@@ -703,22 +716,30 @@ class TestOperators(UnitxtTestCase):
         inputs = [
             {"label": "b"},
         ]
-        exception_text = "Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to process 'label' from {'label': 'b'} due to : The value in field is not a list but 'b'"
+        exception_texts = [
+            "Error processing instance '0' from stream 'test' in RemoveValues due to the exception above.",
+            "Failed to process 'label' from {'label': 'b'} due to the exception above.",
+            "The value in field is not a list but 'b'",
+        ]
         check_operator_exception(
             operator=RemoveValues(field="label", unallowed_values=["c"]),
             inputs=inputs,
-            exception_text=exception_text,
+            exception_texts=exception_texts,
             tester=self,
         )
 
-        exception_text = """Error processing instance '0' from stream 'test' in RemoveValues due to: Failed to get 'label2' from {'label': 'b'} due to : query "label2" did not match any item in dict:
+        exception_texts = [
+            "Error processing instance '0' from stream 'test' in RemoveValues due to the exception above.",
+            "Failed to get 'label2' from {'label': 'b'} due to the exception above.",
+            """query "label2" did not match any item in dict:
 label (str):
     b
-"""
+""",
+        ]
         check_operator_exception(
             operator=RemoveValues(field="label2", unallowed_values=["c"]),
             inputs=inputs,
-            exception_text=exception_text,
+            exception_texts=exception_texts,
             tester=self,
         )
 
@@ -766,7 +787,11 @@ label (str):
         check_operator_exception(
             operator=ApplyOperatorsField(operators_field="d"),
             inputs=inputs,
-            exception_text="Error processing instance '0' from stream 'test' in ApplyOperatorsField due to: No operators found in field 'd', and no default operators provided.",
+            exception_texts=[
+                "Error processing instance '0' from stream 'test' in ApplyOperatorsField due to the exception above.",
+                "No operators found in field 'd', and no default operators provided.",
+            ],
+            tester=self,
         )
         # check default operators:
         inputs = [
@@ -2266,6 +2291,18 @@ label (str):
             tester=self,
         )
 
+    def test_copy_string_to_string_error(self):
+        inputs = [{"source": "hello", "task_data": 3}]
+
+        targets = [{"source": "hello", "task_data": {"source": "hello"}}]
+
+        check_operator(
+            operator=Copy(field="source", to_field="task_data/source"),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
     def test_copy_paste_same_name2(self):
         inputs = [
             {"a": "test"},
@@ -2306,17 +2343,20 @@ label (str):
         )
 
         inputs = [{"prediction": "red", "references": "blue"}]
-        exception_text = """Error processing instance '0' from stream 'test' in EncodeLabels due to: query \"references/*\" did not match any item in dict:
+        exception_texts = [
+            """Error processing instance '0' from stream 'test' in EncodeLabels due to the exception above.""",
+            """query \"references/*\" did not match any item in dict:
 prediction (str):
     red
 references (str):
     blue
-"""
+""",
+        ]
         check_operator_exception(
             operator=EncodeLabels(fields=["references/*", "prediction"]),
             inputs=inputs,
             tester=self,
-            exception_text=exception_text,
+            exception_texts=exception_texts,
         )
 
     def test_join_str(self):

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -95,7 +95,7 @@ class TestOperators(UnitxtTestCase):
             inputs=inputs,
             exception_texts=[
                 "Error processing instance '0' from stream 'test' in MapInstanceValues due to the exception above.",
-                "'process_every_field' == True is allowed only when all fields which have mappers, i.e., ['a'] are lists. Instance = {'a': '1', 'b': '2'}",
+                "'process_every_field' == True is allowed only when for fields whose values are lists, but value of field 'a' is '1'",
             ],
             tester=self,
         )

--- a/tests/library/test_templates.py
+++ b/tests/library/test_templates.py
@@ -949,8 +949,8 @@ class TestTemplates(UnitxtTestCase):
         with self.assertRaises(ValueError) as ve:
             check_operator(template, inputs, targets, tester=self)
         self.assertIn(
-            "Error processing instance '0' from stream 'test' in MultipleChoiceTemplate due to: Available input fields are [numerals, choices, text] but MultipleChoiceTemplate.input_format format requires a different ones: 'Text: {no_text}, Choices: {no_choices}.'",
-            str(ve.exception),
+            "Available input fields are [numerals, choices, text] but MultipleChoiceTemplate.input_format format requires a different ones: 'Text: {no_text}, Choices: {no_choices}.'",
+            str(ve.exception.__cause__),
         )
 
     def test_multiple_choice_template_with_shuffle(self):
@@ -1048,8 +1048,8 @@ class TestTemplates(UnitxtTestCase):
         with self.assertRaises(ValueError) as ve:
             check_operator(template, inputs, targets, tester=self)
         self.assertIn(
-            "Error processing instance '0' from stream 'test' in MultipleChoiceTemplate due to: Available input fields are [numerals, choices, text] but MultipleChoiceTemplate.input_format format requires a different ones: 'Text: {no_text}, Choices: {no_choices}.'",
-            str(ve.exception),
+            "Available input fields are [numerals, choices, text] but MultipleChoiceTemplate.input_format format requires a different ones: 'Text: {no_text}, Choices: {no_choices}.'",
+            str(ve.exception.__cause__),
         )
 
     def test_key_val_template_simple(self):


### PR DESCRIPTION
Up to now, exceptions texts were concatinated to create long (unreadble) error message.  This change makes sure each level adds only new information and refers to the causing exceptio