### PR TITLE
Fix arenahard bluebench template

### DIFF
--- a/prepare/recipes/bluebench.py
+++ b/prepare/recipes/bluebench.py
@@ -127,7 +127,7 @@ ingridients = {
     "card": "cards.arena_hard.generation.english_gpt_4_0314_reference",
     "demos_pool_size": 0,
     "num_demos": 0,
-    "template": "templates.empty",
+    "template": "templates.generation.empty",
     "metrics": [
         "metrics.llm_as_judge.pairwise_comparative_rating.llama_3_70b_instruct.template_arena_hard"
     ],

--- a/src/unitxt/catalog/recipes/bluebench/chatbot_abilities/arena_hard_generation_english_gpt_4_0314_reference.json
+++ b/src/unitxt/catalog/recipes/bluebench/chatbot_abilities/arena_hard_generation_english_gpt_4_0314_reference.json
@@ -7,7 +7,7 @@
     "max_validation_instances": 1000,
     "max_test_instances": 1000,
     "card": "cards.arena_hard.generation.english_gpt_4_0314_reference",
-    "template": "templates.empty",
+    "template": "templates.generation.empty",
     "metrics": [
         "metrics.llm_as_judge.pairwise_comparative_rating.llama_3_70b_instruct.template_arena_hard"
     ],


### PR DESCRIPTION
LLMaJ metrics has an issue with the templates.empty, switching to templates.generation.empty