### PR TITLE
Fix artifact dict assignment bug

### DIFF
--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -89,16 +89,18 @@ class Catalogs:
         self.catalogs = []
 
 
-def map_values_in_place(object, mapper):
-    if isinstance(object, dict):
-        for key, value in object.items():
-            object[key] = mapper(value)
-        return object
-    if isinstance(object, list):
-        for i in range(len(object)):
-            object[i] = mapper(object[i])
-        return object
-    return mapper(object)
+def maybe_recover_artifacts_structure(obj):
+    if Artifact.is_possible_identifier(obj):
+        return verbosed_fetch_artifact(obj)
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            obj[key] = maybe_recover_artifact(value)
+        return obj
+    if isinstance(obj, list):
+        for i in range(len(obj)):
+            obj[i] = maybe_recover_artifact(obj[i])
+        return obj
+    return obj
 
 
 def get_closest_artifact_type(type):
@@ -150,8 +152,12 @@ class Artifact(Dataclass):
     )
 
     @classmethod
-    def is_artifact_dict(cls, d):
-        return isinstance(d, dict) and "__type__" in d
+    def is_artifact_dict(cls, obj):
+        return isinstance(obj, dict) and "__type__" in obj
+
+    @classmethod
+    def is_possible_identifier(cls, obj):
+        return isinstance(obj, str) or cls.is_artifact_dict(obj)
 
     @classmethod
     def verify_artifact_dict(cls, d):
@@ -292,7 +298,7 @@ class Artifact(Dataclass):
                 field.type, Union[Artifact, List[Artifact], Dict[str, Artifact]]
             ):
                 value = getattr(self, field.name)
-                value = map_values_in_place(value, maybe_recover_artifact)
+                value = maybe_recover_artifacts_structure(value)
                 setattr(self, field.name, value)
 
         self.verify_data_classification_policy()
@@ -574,11 +580,10 @@ def reset_artifacts_json_cache():
     artifacts_json_cache.cache_clear()
 
 
-def maybe_recover_artifact(artifact):
-    if isinstance(artifact, str):
-        return verbosed_fetch_artifact(artifact)
-
-    return artifact
+def maybe_recover_artifact(obj):
+    if Artifact.is_possible_identifier(obj):
+        return verbosed_fetch_artifact(obj)
+    return obj
 
 
 def register_all_artifacts(path):

--- a/src/unitxt/dataclass.py
+++ b/src/unitxt/dataclass.py
@@ -533,6 +533,13 @@ class Dataclass(metaclass=DataclassMeta):
             if keep_empty or value is not None
         }
 
+    def get_repr_dict(self):
+        result = {}
+        for field in fields(self):
+            if not field.internal:
+                result[field.name] = getattr(self, field.name)
+        return result
+
     def __repr__(self) -> str:
         """String representation."""
-        return f"{self.__class__.__name__}({', '.join([f'{field.name}={getattr(self, field.name)!r}' for field in fields(self)])})"
+        return f"{self.__class__.__name__}({', '.join([f'{key}={val!r}' for key, val in self.get_repr_dict().items()])})"

--- a/tests/library/test_artifact.py
+++ b/tests/library/test_artifact.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 
 from unitxt.artifact import (
     Artifact,
@@ -29,7 +30,31 @@ logger = get_logger()
 settings = get_settings()
 
 
+class ArtifactToReference(Artifact):
+    a: str
+
+
+class ArtifactReferencing(Artifact):
+    reference: ArtifactToReference
+
+
 class TestArtifact(UnitxtTestCase):
+    def test_artifact_loading_with_artifact_file_reference(self):
+        # Create a temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            ArtifactToReference(a="0").save(os.path.join(temp_dir, "0.json"))
+
+            t = ArtifactReferencing(reference=os.path.join(temp_dir, "0.json"))
+
+        self.assertEqual(str(t.reference), str(ArtifactToReference(a="0")))
+
+    def test_artifact_loading_with_artifact_dict_reference(self):
+        t = ArtifactReferencing(
+            reference={"__type__": "artifact_to_reference", "a": "0"}
+        )
+
+        self.assertEqual(str(t.reference), str(ArtifactToReference(a="0")))
+
     def test_artifact_identifier_setter(self):
         artifact = Artifact()
         artifact_identifier = "artifact.id.dummy"


### PR DESCRIPTION
When assigning artifact dict in the constructor of another artifact unitxt should recover it but it wont. 
See unittests that did not pass before. 