### PR TITLE
Allow a serializer per field in template.

### DIFF
--- a/examples/evaluate_rag_response_generation.py
+++ b/examples/evaluate_rag_response_generation.py
@@ -1,81 +1,47 @@
-from unitxt.api import evaluate, load_dataset
-from unitxt.blocks import (
-    TaskCard,
-)
-from unitxt.collections_operators import Wrap
-from unitxt.inference import (
-    HFPipelineBasedInferenceEngine,
-)
-from unitxt.loaders import LoadFromDictionary
-from unitxt.operators import Rename, Set
-from unitxt.templates import MultiReferenceTemplate, TemplatesDict
+from unitxt.api import create_dataset, evaluate
+from unitxt.inference import CrossProviderInferenceEngine
+from unitxt.serializers import ListSerializer
+from unitxt.templates import MultiReferenceTemplate
 from unitxt.text_utils import print_dict
 
 # Assume the RAG data is proved in this format
-data = {
-    "test": [
-        {
-            "query": "What city is the largest in Texas?",
-            "extracted_chunks": "Austin is the capital of Texas.\nHouston is the the largest city in Texas but not the capital of it. ",
-            "expected_answer": "Houston",
-        },
-        {
-            "query": "What city is the capital of Texas?",
-            "extracted_chunks": "Houston is the the largest city in Texas but not the capital of it. ",
-            "expected_answer": "Austin",
-        },
-    ]
-}
+data = [
+    {
+        "question": "What city is the largest in Texas?",
+        "contexts": [
+            "Austin is the capital of Texas.",
+            "Houston is the the largest city in Texas but not the capital of it. ",
+        ],
+        "reference_answers": ["Houston"],
+    },
+    {
+        "question": "What city is the capital of Texas?",
+        "contexts": [
+            "Houston is the the largest city in Texas but not the capital of it. "
+        ],
+        "reference_answers": ["Austin"],
+    },
+]
 
-
-card = TaskCard(
-    # Assumes this csv, contains 3 fields
-    # question (string), extracted_chunks (string), expected_answer (string)
-    loader=LoadFromDictionary(data=data),
-    # Map these fields to the fields of the task.rag.response_generation task.
-    # See https://www.unitxt.ai/en/latest/catalog/catalog.tasks.rag.response_generation.html
-    preprocess_steps=[
-        Rename(field_to_field={"query": "question"}),
-        Wrap(field="extracted_chunks", inside="list", to_field="contexts"),
-        Wrap(field="expected_answer", inside="list", to_field="reference_answers"),
-        Set(
-            fields={
-                "contexts_ids": [],
-            }
-        ),
-    ],
-    # Specify the task and the desired metrics (note that these are part of the default
-    # metrics for the task, so the metrics selection can be omitted).
-    task="tasks.rag.response_generation",
-    # Specify a default template
-    templates=TemplatesDict(
-        {
-            "simple": MultiReferenceTemplate(
-                instruction="Answer the question based on the information provided in the document given below.\n\n",
-                input_format="Document: {contexts}\nQuestion: {question}",
-                references_field="reference_answers",
-            ),
-        }
-    ),
+template = MultiReferenceTemplate(
+    instruction="Answer the question based on the information provided in the document given below.\n\n",
+    input_format="Contexts:\n\n{contexts}\n\nQuestion: {question}",
+    references_field="reference_answers",
+    serializer={"contexts": ListSerializer(separator="\n\n")},
 )
 
 # Verbalize the dataset using the template
-dataset = load_dataset(
-    card=card,
-    template_card_index="simple",
+dataset = create_dataset(
+    test_set=data,
+    template=template,
+    task="tasks.rag.response_generation",
     format="formats.chat_api",
     split="test",
-    max_test_instances=10,
 )
 
-
-# Infer using Llama-3.2-1B base using HF API
-engine = HFPipelineBasedInferenceEngine(
-    model_name="meta-llama/Llama-3.2-1B", max_new_tokens=32
-)
-# Change to this to infer with external APIs:
-# CrossProviderInferenceEngine(model="llama-3-2-1b-instruct", provider="watsonx")
+engine = CrossProviderInferenceEngine(model="llama-3-2-1b-instruct", provider="watsonx")
 # The provider can be one of: ["watsonx", "together-ai", "open-ai", "aws", "ollama", "bam"]
+
 
 predictions = engine.infer(dataset)
 evaluated_dataset = evaluate(predictions=predictions, data=dataset)

--- a/src/unitxt/serializers.py
+++ b/src/unitxt/serializers.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Union
 from .dataclass import AbstractField, Field
 from .operators import InstanceFieldOperator
 from .settings_utils import get_constants
-from .type_utils import isoftype, to_type_string
+from .type_utils import isoftype
 from .types import Dialog, Image, Number, Table, Video
 
 constants = get_constants()
@@ -26,29 +26,27 @@ class DefaultSerializer(Serializer):
         return str(value)
 
 
-class SingleTypeSerializer(InstanceFieldOperator):
+class SingleTypeSerializer(Serializer):
     serialized_type: object = AbstractField()
 
     def process_instance_value(self, value: Any, instance: Dict[str, Any]) -> str:
         if not isoftype(value, self.serialized_type):
             raise ValueError(
-                f"SingleTypeSerializer for type {self.serialized_type} should get this type. got {to_type_string(value)}"
+                f"SingleTypeSerializer for type {self.serialized_type} should get this type. got {type(value)}. Value: {value}"
             )
         return self.serialize(value, instance)
 
 
-class DefaultListSerializer(Serializer):
-    def serialize(self, value: Any, instance: Dict[str, Any]) -> str:
-        if isinstance(value, list):
-            return ", ".join(str(item) for item in value)
-        return str(value)
-
-
 class ListSerializer(SingleTypeSerializer):
     serialized_type = list
+    separator: str = ", "
+    prefix: str = ""
+    suffix: str = ""
 
     def serialize(self, value: Any, instance: Dict[str, Any]) -> str:
-        return ", ".join(str(item) for item in value)
+        return (
+            self.prefix + self.separator.join(str(item) for item in value) + self.suffix
+        )
 
 
 class DialogSerializer(SingleTypeSerializer):

--- a/tests/library/test_templates.py
+++ b/tests/library/test_templates.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Tuple
 
 from unitxt.dataclass import RequiredFieldError
 from unitxt.error_utils import UnitxtError
+from unitxt.serializers import ListSerializer
 from unitxt.templates import (
     ApplyRandomTemplate,
     ApplySingleTemplate,
@@ -404,7 +405,7 @@ class TestTemplates(UnitxtTestCase):
         template = InputOutputTemplate(
             input_format="This is my text:'{text}'",
             output_format="{label}",
-            instruction="Classify sentiment into: {labels}.\n",
+            instruction="Classify sentiment into: {labels}.",
             target_prefix="Sentiment is: ",
         )
 
@@ -442,7 +443,7 @@ class TestTemplates(UnitxtTestCase):
                 "source": "This is my text:'hello world'",
                 "target": "positive",
                 "references": ["positive"],
-                "instruction": "Classify sentiment into: positive, negative.\n",
+                "instruction": "Classify sentiment into: positive, negative.",
                 "target_prefix": "Sentiment is: ",
                 "postprocessors": ["processors.to_string_stripped"],
             },
@@ -455,7 +456,7 @@ class TestTemplates(UnitxtTestCase):
                 "source": "This is my text:'hello world\n, hell'",
                 "target": "positive",
                 "references": ["positive"],
-                "instruction": "Classify sentiment into: positive, negative.\n",
+                "instruction": "Classify sentiment into: positive, negative.",
                 "target_prefix": "Sentiment is: ",
                 "postprocessors": ["processors.to_string_stripped"],
             },
@@ -468,12 +469,26 @@ class TestTemplates(UnitxtTestCase):
                 "source": "This is my text:'hello world\n, hell'",
                 "target": "positive, 1",
                 "references": ["positive, 1"],
-                "instruction": "Classify sentiment into: positive, negative.\n",
+                "instruction": "Classify sentiment into: positive, negative.",
                 "target_prefix": "Sentiment is: ",
                 "postprocessors": ["processors.to_string_stripped"],
             },
         ]
 
+        check_operator(template, inputs, targets, tester=self)
+        # Now format with a different list serializer
+        for target in targets:
+            target["instruction"] = "Classify sentiment into: [positive/negative]."
+
+        template = InputOutputTemplate(
+            input_format="This is my text:'{text}'",
+            output_format="{label}",
+            instruction="Classify sentiment into: {labels}.",
+            target_prefix="Sentiment is: ",
+            serializer={
+                "labels": ListSerializer(separator="/", prefix="[", suffix="]")
+            },
+        )
         check_operator(template, inputs, targets, tester=self)
 
         # if "source" and "target" and "instruction_format" and "target_prefix" in instance - instance is not modified


### PR DESCRIPTION
This allows the template to control the formating of each field (e.g. how to enumerate lists).  This is done by allow the serializer field of the template to be a dictionary of field_names to serializer .

Fixed example for rag response generation.

Also fixed some bugs in serializer code.