### PR TITLE
fix pd.read_csv - add separator in case it is not the default one

### DIFF
--- a/src/unitxt/dialog_operators.py
+++ b/src/unitxt/dialog_operators.py
@@ -157,13 +157,13 @@ class SerializeOpenAiFormatDialog(SerializeDialog):
                     f"Entry {i} has a non-string 'content': {entry['content']}. The 'content' value must be a string."
                 )
 
-            if entry["role"] not in {"user", "assistant"}:
+            if entry["role"].lower() not in {"user", "assistant"}:
                 raise ValueError(
                     f"Entry {i} has an invalid role: {entry['role']}. Allowed roles are 'user' and 'assistant'."
                 )
 
         first_entry = dialog[0]
-        if first_entry["role"] != "user":
+        if first_entry["role"].lower() != "user":
             raise ValueError(
                 f"First entry role is expected to be 'user' It is  {first_entry['role']}."
             )

--- a/src/unitxt/loaders.py
+++ b/src/unitxt/loaders.py
@@ -361,7 +361,7 @@ class LoadCSV(Loader):
                     file, nrows=self.get_limit(), sep=self.sep
                 ).to_dict("records")
             else:
-                self._cache[file] = pd.read_csv(file).to_dict("records")
+                self._cache[file] = pd.read_csv(file, sep=self.sep).to_dict("records")
 
         yield from self._cache[file]
 


### PR DESCRIPTION
In loaders.py , we must pass the separator value while reading a pd.read_csv(