### PR TITLE
Fix model strings for Llama 3 on Together AI

### DIFF
--- a/src/unitxt/inference.py
+++ b/src/unitxt/inference.py
@@ -2739,8 +2739,8 @@ class CrossProviderInferenceEngine(InferenceEngine, StandardAPIParamsMixin):
             "granite-3-8b-instruct": "ibm/granite-3-8b-instruct",
         },
         "together-ai": {
-            "llama-3-8b-instruct": "together_ai/togethercomputer/llama-3-8b-instruct",
-            "llama-3-70b-instruct": "together_ai/togethercomputer/llama-3-70b-instruct",
+            "llama-3-8b-instruct": "together_ai/meta-llama/Llama-3-8b-chat-hf",
+            "llama-3-70b-instruct": "together_ai/meta-llama/Llama-3-70b-chat-hf",
             "llama-3-2-1b-instruct": "together_ai/togethercomputer/llama-3-2-1b-instruct",
         },
         "aws": {


### PR DESCRIPTION
The current model strings for Llama 3 are incorrect. This updates the model strings to match the current [Together AI documentation](https://docs.together.ai/docs/serverless-models).