### PR TITLE
Switch scigen card to use CrossProviderInferenceEngine

### DIFF
--- a/prepare/cards/scigen.py
+++ b/prepare/cards/scigen.py
@@ -26,7 +26,7 @@ card = TaskCard(
             }
         ),
     ],
-    task="tasks.generation.from_pair[metrics=[metrics.llm_as_judge.rating.llama_3_70b_instruct_ibm_genai_template_table2text_single_turn_with_reference]]",
+    task="tasks.generation.from_pair[metrics=[metrics.llm_as_judge.rating.llama_3_70b_instruct_cross_provider_template_table2text_single_turn_with_reference]]",
     templates=[
         "templates.generation.from_pair.default[postprocessors=[processors.lower_case]]"
     ],

--- a/prepare/metrics/llm_as_judge/rating/llama_3_cross_provider_table2text_template.py
+++ b/prepare/metrics/llm_as_judge/rating/llama_3_cross_provider_table2text_template.py
@@ -1,0 +1,32 @@
+from unitxt import add_to_catalog
+from unitxt.inference import CrossProviderInferenceEngine
+from unitxt.llm_as_judge import LLMAsJudge
+from unitxt.random_utils import get_seed
+
+model_list = ["llama-3-70b-instruct"]
+format = "formats.llama3_instruct"
+template = "templates.response_assessment.rating.table2text_single_turn_with_reference"
+task = "rating.single_turn_with_reference"
+
+for model_id in model_list:
+    inference_model = CrossProviderInferenceEngine(
+        model=model_id, max_tokens=252, seed=get_seed()
+    )
+    model_label = model_id.replace("-", "_").replace(".", ",").lower()
+    model_label = f"{model_label}_cross_provider"
+    template_label = template.split(".")[-1]
+    metric_label = f"{model_label}_template_{template_label}"
+    metric = LLMAsJudge(
+        inference_model=inference_model,
+        template=template,
+        task=task,
+        format=format,
+        main_score=metric_label,
+        prediction_type="str",
+    )
+
+    add_to_catalog(
+        metric,
+        f"metrics.llm_as_judge.rating.{model_label}_template_{template_label}",
+        overwrite=True,
+    )

--- a/src/unitxt/catalog/cards/scigen.json
+++ b/src/unitxt/catalog/cards/scigen.json
@@ -39,7 +39,7 @@
             }
         }
     ],
-    "task": "tasks.generation.from_pair[metrics=[metrics.llm_as_judge.rating.llama_3_70b_instruct_ibm_genai_template_table2text_single_turn_with_reference]]",
+    "task": "tasks.generation.from_pair[metrics=[metrics.llm_as_judge.rating.llama_3_70b_instruct_cross_provider_template_table2text_single_turn_with_reference]]",
     "templates": [
         "templates.generation.from_pair.default[postprocessors=[processors.lower_case]]"
     ],

--- a/src/unitxt/catalog/metrics/llm_as_judge/rating/llama_3_70b_instruct_cross_provider_template_table2text_single_turn_with_reference.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/rating/llama_3_70b_instruct_cross_provider_template_table2text_single_turn_with_reference.json
@@ -1,0 +1,14 @@
+{
+    "__type__": "llm_as_judge",
+    "inference_model": {
+        "__type__": "cross_provider_inference_engine",
+        "model": "llama-3-70b-instruct",
+        "max_tokens": 252,
+        "seed": 42
+    },
+    "template": "templates.response_assessment.rating.table2text_single_turn_with_reference",
+    "task": "rating.single_turn_with_reference",
+    "format": "formats.llama3_instruct",
+    "main_score": "llama_3_70b_instruct_cross_provider_template_table2text_single_turn_with_reference",
+    "prediction_type": "str"
+}


### PR DESCRIPTION
This creates a new metric `llama_3_70b_instruct_cross_provider_template_table2text_single_turn_with_reference` which is the cross provider version of `llama_3_70b_instruct_ibm_genai_template_table2text_single_turn_with_reference`, and then switches scigen to use the new metric. This allows running scigen with other model providers.