### PR TITLE
not_exist_ok for dict_set only allows to add a non existing key to a dictionary, or non existing entry to a list. Not a whole nested structure implied by the query

### DIFF
--- a/prepare/cards/mmmu.py
+++ b/prepare/cards/mmmu.py
@@ -1,7 +1,7 @@
 from unitxt.blocks import LoadHF, TaskCard
 from unitxt.catalog import add_to_catalog
 from unitxt.collections_operators import Filter
-from unitxt.operators import ListFieldValues, MapValues
+from unitxt.operators import ListFieldValues, MapValues, SetEmptyDictIfDoesNotExist
 from unitxt.processors import LiteralEval, Lower
 from unitxt.splitters import RenameSplits
 from unitxt.string_operators import MapReplace
@@ -47,6 +47,7 @@ for name in config_names:
         ),
         preprocess_steps=[
             RenameSplits(mapper={"dev": "train", "validation": "test"}),
+            SetEmptyDictIfDoesNotExist(field="media"),
             ListFieldValues(
                 fields=[f"image_{i}" for i in range(1, 8)], to_field="media/images"
             ),

--- a/prepare/metrics/normalized_sacrebleu.py
+++ b/prepare/metrics/normalized_sacrebleu.py
@@ -1,6 +1,6 @@
 from unitxt import add_to_catalog
 from unitxt.metrics import MetricPipeline, NormalizedSacrebleu
-from unitxt.operators import Copy, MapInstanceValues
+from unitxt.operators import Copy, MapInstanceValues, SetEmptyDictIfDoesNotExist
 from unitxt.processors import Lower
 from unitxt.test_utils.metrics import test_metric
 
@@ -30,6 +30,7 @@ metric = MetricPipeline(
     main_score="sacrebleu",
     prediction_type=str,
     preprocess_steps=[
+        SetEmptyDictIfDoesNotExist(field="task_data"),
         Copy(
             field="task_data/target_language",
             to_field="task_data/tokenize",

--- a/prepare/metrics/unnormalized_sacrebleu.py
+++ b/prepare/metrics/unnormalized_sacrebleu.py
@@ -1,11 +1,12 @@
 from unitxt import add_to_catalog
 from unitxt.metrics import HuggingfaceMetric, MetricPipeline
-from unitxt.operators import Copy, MapInstanceValues
+from unitxt.operators import Copy, MapInstanceValues, SetEmptyDictIfDoesNotExist
 from unitxt.test_utils.metrics import test_metric
 
 metric = MetricPipeline(
     main_score="sacrebleu",
     preprocess_steps=[
+        SetEmptyDictIfDoesNotExist(field="task_data"),
         Copy(
             field="task_data/target_language",
             to_field="task_data/tokenize",

--- a/src/unitxt/catalog/cards/mmmu/accounting.json
+++ b/src/unitxt/catalog/cards/mmmu/accounting.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/agriculture.json
+++ b/src/unitxt/catalog/cards/mmmu/agriculture.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/architecture_and_engineering.json
+++ b/src/unitxt/catalog/cards/mmmu/architecture_and_engineering.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/art.json
+++ b/src/unitxt/catalog/cards/mmmu/art.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/art_theory.json
+++ b/src/unitxt/catalog/cards/mmmu/art_theory.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/basic_medical_science.json
+++ b/src/unitxt/catalog/cards/mmmu/basic_medical_science.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/biology.json
+++ b/src/unitxt/catalog/cards/mmmu/biology.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/chemistry.json
+++ b/src/unitxt/catalog/cards/mmmu/chemistry.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/clinical_medicine.json
+++ b/src/unitxt/catalog/cards/mmmu/clinical_medicine.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/computer_science.json
+++ b/src/unitxt/catalog/cards/mmmu/computer_science.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/design.json
+++ b/src/unitxt/catalog/cards/mmmu/design.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/diagnostics_and_laboratory_medicine.json
+++ b/src/unitxt/catalog/cards/mmmu/diagnostics_and_laboratory_medicine.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/economics.json
+++ b/src/unitxt/catalog/cards/mmmu/economics.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/electronics.json
+++ b/src/unitxt/catalog/cards/mmmu/electronics.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/energy_and_power.json
+++ b/src/unitxt/catalog/cards/mmmu/energy_and_power.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/finance.json
+++ b/src/unitxt/catalog/cards/mmmu/finance.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/geography.json
+++ b/src/unitxt/catalog/cards/mmmu/geography.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/history.json
+++ b/src/unitxt/catalog/cards/mmmu/history.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/literature.json
+++ b/src/unitxt/catalog/cards/mmmu/literature.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/manage.json
+++ b/src/unitxt/catalog/cards/mmmu/manage.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/marketing.json
+++ b/src/unitxt/catalog/cards/mmmu/marketing.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/materials.json
+++ b/src/unitxt/catalog/cards/mmmu/materials.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/math.json
+++ b/src/unitxt/catalog/cards/mmmu/math.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/mechanical_engineering.json
+++ b/src/unitxt/catalog/cards/mmmu/mechanical_engineering.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/music.json
+++ b/src/unitxt/catalog/cards/mmmu/music.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/pharmacy.json
+++ b/src/unitxt/catalog/cards/mmmu/pharmacy.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/physics.json
+++ b/src/unitxt/catalog/cards/mmmu/physics.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/psychology.json
+++ b/src/unitxt/catalog/cards/mmmu/psychology.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/public_health.json
+++ b/src/unitxt/catalog/cards/mmmu/public_health.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/cards/mmmu/sociology.json
+++ b/src/unitxt/catalog/cards/mmmu/sociology.json
@@ -17,6 +17,10 @@
             }
         },
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "media"
+        },
+        {
             "__type__": "list_field_values",
             "fields": [
                 "image_1",

--- a/src/unitxt/catalog/metrics/normalized_sacrebleu.json
+++ b/src/unitxt/catalog/metrics/normalized_sacrebleu.json
@@ -4,6 +4,10 @@
     "prediction_type": "str",
     "preprocess_steps": [
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "task_data"
+        },
+        {
             "__type__": "copy",
             "field": "task_data/target_language",
             "to_field": "task_data/tokenize",

--- a/src/unitxt/catalog/metrics/sacrebleu.json
+++ b/src/unitxt/catalog/metrics/sacrebleu.json
@@ -3,6 +3,10 @@
     "main_score": "sacrebleu",
     "preprocess_steps": [
         {
+            "__type__": "set_empty_dict_if_does_not_exist",
+            "field": "task_data"
+        },
+        {
             "__type__": "copy",
             "field": "task_data/target_language",
             "to_field": "task_data/tokenize",

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -26,10 +26,8 @@ def is_wildcard(string):
 # A -> name | * | non-neg-int
 # name -> a string satisfying is_name above.
 #
-## to delete:  * matches ALL members (each and every) of a list or a dictionary element in input dictionary,
-#
-# a path p in dictionary dic, leading to element (aka subfield) el, is said to match query qpath
-# (also said reciprocately: query qpath matches path p in dic),
+# A path p in dictionary dic, leading to element (aka subfield) el, is said to match query qpath
+# (alternatively said: query qpath matches path p in dic),
 # if the following recursively defined condition is satisfied:
 # (1) the prefix of length 0 of qpath (i.e., pref = "") matches the empty path in dic, the path leading to the whole of dic.
 # (2) Denoting by el the element in dic lead to by the path in dic that matches the prefix pref of qpath
@@ -297,8 +295,10 @@ def get_values(
 
 # going down from current_element via query[index_into_query]
 # returns the updated current_element.
-# if fixed_parameters["generate_if_not_exists"] (reflecting not_exist_ok of dict_set)
-# and the last component is missing from dic -- generate it. But not any earier component.
+# if not_exist_ok and the last component is missing from dic -- generate it. But not any earier component.
+# That is, through processing the query, that most that can be added to the processed dic, is a field in a
+# dictionary or an entry in a list (extending an existing list). If more is needed to add to dic, pass it
+# through the value being set, which can be anything, structured and complex, or simple.
 def set_values(
     current_element: Any,
     value: Any,

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -278,7 +278,8 @@ def get_values(
         return (len(to_ret) > 0 or index_into_query == -1, to_ret)
         # when * is the last component, it refers to 'all the contents' of an empty list being current_element.
     # next_component is indx or name, current_element must be a list or a dict
-    if is_index(component) and isinstance(current_element, list):
+    if is_index(component) and isinstance(current_element, (list, str)):
+        # for backward compatibility, use the fact that also a string can be indexed into
         component = int(component)
     try:
         success, new_val = get_values(

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -24,15 +24,19 @@ def is_wildcard(string):
 # formal definition of qpath syntax by which a query is specified:
 # qpath -> A (/A)*
 # A -> name | * | non-neg-int
-# name -> name.matches()
-#  * matches ALL members (each and every) of a list or a dictionary element in input dictionary,
+# name -> a string satisfying is_name above.
 #
-# a path p in dictionary dic is said to match query qpath if it satisfies the following recursively
-# defined condition:
-# (1) the prefix of length 0 of p (i.e., pref = "") matches the whole of dic. Also denoted here: pref leads to dic.
-# (2) Denoting by el the element in dic lead to by prefix pref of qpath (el must be a list or dictionary),
+## to delete:  * matches ALL members (each and every) of a list or a dictionary element in input dictionary,
+#
+# a path p in dictionary dic, leading to element (aka subfield) el, is said to match query qpath
+# (also said reciprocately: query qpath matches path p in dic),
+# if the following recursively defined condition is satisfied:
+# (1) the prefix of length 0 of qpath (i.e., pref = "") matches the empty path in dic, the path leading to the whole of dic.
+# (2) Denoting by el the element in dic lead to by the path in dic that matches the prefix pref of qpath
+# (el must be a list or dictionary, since led to by a path matching a prefix of qpath, and not the whole of qpath),
 # and by A (as the definition above) the component, DIFFERENT from *, in qpath, that follows pref, the element
-# lead to by pref/A is el[A]. If el[A] is missing from dic, then no path in dic matches prefix pref/A of qpath,
+# lead to by the path in dic matching query pref/A is el[A]. If el[A] is missing from dic, then no path in dic matches
+# pref/A, that is either a longer prefix of qpath, or the whole of qpath,
 # and hence no path in dic matches query qpath. (E.g., when el is a list, A must match indx, and its
 # int value should be smaller than len(el) in order for the path in dic leading to element el[A] to match pref/A)
 # (3) Denoting as in (2), now with A == * : when el is a list, each and every element in the set:
@@ -46,7 +50,7 @@ def is_wildcard(string):
 #
 # Thus, for a query with no *, dic contains at most one element the path to which matches the query.
 # If there is such one in dic - the function (either dict_get, dict_set, or dict_delete) operates on
-# that element according to its arguments, other than not_exist_ok
+# that element according to its arguments, other than not_exist_ok.
 # If there is not any such element in dic - the function throws or does not throw an exception, depending
 # on flag not_exist_ok.
 # For a query with *, there could be up to as many as there are values to match the *
@@ -56,9 +60,9 @@ def is_wildcard(string):
 # operation (read, set, or delete) to each and every element el in dic, the path to which matches the query in whole,
 # and reads a value from, or sets a new value to, or pops the value out from dic.
 #
-# If no path in dic matches the query, then # if not_exist_ok=False, the function throws an exception;
+# If no path in dic matches the query, then if not_exist_ok=False, the function throws an exception;
 # but if not_exist_ok=True, the function returns a default value (dict_get) or does nothing (dict_delete)
-# or generates all the needed missing suffixes (dict_set, see details below).
+# or generates the needed missing suffix, when consists of at most one component (dict_set, see details below).
 #
 # Each of the functions below scans the dic-tree recursively.
 # It swallows all exceptions, in order to not stop prematurely, before the scan
@@ -66,9 +70,7 @@ def is_wildcard(string):
 
 
 # validate and normalizes into components
-def validate_query_and_break_to_components(
-    query: str, allow_int_index=True
-) -> List[str]:
+def validate_query_and_break_to_components(query: str) -> List[str]:
     if not isinstance(query, str) or len(query) == 0:
         raise ValueError(
             f"invalid query: either not a string or an empty string: {query}"
@@ -85,25 +87,17 @@ def validate_query_and_break_to_components(
     components = query.split("/")
     components = [component.strip() for component in components]
     for component in components:
-        if not (
-            is_name(component)
-            or is_wildcard(component)
-            or (is_index(component) and allow_int_index)
-        ):
+        if not (is_name(component) or is_wildcard(component)):
             raise ValueError(
                 f"Component {component} in input query is none of: valid field-name, non-neg-int, or '*'"
             )
     return components
 
 
-def is_subpath(subpath, fullpath, allow_int_index=True):
+def is_subpath(subpath, fullpath):
     # Split the paths into individual components
-    subpath_components = validate_query_and_break_to_components(
-        subpath, allow_int_index=allow_int_index
-    )
-    fullpath_components = validate_query_and_break_to_components(
-        fullpath, allow_int_index=allow_int_index
-    )
+    subpath_components = validate_query_and_break_to_components(subpath)
+    fullpath_components = validate_query_and_break_to_components(fullpath)
 
     # Check if the full path starts with the subpath
     return fullpath_components[: len(subpath_components)] == subpath_components
@@ -111,7 +105,9 @@ def is_subpath(subpath, fullpath, allow_int_index=True):
 
 # We are on current_element, going down from it via query[index_into_query].
 # query comprising at least two components is assumed. dic_delete worries about
-# single component queries without invoking qpath_delete
+# single component queries without invoking qpath_delete.
+# user wants to delete the element led to by the whole query from the element led to
+# by the prefix of the query consisting of all but the last component.
 # Returned value is a pair (boolean, element_of_input dic or None)
 # the first component signals whether the second is yielded from a reach to the query end,
 # or rather -- a result of a failure before query end has been reached.
@@ -121,17 +117,17 @@ def delete_values(
     query: List[str],
     index_into_query: int,
     remove_empty_ancestors=False,
-    allow_int_index=True,
 ) -> Tuple[bool, Any]:
     component = query[index_into_query]
     if index_into_query == -1:
+        # need to delete a subelement, identified by component, of current_element.
         if is_wildcard(component):
             # delete all members of the list or dict
             current_element = [] if isinstance(current_element, list) else {}
             return (True, current_element)
         # component is a either a dictionary key or an index into a list,
         # pop the respective element from current_element
-        if is_index(component) and allow_int_index:
+        if is_index(component) and isinstance(current_element, list):
             component = int(component)
         try:
             current_element.pop(component)
@@ -163,7 +159,6 @@ def delete_values(
                     query=query,
                     index_into_query=index_into_query + 1,
                     remove_empty_ancestors=remove_empty_ancestors,
-                    allow_int_index=allow_int_index,
                 )
                 if not success:
                     continue
@@ -178,7 +173,7 @@ def delete_values(
         return (any_success, current_element)
 
     # current component is index into a list or a key into a dictionary
-    if is_index(component) and allow_int_index:
+    if is_index(component) and isinstance(current_element, list):
         component = int(component)
     try:
         success, new_val = delete_values(
@@ -186,7 +181,6 @@ def delete_values(
             query=query,
             index_into_query=index_into_query + 1,
             remove_empty_ancestors=remove_empty_ancestors,
-            allow_int_index=allow_int_index,
         )
         if not success:
             return (False, None)
@@ -204,7 +198,6 @@ def dict_delete(
     query: str,
     not_exist_ok: bool = False,
     remove_empty_ancestors=False,
-    allow_int_index=True,
 ):
     # We remove from dic the value from each and every element lead to by a path matching the query.
     # If remove_empty_ancestors=True, and the removal of any such value leaves its containing element (list or dict)
@@ -225,9 +218,7 @@ def dict_delete(
         dic.pop(query.strip())
         return
 
-    qpath = validate_query_and_break_to_components(
-        query, allow_int_index=allow_int_index
-    )
+    qpath = validate_query_and_break_to_components(query)
 
     try:
         success, new_val = delete_values(
@@ -235,7 +226,6 @@ def dict_delete(
             query=qpath,
             index_into_query=(-1) * len(qpath),
             remove_empty_ancestors=remove_empty_ancestors,
-            allow_int_index=allow_int_index,
         )
 
         if success:
@@ -259,7 +249,6 @@ def get_values(
     current_element: Any,
     query: List[str],
     index_into_query: int,
-    allow_int_index=True,
 ) -> Tuple[bool, Any]:
     # going down from current_element through query[index_into_query].
     if index_into_query == 0:
@@ -282,7 +271,6 @@ def get_values(
                     sub_element,
                     query,
                     index_into_query + 1,
-                    allow_int_index=allow_int_index,
                 )
                 if success:
                     to_ret.append(val)
@@ -292,14 +280,13 @@ def get_values(
         return (len(to_ret) > 0 or index_into_query == -1, to_ret)
         # when * is the last component, it refers to 'all the contents' of an empty list being current_element.
     # next_component is indx or name, current_element must be a list or a dict
-    if is_index(component) and allow_int_index:
+    if is_index(component) and isinstance(current_element, list):
         component = int(component)
     try:
         success, new_val = get_values(
             current_element[component],
             query,
             index_into_query + 1,
-            allow_int_index=allow_int_index,
         )
         if success:
             return (True, new_val)
@@ -309,38 +296,34 @@ def get_values(
 
 
 # going down from current_element via query[index_into_query]
-# returns the updated current_element
+# returns the updated current_element.
+# if fixed_parameters["generate_if_not_exists"] (reflecting not_exist_ok of dict_set)
+# and the last component is missing from dic -- generate it. But not any earier component.
 def set_values(
     current_element: Any,
     value: Any,
     index_into_query: int,
-    fixed_parameters: dict,
+    query: List[str],
+    not_exist_ok: bool,
     set_multiple: bool = False,
-    allow_int_index=True,
 ) -> Tuple[bool, Any]:
     if index_into_query == 0:
         return (True, value)  # matched query all along!
 
-    # current_element should be a list or dict: a containing element
-    if current_element is not None and not isinstance(current_element, (list, dict)):
-        current_element = None  # give it a chance to become what is needed, if allowed
-
-    if current_element is None and not fixed_parameters["generate_if_not_exists"]:
-        return (False, None)
-
-    component = fixed_parameters["query"][index_into_query]
+    component = query[index_into_query]
     if component == "*":
-        if current_element is not None and set_multiple:
+        if set_multiple:
             if isinstance(current_element, dict) and len(current_element) != len(value):
                 return (False, None)
             if isinstance(current_element, list) and len(current_element) > len(value):
                 return (False, None)
             if len(current_element) < len(value):
-                if not fixed_parameters["generate_if_not_exists"]:
+                if not not_exist_ok or index_into_query < -1:
                     return (False, None)
-                # current_element must be a list, extend current_element to the length needed
+                # current_element must be a list, extend current_element to the length needed, but only
+                # if at the last component of the query
                 current_element.extend([None] * (len(value) - len(current_element)))
-        if current_element is None or current_element == []:
+        if current_element == []:
             current_element = [None] * (
                 len(value)
                 if set_multiple
@@ -362,9 +345,9 @@ def set_values(
                     current_element=current_element[keys[i]],
                     value=value[i] if set_multiple else value,
                     index_into_query=index_into_query + 1,
+                    query=query,
+                    not_exist_ok=not_exist_ok,
                     set_multiple=False,  # now used, not allowed again,
-                    fixed_parameters=fixed_parameters,
-                    allow_int_index=allow_int_index,
                 )
                 if not success:
                     continue
@@ -379,29 +362,23 @@ def set_values(
         )
 
     # component is an index into a list or a key into a dictionary
-    if is_index(component) and allow_int_index:
-        if current_element is None or not isinstance(current_element, list):
-            if not fixed_parameters["generate_if_not_exists"]:
-                return (False, None)
-            current_element = []
+    if is_index(component) and isinstance(current_element, list):
         # current_element is a list
         component = int(component)
         if component >= len(current_element):
-            if not fixed_parameters["generate_if_not_exists"]:
+            if not not_exist_ok or index_into_query < -1:
+                # preparing a new place for the value to set is only allowed at the end of the query
                 return (False, None)
             # extend current_element to the length needed
             current_element.extend([None] * (component + 1 - len(current_element)))
         next_current_element = current_element[component]
     else:  # component is a key into a dictionary
-        if current_element is None or not isinstance(current_element, dict):
-            if not fixed_parameters["generate_if_not_exists"]:
-                return (False, None)
-            current_element = {}
-        if (
-            component not in current_element
-            and not fixed_parameters["generate_if_not_exists"]
-        ):
+        if not isinstance(current_element, dict):
             return (False, None)
+        if component not in current_element:
+            if not not_exist_ok or index_into_query < -1:
+                # preparing a new place for the value to set is only allowed at the end of the query
+                return (False, None)
         next_current_element = (
             None if component not in current_element else current_element[component]
         )
@@ -410,9 +387,9 @@ def set_values(
             current_element=next_current_element,
             value=value,
             index_into_query=index_into_query + 1,
-            fixed_parameters=fixed_parameters,
+            query=query,
+            not_exist_ok=not_exist_ok,
             set_multiple=set_multiple,
-            allow_int_index=allow_int_index,
         )
         if success:
             current_element[component] = new_val
@@ -428,7 +405,6 @@ def dict_get(
     query: str,
     not_exist_ok: bool = False,
     default: Any = None,
-    allow_int_index=True,
 ):
     if len(query.strip()) == 0:
         return dic
@@ -439,9 +415,7 @@ def dict_get(
     if isinstance(dic, dict) and query.strip() in dic:
         return dic[query.strip()]
 
-    components = validate_query_and_break_to_components(
-        query, allow_int_index=allow_int_index
-    )
+    components = validate_query_and_break_to_components(query)
     if len(components) > 1:
         try:
             success, values = get_values(dic, components, -1 * len(components))
@@ -449,14 +423,14 @@ def dict_get(
                 return values
         except Exception as e:
             raise ValueError(
-                f'query "{query}" did not match any item in dict:\n{construct_dict_str(dic)}'
+                f"query '{query}' did not match any item in dict:\n{construct_dict_str(dic)}"
             ) from e
 
         if not_exist_ok:
             return default
 
         raise ValueError(
-            f'query "{query}" did not match any item in dict:\n{construct_dict_str(dic)}'
+            f"query '{query}' did not match any item in dict:\n{construct_dict_str(dic)}"
         )
 
     # len(components) == 1
@@ -467,7 +441,7 @@ def dict_get(
         return default
 
     raise ValueError(
-        f'query "{query}" did not match any item in dict:\n{construct_dict_str(dic)}'
+        f"query '{query}' did not match any item in dict:\n{construct_dict_str(dic)}"
     )
 
 
@@ -478,24 +452,8 @@ def dict_get(
 # any new elements into 'dic'. Rather - it just sets the 'value' arg to each and every element the path to which matches
 # the query. That 'value' arg, again, can be complex and involved, a dictionary or a list, or scalar, or whatever.
 #
-# When not_exist_ok = True, the processing itself is allowed to generate new containing elements (dictionaries, lists, or elements
-# therein) into dictionary 'dic', new containing elements such that, at the end of the processing, 'dic' will contain at
-# least one element the path to which matches 'query', provided that no existing value in 'dic' is modified nor popped out,
-# other than the values sitting on the path along 'query' in whole.
-# This generation is defined as follows.
-# Having generated what is needed to have in dic an element el, lead to by prefix pref of 'query', and A (as above) is the
-# component that follows pref in 'query' (i.e., pref/A is a prefix of 'query', longer than pref by one component) then:
-# (1) if indx.match(A), and el existed in 'dic' before dict_set was invoked, then if el is not a list, generate an empty
-# list for it: []. If len(el)>A, proceed to element el[A], and continue recursively. If len(el) <= A, extend
-# el with [None]*(A+1-len(el)), and continue recursively from there, with elements that surely did not exist in dic
-# before dict_set was invoked. If el did not exist in 'dic' before dict_set was invoked, then a whole new list [None]*(A+1)
-# is generated, and continue from there recursively.
-# (2) if not indx but name.match(A), continue in analogy with (1), with el being a dictionary now.
-# (3) if A is '*', and el already exists, continue into ALL el's existing sub_elements as above. if el was not existing
-# in dic before dict_set was invoked, which means it is None that we ride on from (1) or (2), then we generate
-# a new [None] List (only a list, not a dict, because we have no keys to offer), and continue as above
-# once the end of the query is thus reached, 'value' is returned backward on the recursion, and the elements
-# that were None for a while - reshape into the needed (dict or list) element.
+# When not_exist_ok = True, dict_set is allowed to generate a new key, or list element, in the element led to
+# by the prefix being all but the last component of the query. But not allowed to generate missing earlier components.
 #
 # If two or more (existing in input dic, or newly generated per not_exist_ok = True) paths in dic match the query
 # all the elements lead to by these paths are assigned copies of value.
@@ -506,12 +464,11 @@ def dict_get(
 # The processing of set_multiple=True applies to the first occurrence of * in the query, and only to it, and is
 # done as follows:
 # Let el denote the element lead to by prefix pref of 'query' down to one component preceding the first * in 'query'
-# (depending on not_exist_ok, el can be None). If el existed in dic before dict_set is invoked (el is not None) and
-# is not a list nor a dict, or is a list longer than len('value') or is a dict of len different from len('value'),
+# If el is not a list nor a dict, or is a list longer than len('value') or is a dict of len different from len('value'),
 # return a failure for prefix pref/*.
-# If el existed, and is a list shorted than len('value'), or did not exist at all, then if not_exist_ok= False,
-# return a failure for prefix pref/*. If not_exist_ok = True, then make el into a list of length
-# len('value') that starts with el (if existed) and continues into zero or more None-s, as many as needed.
+# If el is a list shorter than 'value', and not_exist_ok = False, return a failure for prefix pref/*.
+# If not_exist_ok = True, and * is the last component in the query, then make el into a list of length
+# len('value') that starts with el and continues into zero or more None-s, as many as needed.
 # Now that el (potentially wholly or partly generated just now) is a list of length len('value'), set value='value'[i]
 # as the target value for the i-th path that goes through el.
 # Such a breakdown of 'value' for set_multiple=True, is done only once - on the leftmost * in 'query'.
@@ -522,11 +479,10 @@ def dict_set(
     value: Any,
     not_exist_ok=True,
     set_multiple=False,
-    allow_int_index=True,
 ):  # sets dic to its new value
     if dic is None or not isinstance(dic, (list, dict)):
         raise ValueError(
-            f"Can not change dic that is either None or not a dict nor a list. Got dic = {dic}"
+            f"Can only change a dic that is either a dict or a list. Got dic = '{dic}'"
         )
 
     if query.strip() == "":
@@ -534,7 +490,7 @@ def dict_set(
         if isinstance(dic, dict):
             if value is None or not isinstance(value, dict):
                 raise ValueError(
-                    f"Through an empty query, trying to set a whole new value, {value}, to the whole of dic, {dic}, but value is not a dict"
+                    f"Through an empty query, trying to set a whole new value, '{value}', to the whole of dic, '{dic}', but value is not a dict"
                 )
             dic.clear()
             dic.update(value)
@@ -543,7 +499,7 @@ def dict_set(
         if isinstance(dic, list):
             if value is None or not isinstance(value, list):
                 raise ValueError(
-                    f"Through an empty query, trying to set a whole new value, {value}, to the whole of dic, {dic}, but value is not a list"
+                    f"Through an empty query, trying to set a whole new value, '{value}', to the whole of dic, '{dic}', but value is not a list"
                 )
             dic.clear()
             dic.extend(value)
@@ -556,27 +512,21 @@ def dict_set(
     if set_multiple:
         if value is None or not isinstance(value, list) or len(value) == 0:
             raise ValueError(
-                f"set_multiple=True, but value, {value}, can not be broken up, as either it is not a list or it is an empty list"
+                f"set_multiple=True, but value, '{value}', can not be broken up, as either it is not a list or it is an empty list"
             )
 
-    components = validate_query_and_break_to_components(
-        query, allow_int_index=allow_int_index
-    )
-    fixed_parameters = {
-        "query": components,
-        "generate_if_not_exists": not_exist_ok,
-    }
+    components = validate_query_and_break_to_components(query)
     try:
         success, val = set_values(
             current_element=dic,
             value=value,
             index_into_query=(-1) * len(components),
-            fixed_parameters=fixed_parameters,
+            query=components,
+            not_exist_ok=not_exist_ok,
             set_multiple=set_multiple,
-            allow_int_index=allow_int_index,
         )
-        if not success and not not_exist_ok:
-            raise ValueError(f"No path in dic {dic} matches query {query}.")
+        if not success:
+            raise ValueError(f"No path in dic '{dic}' matches query '{query}'.")
 
     except Exception as e:
-        raise ValueError(f"No path in dic {dic} matches query {query}.") from e
+        raise ValueError(f"No path in dic '{dic}' matches query '{query}'.") from e

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -296,8 +296,8 @@ def get_values(
 
 # going down from current_element via query[index_into_query]
 # returns the updated current_element.
-# if not_exist_ok and the last component is missing from dic -- generate that last component in that dic. 
-# But not any earier component. E.g., not that containing dict. 
+# if not_exist_ok and the last component is missing from dic -- generate that last component in that dic.
+# But not any earier component. E.g., not that containing dict.
 # That is, through processing the query, that most that can be added to the processed dic, is a field in a
 # dictionary or an entry in a list (extending an existing list). If more is needed to add to dic, pass it
 # through the value being set, which can be anything, structured and complex, or simple.
@@ -448,8 +448,9 @@ def dict_get(
 
 
 # dict_set sets a value, 'value', which by itself, can be a dict or list or scalar, into 'dic', to become the value of
-# the element the path from 'dic' head to which matches 'query'. (aka - 'the element specified by the query')
-# 'the element specified by the query' is thus either a key in a dictionary, or a list member specified by its index in the list.
+# the element the path from 'dic' head to which matches 'query' (aka - 'the element specified by the query').
+# 'the element specified by the query' is thus either a key in a dictionary element, or a list member specified by
+# its index in the list.
 # Unless otherwise specified (through 'not_exist_ok=True'), the processing of 'query' by dict_set does not generate
 # any new elements into 'dic'. Rather - it just sets the 'value' arg to each and every element the path to which matches
 # the query. That 'value' arg, again, can be complex and involved, a dictionary or a list, or scalar, or whatever.
@@ -457,8 +458,9 @@ def dict_get(
 # When not_exist_ok = True, dict_set is allowed to generate a new key, or list element, in the element led to
 # by the prefix being all but the last component of the query. But not allowed to generate missing earlier components.
 #
-# If two or more (existing in input dic, or newly generated per not_exist_ok = True) paths in dic match the query
-# all the elements lead to by these paths are assigned copies of value.
+# If two or more (existing in input dic, or newly generated per not_exist_ok = True) paths in dic match the query (two or
+# more paths can match queries that include * components), then all the elements lead to by these paths are assigned
+# copies of value.
 #
 # If set_multiple=True, 'value' must be a list, 'query' should contain at least one * , and there should be exactly
 # len(values) paths that match the query, and in this case, dict_set assigns one member of 'value' to each path.
@@ -484,7 +486,7 @@ def dict_set(
 ):  # sets dic to its new value
     if dic is None or not isinstance(dic, (list, dict)):
         raise ValueError(
-            f"Can only change a dic that is either a dict or a list. Got dic = '{dic}'"
+            f"Can only change arg dic that is either a dict or a list. Got dic = '{dic}'"
         )
 
     if query.strip() == "":

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -424,14 +424,14 @@ def dict_get(
                 return values
         except Exception as e:
             raise ValueError(
-                f"query '{query}' did not match any item in dict:\n{construct_dict_str(dic)}"
+                f"dict_get: query '{query}' did not match any item in dict:\n{construct_dict_str(dic)}"
             ) from e
 
         if not_exist_ok:
             return default
 
         raise ValueError(
-            f"query '{query}' did not match any item in dict:\n{construct_dict_str(dic)}"
+            f"dict_get: query '{query}' did not match any item in dict:\n{construct_dict_str(dic)}"
         )
 
     # len(components) == 1
@@ -527,7 +527,11 @@ def dict_set(
             set_multiple=set_multiple,
         )
         if not success:
-            raise ValueError(f"No path in dic '{dic}' matches query '{query}'.")
+            raise ValueError(
+                f"dict_set: query '{query}' did not match any item in dict:\n{construct_dict_str(dic)}"
+            )
 
     except Exception as e:
-        raise ValueError(f"No path in dic '{dic}' matches query '{query}'.") from e
+        raise ValueError(
+            f"dict_set: query '{query}' did not match any item in dict:\n{construct_dict_str(dic)}"
+        ) from e

--- a/src/unitxt/dict_utils.py
+++ b/src/unitxt/dict_utils.py
@@ -296,7 +296,8 @@ def get_values(
 
 # going down from current_element via query[index_into_query]
 # returns the updated current_element.
-# if not_exist_ok and the last component is missing from dic -- generate it. But not any earier component.
+# if not_exist_ok and the last component is missing from dic -- generate that last component in that dic. 
+# But not any earier component. E.g., not that containing dict. 
 # That is, through processing the query, that most that can be added to the processed dic, is a field in a
 # dictionary or an entry in a list (extending an existing list). If more is needed to add to dic, pass it
 # through the value being set, which can be anything, structured and complex, or simple.

--- a/src/unitxt/metric_utils.py
+++ b/src/unitxt/metric_utils.py
@@ -22,6 +22,7 @@ from .operators import (
     FlattenInstances,
     RecursiveCopy,
     Rename,
+    SetEmptyDictIfDoesNotExist,
 )
 from .register import _reset_env_local_catalogs, register_all_artifacts
 from .schema import UNITXT_DATASET_SCHEMA
@@ -81,6 +82,7 @@ _post_process_steps = SequentialOperator(
             to_field="raw_references",
             dont_apply_to_streams=[constants.inference_stream],
         ),
+        SetEmptyDictIfDoesNotExist(field="task_data"),
         RecursiveCopy(
             field="source",
             to_field="task_data/source",
@@ -327,6 +329,7 @@ class MetricRecipe(SequentialOperatorInitializer):
                 field="raw_references",
                 to_field="references",
             ),
+            SetEmptyDictIfDoesNotExist(field="task_data"),
             RecursiveCopy(
                 field="source",
                 to_field="task_data/source",

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -39,6 +39,7 @@ General Operators List:
 ------------------------
 """
 
+import json
 import operator
 import uuid
 import warnings
@@ -285,6 +286,9 @@ class SetEmptyDictIfDoesNotExist(InstanceOperator):
     ) -> Dict[str, Any]:
         if self.field not in instance:
             instance[self.field] = {}
+        if not isinstance(instance[self.field], dict):
+            assert isinstance(instance[self.field], str)
+            instance[self.field] = json.loads(instance[self.field])
         return instance
 
 

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -277,6 +277,17 @@ class Set(InstanceOperator):
         return instance
 
 
+class SetEmptyDictIfDoesNotExist(InstanceOperator):
+    field: str
+
+    def process(
+        self, instance: Dict[str, Any], stream_name: Optional[str] = None
+    ) -> Dict[str, Any]:
+        if self.field not in instance:
+            instance[self.field] = {}
+        return instance
+
+
 @deprecation(version="2.0.0", alternative=Set)
 class AddFields(Set):
     pass

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -456,6 +456,7 @@ class InstanceFieldOperator(InstanceOperator):
                 raise ValueError(
                     f"Failed to get '{from_field}' from instance due to the exception above."
                 ) from e
+
             try:
                 if self.process_every_value:
                     new_value = [

--- a/src/unitxt/standard.py
+++ b/src/unitxt/standard.py
@@ -9,7 +9,7 @@ from .error_utils import UnitxtError
 from .formats import Format, SystemFormat
 from .logging_utils import get_logger
 from .operator import SequentialOperator, SourceSequentialOperator, StreamingOperator
-from .operators import Set, StreamRefiner
+from .operators import Set, SetEmptyDictIfDoesNotExist, StreamRefiner
 from .recipe import Recipe
 from .schema import FinalizeDataset
 from .serializers import SingleTypeSerializer
@@ -294,6 +294,7 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
                     StreamRefiner(max_instances=self.loader_limit)
                 )
 
+        self.metadata.steps.append(SetEmptyDictIfDoesNotExist(field="recipe_metadata"))
         self.metadata.steps.append(
             Set(
                 fields={
@@ -356,6 +357,9 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
                     )
                 )
                 self.verbalization.steps.append(
+                    SetEmptyDictIfDoesNotExist(field="recipe_metadata")
+                )
+                self.verbalization.steps.append(
                     Set(fields={"recipe_metadata/num_demos": self.num_demos})
                 )
 
@@ -367,6 +371,9 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
                         sampler=self.sampler,
                         sample_sizes=self.num_demos,
                     )
+                )
+                self.verbalization.steps.append(
+                    SetEmptyDictIfDoesNotExist(field="recipe_metadata")
                 )
                 self.verbalization.steps.append(
                     GetLength(field="demos", to_field="recipe_metadata/num_demos")
@@ -387,6 +394,9 @@ class BaseRecipe(Recipe, SourceSequentialOperator):
                     )
                 )
         else:
+            self.verbalization.steps.append(
+                SetEmptyDictIfDoesNotExist(field="recipe_metadata")
+            )
             self.verbalization.steps.append(
                 Set(fields={"recipe_metadata/num_demos": 0})
             )

--- a/src/unitxt/templates.py
+++ b/src/unitxt/templates.py
@@ -221,6 +221,8 @@ class ApplyTemplate(InstanceOperator):
                 self.apply(template, demo_instance)
                 for demo_instance in instance[self.demos_field]
             ]
+        if "recipe_metadata" not in instance:
+            instance["recipe_metadata"] = {}
         dict_set(instance, "recipe_metadata/template", template)
         return self.apply(template, instance, stream_name)
 

--- a/src/unitxt/text_utils.py
+++ b/src/unitxt/text_utils.py
@@ -73,11 +73,11 @@ def construct_dict_str(d, indent=0, indent_delta=4, max_chars=None, keys=None):
     """Constructs a formatted string of a dictionary.
 
     Args:
-        d (dict): The dictionary to be formatted.
+        d (dict or list): The dictionary (or list) to be formatted.
         indent (int, optional): The current level of indentation. Defaults to 0.
         indent_delta (int, optional): The amount of spaces to add for each level of indentation. Defaults to 4.
         max_chars (int, optional): The maximum number of characters for each line. Defaults to terminal width - 10.
-        keys (List[Str], optional): the list of fields to print
+        keys (List[Str], optional): the list of fields (or indices) to print
     """
     max_chars = max_chars or shutil.get_terminal_size()[0] - 10
     indent_str = " " * indent
@@ -85,9 +85,19 @@ def construct_dict_str(d, indent=0, indent_delta=4, max_chars=None, keys=None):
     res = ""
 
     if keys is None:
-        keys = d.keys()
+        keys = (
+            d.keys()
+            if isinstance(d, dict)
+            else range(len(d))
+            if isinstance(d, list)
+            else []
+        )
     for key in keys:
-        if key not in d.keys():
+        if isinstance(d, dict) and key not in d.keys():
+            raise ValueError(
+                f"Dictionary does not contain field {key} specified in 'keys' argument. The available keys are {d.keys()}"
+            )
+        if isinstance(d, list) and key not in range(len(d)):
             raise ValueError(
                 f"Dictionary does not contain field {key} specified in 'keys' argument. The available keys are {d.keys()}"
             )

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -199,6 +199,7 @@ class TestDictUtils(UnitxtTestCase):
             dict_delete(dic, "a/2/3")
 
         self.assertEqual("i1", dict_get(dic, "a/0/0/0"))
+        # for backward compatibility: allow also indexing into a string in dict_get:
         self.assertEqual("i", dict_get(dic, "a/0/0/0/0"))
         self.assertEqual("i", dict_get(dic, "a/0/0/0/0/0/0/0"))
 

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -199,13 +199,10 @@ class TestDictUtils(UnitxtTestCase):
             dict_delete(dic, "a/2/3")
 
         self.assertEqual("i1", dict_get(dic, "a/0/0/0"))
-<<<<<<< HEAD
         # for backward compatibility: allow also indexing into a string in dict_get:
         self.assertEqual("i", dict_get(dic, "a/0/0/0/0"))
         self.assertEqual("i", dict_get(dic, "a/0/0/0/0/0/0/0"))
 
-=======
->>>>>>> 12f6435f (not_exist_ok for dict_set only allows to add a non existing key to a dictionary, or non existing entry to a list. Not a nested structure as implied by the query)
         with self.assertRaises(ValueError):
             dict_get(dic, "a/0/0/0/*/0")
 

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -199,10 +199,13 @@ class TestDictUtils(UnitxtTestCase):
             dict_delete(dic, "a/2/3")
 
         self.assertEqual("i1", dict_get(dic, "a/0/0/0"))
+<<<<<<< HEAD
         # for backward compatibility: allow also indexing into a string in dict_get:
         self.assertEqual("i", dict_get(dic, "a/0/0/0/0"))
         self.assertEqual("i", dict_get(dic, "a/0/0/0/0/0/0/0"))
 
+=======
+>>>>>>> 12f6435f (not_exist_ok for dict_set only allows to add a non existing key to a dictionary, or non existing entry to a list. Not a nested structure as implied by the query)
         with self.assertRaises(ValueError):
             dict_get(dic, "a/0/0/0/*/0")
 

--- a/tests/library/test_dict_utils.py
+++ b/tests/library/test_dict_utils.py
@@ -199,6 +199,9 @@ class TestDictUtils(UnitxtTestCase):
             dict_delete(dic, "a/2/3")
 
         self.assertEqual("i1", dict_get(dic, "a/0/0/0"))
+        self.assertEqual("i", dict_get(dic, "a/0/0/0/0"))
+        self.assertEqual("i", dict_get(dic, "a/0/0/0/0/0/0/0"))
+
         with self.assertRaises(ValueError):
             dict_get(dic, "a/0/0/0/*/0")
 

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -2297,7 +2297,9 @@ class TestOperators(UnitxtTestCase):
         check_operator_exception(
             operator=Copy(field="source", to_field="task_data/source"),
             inputs=inputs,
-            exception_texts = [""],
+            exception_texts=[
+                "Error processing instance '0' from stream 'test' in Copy due to the exception above."
+            ],
             tester=self,
         )
 
@@ -2310,7 +2312,9 @@ class TestOperators(UnitxtTestCase):
         check_operator_exception(
             operator=Copy(field="a", to_field="a/x"),
             inputs=inputs,
-            exception_tests=[""],
+            exception_texts=[
+                "Error processing instance '0' from stream 'test' in Copy due to the exception above."
+            ],
             tester=self,
         )
 
@@ -2341,7 +2345,7 @@ class TestOperators(UnitxtTestCase):
         inputs = [{"prediction": "red", "references": "blue"}]
         exception_texts = [
             "Error processing instance '0' from stream 'test' in EncodeLabels due to the exception above.",
-            "query 'references/*' did not match any item in dict:\nprediction (str):\n    red\nreferences (str):\n    blue\n",
+            "dict_get: query 'references/*' did not match any item in dict:\nprediction (str):\n    red\nreferences (str):\n    blue\n",
         ]
         check_operator_exception(
             operator=EncodeLabels(fields=["references/*", "prediction"]),

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -733,10 +733,7 @@ class TestOperators(UnitxtTestCase):
         exception_texts = [
             "Error processing instance '0' from stream 'test' in RemoveValues due to the exception above.",
             "Failed to get 'label2' from instance due to the exception above.",
-            """query "label2" did not match any item in dict:
-label (str):
-    b
-""",
+            "query 'label2' did not match any item in dict:label (str):\n    b\n",
         ]
         check_operator_exception(
             operator=RemoveValues(field="label2", unallowed_values=["c"]),
@@ -2297,12 +2294,10 @@ label (str):
     def test_copy_string_to_string_error(self):
         inputs = [{"source": "hello", "task_data": 3}]
 
-        targets = [{"source": "hello", "task_data": {"source": "hello"}}]
-
-        check_operator(
+        check_operator_exception(
             operator=Copy(field="source", to_field="task_data/source"),
             inputs=inputs,
-            targets=targets,
+            exception_texts = [""],
             tester=self,
         )
 
@@ -2314,10 +2309,10 @@ label (str):
 
         targets = [{"a": {"x": "test"}}, {"a": {"x": "pest"}}]
 
-        check_operator(
+        check_operator_exception(
             operator=Copy(field="a", to_field="a/x"),
             inputs=inputs,
-            targets=targets,
+            exception_tests=[""],
             tester=self,
         )
 
@@ -2346,7 +2341,10 @@ label (str):
         )
 
         inputs = [{"prediction": "red", "references": "blue"}]
-        exception_texts = ["Error processing instance '0' from stream 'test' in EncodeLabels due to: query 'references/*' did not match any item in dict:\nprediction (str):\n    red\nreferences (str):\n    blue\n"]
+        exception_texts = [
+            "Error processing instance '0' from stream 'test' in EncodeLabels due to the exception above.",
+            "query 'references/*' did not match any item in dict:\nprediction (str):\n    red\nreferences (str):\n    blue\n",
+        ]
         check_operator_exception(
             operator=EncodeLabels(fields=["references/*", "prediction"]),
             inputs=inputs,

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -733,7 +733,7 @@ class TestOperators(UnitxtTestCase):
         exception_texts = [
             "Error processing instance '0' from stream 'test' in RemoveValues due to the exception above.",
             "Failed to get 'label2' from instance due to the exception above.",
-            "query 'label2' did not match any item in dict:label (str):\n    b\n",
+            "query 'label2' did not match any item in dict:\nlabel (str):\n    b\n",
         ]
         check_operator_exception(
             operator=RemoveValues(field="label2", unallowed_values=["c"]),
@@ -2301,13 +2301,11 @@ class TestOperators(UnitxtTestCase):
             tester=self,
         )
 
-    def test_copy_paste_same_name2(self):
+    def test_copy_paste_same_name2_error(self):
         inputs = [
             {"a": "test"},
             {"a": "pest"},
         ]
-
-        targets = [{"a": {"x": "test"}}, {"a": {"x": "pest"}}]
 
         check_operator_exception(
             operator=Copy(field="a", to_field="a/x"),

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -2346,13 +2346,7 @@ label (str):
         )
 
         inputs = [{"prediction": "red", "references": "blue"}]
-        exception_text = """Error processing instance '0' from stream 'test' in EncodeLabels due to: query 'references/*' did not match any item in dict:
-prediction (str):
-    red
-references (str):
-    blue
-""",
-        ]
+        exception_texts = ["Error processing instance '0' from stream 'test' in EncodeLabels due to: query 'references/*' did not match any item in dict:\nprediction (str):\n    red\nreferences (str):\n    blue\n"]
         check_operator_exception(
             operator=EncodeLabels(fields=["references/*", "prediction"]),
             inputs=inputs,

--- a/tests/library/test_splitters.py
+++ b/tests/library/test_splitters.py
@@ -210,7 +210,7 @@ class TestCloseTextSampler(UnitxtTestCase):
         with self.assertRaises(ValueError) as cm:
             sampler.sample(num_samples, instances, instance)
         self.assertIn(
-            'query "input_fields/wrong_field" did not match any item in dict',
+            "query 'input_fields/wrong_field' did not match any item in dict",
             str(cm.exception),
         )
 


### PR DESCRIPTION
closes: https://github.com/IBM/unitxt/issues/1400

Can still set a whole nested structure, but as the value being set, not through processing the query by dict_set.