### PR TITLE
Indentation within docstrings to improve appearance on web pages, on the way - eliminating two red lines from "make docs-server"

### DIFF
--- a/src/unitxt/api.py
+++ b/src/unitxt/api.py
@@ -100,27 +100,31 @@ def load_dataset(
     given parameters.
 
     Args:
-        dataset_query (str, optional): A string query which specifies a dataset to load from local catalog or name of specific recipe or benchmark in the catalog.
-        For example: ``"card=cards.wnli,template=templates.classification.multi_class.relation.default".``
-
-        streaming (bool, False): When True yields the data as Unitxt streams dictionary
-
-        split (str, optional): The split of the data to load
-
-        disable_cache (str, optional): Disable caching process of the data
-
-        **kwargs: Arguments used to load dataset from provided card, which is not present in local catalog.
+        dataset_query (str, optional):
+            A string query which specifies a dataset to load from
+            local catalog or name of specific recipe or benchmark in the catalog. For
+            example, ``"card=cards.wnli,template=templates.classification.multi_class.relation.default"``.
+        streaming (bool, False):
+            When True yields the data as Unitxt streams dictionary
+        split (str, optional):
+            The split of the data to load
+        disable_cache (str, optional):
+            Disable caching process of the data
+        **kwargs:
+            Arguments used to load dataset from provided card, which is not present in local catalog.
 
     Returns:
         DatasetDict
 
-    Example:
+    :Example:
+
         .. code-block:: python
 
             dataset = load_dataset(
                 dataset_query="card=cards.stsb,template=templates.regression.two_texts.simple,max_train_instances=5"
-            )  # card must be present in local catalog
+            )  # card and template must be present in local catalog
 
+            # or built programmatically
             card = TaskCard(...)
             template = Template(...)
             loader_limit = 10

--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -388,17 +388,15 @@ class Artifact(Dataclass):
         proper way (for example when sending it to some external services).
 
         Args:
-            instance (Dict[str, Any]): data which should contain its allowed data
-            classification policies under key 'data_classification_policy'.
+            instance (Dict[str, Any]): data which should contain its allowed data classification policies under key 'data_classification_policy'.
 
-            name (Optional[str]): name of artifact which should be used to retrieve
-            data classification from env. If not specified, then either ``__id__`` or
-            ``__class__.__name__``, are used instead, respectively.
+            name (Optional[str]): name of artifact which should be used to retrieve data classification from env. If not specified, then either ``__id__`` or ``__class__.__name__``, are used instead, respectively.
 
         Returns:
             Dict[str, Any]: unchanged instance.
 
-        Examples:
+        :Examples:
+
         .. code-block:: python
 
             instance = {"x": "some_text", "data_classification_policy": ["pii"]}
@@ -415,6 +413,7 @@ class Artifact(Dataclass):
             UNITXT_DATA_CLASSIFICATION_POLICY = json.dumps({"metrics.accuracy": ["pii"]})
             metric = fetch_artifact("metrics.accuracy")
             metric.verify_instance(instance)
+
         """
         name = name or self.get_pretty_print_name()
         data_classification_policy = get_artifacts_data_classification(name)

--- a/src/unitxt/dataclass.py
+++ b/src/unitxt/dataclass.py
@@ -375,8 +375,8 @@ class Dataclass(metaclass=DataclassMeta):
     7. MetaClass Usage: Uses a metaclass (DataclassMeta) for customization of class creation,
        allowing checks and alterations to be made at the time of class creation, providing more control.
 
-    Example:
-    .. highlight:: python
+    :Example:
+
     .. code-block:: python
 
         class Parent(Dataclass):

--- a/src/unitxt/dataset.py
+++ b/src/unitxt/dataset.py
@@ -116,6 +116,38 @@ class Dataset(datasets.GeneratorBasedBuilder):
         verification_mode: Optional[Union[datasets.VerificationMode, str]] = None,
         in_memory=False,
     ) -> Union[datasets.Dataset, datasets.DatasetDict]:
+        """Return a Dataset for the specified split.
+
+        Args:
+            split (`datasets.Split`):
+                Which subset of the data to return.
+            run_post_process (`bool`, defaults to `True`):
+                Whether to run post-processing dataset transforms and/or add
+                indexes.
+            verification_mode ([`VerificationMode`] or `str`, defaults to `BASIC_CHECKS`):
+                Verification mode determining the checks to run on the
+                downloaded/processed dataset information (checksums/size/splits/...).
+            in_memory (`bool`, defaults to `False`):
+                Whether to copy the data in-memory.
+
+        Returns:
+            datasets.Dataset
+
+        :Example:
+
+        .. code-block:: python
+
+            from datasets import load_dataset_builder
+            builder = load_dataset_builder('rotten_tomatoes')
+            builder.download_and_prepare()
+            ds = builder.as_dataset(split='train')
+            print(ds)
+            # prints:
+            # Dataset({
+            #     features: ['text', 'label'],
+            #     num_rows: 8530
+            # })
+        """
         return (
             super()
             .as_dataset(split, run_post_process, verification_mode, in_memory)

--- a/src/unitxt/splitters.py
+++ b/src/unitxt/splitters.py
@@ -230,21 +230,23 @@ class DiverseLabelsSampler(Sampler):
     The `choices` param is required and determines which values should be considered.
 
     Example:
-        If choices is ['dog,'cat'] , then the following combinations will be considered.
+        If choices is ['dog','cat'] , then the following combinations will be considered.
         ['']
         ['cat']
         ['dog']
         ['dog','cat']
 
         If the instance contains a value not in the 'choice' param, it is ignored. For example,
-        if choices is ['dog,'cat'] and the instance field is ['dog','cat','cow'], then 'cow' is ignored
+        if choices is ['dog','cat'] and the instance field is ['dog','cat','cow'], then 'cow' is ignored
         then the instance is considered as ['dog','cat'].
 
     Args:
-        sample_size - number of samples to extract
-        choices - name of input field that contains the list of values to balance on
-        labels - name of output field with labels that must be balanced
-
+        sample_size (int):
+            number of samples to extract
+        choices (str):
+            name of input field that contains the list of values to balance on
+        labels (str):
+            name of output field with labels that must be balanced
 
     """
 

--- a/src/unitxt/test_utils/card.py
+++ b/src/unitxt/test_utils/card.py
@@ -238,20 +238,21 @@ def test_card(
     It also shows the processed predictions and references, after the template's post processors
     are applied.  Thus wayit is possible to debug and see that the inputs to the metrics are as expected.
 
-    Parameters:
-        1. `card`: The `Card` object to be tested.
-        2. `debug`: A boolean value indicating whether to enable debug mode. In debug mode, the data processing pipeline is executed step by step, printing a representative output of each step.  Default is False.
-        3. `strict`: A boolean value indicating whether to fail if scores do not match the expected ones.
+    :Parameters:
+
+        1. **card** : The `Card` object to be tested.
+        2. **debug** : A boolean value indicating whether to enable debug mode. In debug mode, the data processing pipeline is executed step by step, printing a representative output of each step.  Default is False.
+        3. **strict** : A boolean value indicating whether to fail if scores do not match the expected ones.
            Default is True.
-        4. `test_exact_match_score_when_predictions_equal_references`: A boolean value indicating whether to test the exact match score when predictions equal references. Default is True.
-        5. `test_full_mismatch_score_with_full_mismatch_prediction_values`: A boolean value indicating whether to test the full mismatch score with full mismatch prediction values.
+        4. **test_exact_match_score_when_predictions_equal_references** : A boolean value indicating whether to test the exact match score when predictions equal references. Default is True.
+        5. **test_full_mismatch_score_with_full_mismatch_prediction_values** : A boolean value indicating whether to test the full mismatch score with full mismatch prediction values.
            The potential mismatched predeiction values are specified in full_mismatch_prediction_values`.
            Default is True.
-        6. `exact_match_score`: The expected score to be returned when predictions are equal the gold reference. Default is 1.0.
-        7. `maximum_full_mismatch_score`: The maximum score allowed to be returned when predictions are full mismatched. Default is 0.0.
-        8. `full_mismatch_prediction_values`: An optional list of prediction values to use for testing full mismatches. Default is None.
+        6. **exact_match_score** : The expected score to be returned when predictions are equal the gold reference. Default is 1.0.
+        7. **maximum_full_mismatch_score** : The maximum score allowed to be returned when predictions are full mismatched. Default is 0.0.
+        8. **full_mismatch_prediction_values** : An optional list of prediction values to use for testing full mismatches. Default is None.
            If not set, a default set of values: ["a1s", "bfsdf", "dgdfgs", "gfjgfh", "ghfjgh"]
-        9. `**kwargs` : Additional keyword arguments to be passed to the recipe.
+        9. ****kwargs** : Additional keyword arguments to be passed to the recipe.
 
     Examples:
         .. code-block:: python


### PR DESCRIPTION
face lift to the documentation on the web pages for:
https://www.unitxt.ai/en/latest/unitxt.api.html#unitxt.api.load_dataset
https://www.unitxt.ai/en/latest/unitxt.artifact.html#unitxt.artifact.Artifact.verify_instance
https://www.unitxt.ai/en/latest/unitxt.splitters.html#unitxt.splitters.DiverseLabelsSampler
https://www.unitxt.ai/en/latest/unitxt.dataclass.html#unitxt.dataclass.Dataclass
https://www.unitxt.ai/en/latest/unitxt.dataset.html#unitxt.dataset.Dataset.as_dataset
https://www.unitxt.ai/en/latest/unitxt.test_utils.card.html#unitxt.test_utils.card.test_card
