### PR TITLE
not using "score" as metric main_score

### DIFF
--- a/prepare/metrics/hhem.py
+++ b/prepare/metrics/hhem.py
@@ -16,7 +16,7 @@ task_data = [{"contexts": [p[0]]} for p in pairs]
 ## 1. Regular unitxt flow: predictions are taken from model prediction and contexts appears in the task data
 ## 2. Running on external rag output: each instance contains field "answer" and field "contexts"
 metric = MetricPipeline(
-    main_score="score",
+    main_score="hhem_score",
     preprocess_steps=[
         Copy(
             field_to_field={"task_data/contexts": "references", "answer": "prediction"},
@@ -28,16 +28,19 @@ metric = MetricPipeline(
     __description__="Vectara's halucination detection model, HHEM2.1, compares contexts and generated answer to determine faithfulness.",
 )
 instance_targets = [
-    {"score": 0.01, "score_name": "score"},
-    {"score": 0.65, "score_name": "score"},
-    {"score": 0.13, "score_name": "score"},
+    {"score": 0.01, "score_name": "hhem_score", "hhem_score": 0.01},
+    {"score": 0.65, "score_name": "hhem_score", "hhem_score": 0.65},
+    {"score": 0.13, "score_name": "hhem_score", "hhem_score": 0.13},
 ]
 global_target = {
     "num_of_instances": 3,
     "score": 0.26,
-    "score_name": "score",
+    "score_name": "hhem_score",
     "score_ci_low": 0.05,
     "score_ci_high": 0.65,
+    "hhem_score": 0.26,
+    "hhem_score_ci_low": 0.05,
+    "hhem_score_ci_high": 0.65,
 }
 
 

--- a/prepare/metrics/rag.py
+++ b/prepare/metrics/rag.py
@@ -270,14 +270,17 @@ references = [
     ["foo bar foobar", "foo bar"],
 ]
 instance_targets = [
-    {"score": 0.71, "score_name": "score"},
-    {"score": 1.0, "score_name": "score"},
+    {"sbert_score": 0.71, "score": 0.71, "score_name": "sbert_score"},
+    {"sbert_score": 1.0, "score": 1.0, "score_name": "sbert_score"},
 ]
 global_target = {
+    "sbert_score": 0.86,
+    "sbert_score_ci_high": 1.0,
+    "sbert_score_ci_low": 0.71,
     "score": 0.86,
     "score_ci_high": 1.0,
     "score_ci_low": 0.71,
-    "score_name": "score",
+    "score_name": "sbert_score",
     "num_of_instances": 2,
 }
 test_metric(
@@ -291,14 +294,27 @@ metric = metrics["metrics.reward.deberta_v3_large_v2"]
 predictions = ["hello there General Dude", "foo bar foobar"]
 references = [["How do you greet General Dude"], ["What is your name?"]]
 instance_targets = [
-    {"label": "LABEL_0", "score": 0.14, "score_name": "score"},
-    {"label": "LABEL_0", "score": 0.03, "score_name": "score"},
+    {
+        "label": "LABEL_0",
+        "score": 0.14,
+        "score_name": "reward_score",
+        "reward_score": 0.14,
+    },
+    {
+        "label": "LABEL_0",
+        "score": 0.03,
+        "score_name": "reward_score",
+        "reward_score": 0.03,
+    },
 ]
 global_target = {
+    "reward_score": 0.09,
+    "reward_score_ci_high": 0.14,
+    "reward_score_ci_low": 0.03,
     "score": 0.09,
     "score_ci_high": 0.14,
     "score_ci_low": 0.03,
-    "score_name": "score",
+    "score_name": "reward_score",
     "num_of_instances": 2,
 }
 # test_metric(

--- a/prepare/metrics/rag_answer_correctness.py
+++ b/prepare/metrics/rag_answer_correctness.py
@@ -46,8 +46,8 @@ for new_catalog_name, base_catalog_name, main_score in [
         "metrics.bert_score.deberta_v3_base_mnli_xnli_ml",
         "recall",
     ),
-    ("sentence_bert_bge", "metrics.sentence_bert.bge_large_en_1_5", "score"),
-    ("sentence_bert_mini_lm", "metrics.sentence_bert.minilm_l12_v2", "score"),
+    ("sentence_bert_bge", "metrics.sentence_bert.bge_large_en_1_5", "sbert_score"),
+    ("sentence_bert_mini_lm", "metrics.sentence_bert.minilm_l12_v2", "sbert_score"),
 ]:
     metric = MetricPipeline(
         main_score=main_score,
@@ -84,20 +84,25 @@ def test_answer_correctness_sentence_bert():
             "score": 0.64,
             "score_ci_high": 0.75,
             "score_ci_low": 0.53,
-            "score_name": "score",
+            "sbert_score": 0.64,
+            "sbert_score_ci_high": 0.75,
+            "sbert_score_ci_low": 0.53,
+            "score_name": "sbert_score",
             "num_of_instances": 2,
         },
         instance_targets=[
             {
+                "sbert_score": 0.75,
                 "score": 0.75,
-                "score_name": "score",
+                "score_name": "sbert_score",
             },
             {
+                "sbert_score": 0.53,
                 "score": 0.53,
-                "score_name": "score",
+                "score_name": "sbert_score",
             },
         ],
-        main_score="score",
+        main_score="sbert_score",
     )
 
     test_answer_correctness(
@@ -107,20 +112,25 @@ def test_answer_correctness_sentence_bert():
             "score": 0.17,
             "score_ci_high": 0.42,
             "score_ci_low": -0.08,
-            "score_name": "score",
+            "sbert_score": 0.17,
+            "sbert_score_ci_high": 0.42,
+            "sbert_score_ci_low": -0.08,
+            "score_name": "sbert_score",
             "num_of_instances": 2,
         },
         instance_targets=[
             {
+                "sbert_score": 0.42,
                 "score": 0.42,
-                "score_name": "score",
+                "score_name": "sbert_score",
             },
             {
+                "sbert_score": -0.08,
                 "score": -0.08,
-                "score_name": "score",
+                "score_name": "sbert_score",
             },
         ],
-        main_score="score",
+        main_score="sbert_score",
     )
 
 

--- a/prepare/metrics/rag_context_relevance.py
+++ b/prepare/metrics/rag_context_relevance.py
@@ -9,8 +9,8 @@ default = "perplexity_flan_t5_small"
 
 for new_catalog_name, base_catalog_name, main_score in [
     ("perplexity_flan_t5_small", "metrics.perplexity_q.flan_t5_small", "perplexity"),
-    ("sentence_bert_bge", "metrics.sentence_bert.bge_large_en_1_5", "score"),
-    ("sentence_bert_mini_lm", "metrics.sentence_bert.minilm_l12_v2", "score"),
+    ("sentence_bert_bge", "metrics.sentence_bert.bge_large_en_1_5", "sbert_score"),
+    ("sentence_bert_mini_lm", "metrics.sentence_bert.minilm_l12_v2", "sbert_score"),
 ]:
     metric = MetricPipeline(
         main_score=main_score,

--- a/prepare/metrics/rag_faithfulness.py
+++ b/prepare/metrics/rag_faithfulness.py
@@ -16,8 +16,8 @@ for new_catalog_name, base_catalog_name, main_score in [
         "metrics.bert_score.deberta_v3_base_mnli_xnli_ml",
         "precision",
     ),
-    ("sentence_bert_bge", "metrics.sentence_bert.bge_large_en_1_5", "score"),
-    ("sentence_bert_mini_lm", "metrics.sentence_bert.minilm_l12_v2", "score"),
+    ("sentence_bert_bge", "metrics.sentence_bert.bge_large_en_1_5", "sbert_score"),
+    ("sentence_bert_mini_lm", "metrics.sentence_bert.minilm_l12_v2", "sbert_score"),
 ]:
     metric = MetricPipeline(
         main_score=main_score,
@@ -85,20 +85,25 @@ def test_faithfulness_sentence_bert():
             "score": 0.64,
             "score_ci_high": 0.75,
             "score_ci_low": 0.53,
-            "score_name": "score",
+            "sbert_score": 0.64,
+            "sbert_score_ci_high": 0.75,
+            "sbert_score_ci_low": 0.53,
+            "score_name": "sbert_score",
             "num_of_instances": 2,
         },
         instance_targets=[
             {
+                "sbert_score": 0.75,
                 "score": 0.75,
-                "score_name": "score",
+                "score_name": "sbert_score",
             },
             {
+                "sbert_score": 0.53,
                 "score": 0.53,
-                "score_name": "score",
+                "score_name": "sbert_score",
             },
         ],
-        main_score="score",
+        main_score="sbert_score",
     )
 
     test_faithfulness(
@@ -108,20 +113,25 @@ def test_faithfulness_sentence_bert():
             "score": 0.17,
             "score_ci_high": 0.42,
             "score_ci_low": -0.08,
-            "score_name": "score",
+            "sbert_score": 0.17,
+            "sbert_score_ci_high": 0.42,
+            "sbert_score_ci_low": -0.08,
+            "score_name": "sbert_score",
             "num_of_instances": 2,
         },
         instance_targets=[
             {
+                "sbert_score": 0.42,
                 "score": 0.42,
-                "score_name": "score",
+                "score_name": "sbert_score",
             },
             {
+                "sbert_score": -0.08,
                 "score": -0.08,
-                "score_name": "score",
+                "score_name": "sbert_score",
             },
         ],
-        main_score="score",
+        main_score="sbert_score",
     )
 
 

--- a/src/unitxt/catalog/metrics/rag/answer_correctness/sentence_bert_bge.json
+++ b/src/unitxt/catalog/metrics/rag/answer_correctness/sentence_bert_bge.json
@@ -1,6 +1,6 @@
 {
     "__type__": "metric_pipeline",
-    "main_score": "score",
+    "main_score": "sbert_score",
     "preprocess_steps": [
         {
             "__type__": "copy",

--- a/src/unitxt/catalog/metrics/rag/answer_correctness/sentence_bert_mini_lm.json
+++ b/src/unitxt/catalog/metrics/rag/answer_correctness/sentence_bert_mini_lm.json
@@ -1,6 +1,6 @@
 {
     "__type__": "metric_pipeline",
-    "main_score": "score",
+    "main_score": "sbert_score",
     "preprocess_steps": [
         {
             "__type__": "copy",

--- a/src/unitxt/catalog/metrics/rag/context_relevance/sentence_bert_bge.json
+++ b/src/unitxt/catalog/metrics/rag/context_relevance/sentence_bert_bge.json
@@ -1,6 +1,6 @@
 {
     "__type__": "metric_pipeline",
-    "main_score": "score",
+    "main_score": "sbert_score",
     "preprocess_steps": [
         {
             "__type__": "copy",

--- a/src/unitxt/catalog/metrics/rag/context_relevance/sentence_bert_mini_lm.json
+++ b/src/unitxt/catalog/metrics/rag/context_relevance/sentence_bert_mini_lm.json
@@ -1,6 +1,6 @@
 {
     "__type__": "metric_pipeline",
-    "main_score": "score",
+    "main_score": "sbert_score",
     "preprocess_steps": [
         {
             "__type__": "copy",

--- a/src/unitxt/catalog/metrics/rag/faithfulness/sentence_bert_bge.json
+++ b/src/unitxt/catalog/metrics/rag/faithfulness/sentence_bert_bge.json
@@ -1,6 +1,6 @@
 {
     "__type__": "metric_pipeline",
-    "main_score": "score",
+    "main_score": "sbert_score",
     "preprocess_steps": [
         {
             "__type__": "copy",

--- a/src/unitxt/catalog/metrics/rag/faithfulness/sentence_bert_mini_lm.json
+++ b/src/unitxt/catalog/metrics/rag/faithfulness/sentence_bert_mini_lm.json
@@ -1,6 +1,6 @@
 {
     "__type__": "metric_pipeline",
-    "main_score": "score",
+    "main_score": "sbert_score",
     "preprocess_steps": [
         {
             "__type__": "copy",

--- a/src/unitxt/catalog/metrics/rag/faithfulness/vectara_hhem_2_1.json
+++ b/src/unitxt/catalog/metrics/rag/faithfulness/vectara_hhem_2_1.json
@@ -1,6 +1,6 @@
 {
     "__type__": "metric_pipeline",
-    "main_score": "score",
+    "main_score": "hhem_score",
     "preprocess_steps": [
         {
             "__type__": "copy",


### PR DESCRIPTION
Using "score" as main_score disables scores_prefix (as prefix is not added to "score") and makes it impossible to track scores from a list of metric.
With this fix, the new main_score (and main_score_ci_) are added to the results, without changing the previous reported scores.

Signed-off-by: lilacheden <lilach.edel@gmail.com>