### PR TITLE
Since Meteor is a decent InstanceMetric, it does not need a tiny n_resamples

### DIFF
--- a/prepare/metrics/meteor.py
+++ b/prepare/metrics/meteor.py
@@ -39,7 +39,7 @@ global_target = {
     "num_of_instances": 4,
 }
 
-# to match the setting to occur by testing on the global version, metric2, below
+# n_resample = 3 just to match the setting to occur by testing on the global version, metric2, below
 
 outputs = test_metric(
     metric=metric,
@@ -62,4 +62,8 @@ outputs = test_metric(
     global_target=global_target,
 )
 
+metric = Meteor()
+
+
 add_to_catalog(metric, "metrics.meteor", overwrite=True)
+add_to_catalog(metric2, "metrics.meteor_hf", overwrite=True)

--- a/src/unitxt/catalog/metrics/meteor.json
+++ b/src/unitxt/catalog/metrics/meteor.json
@@ -1,4 +1,3 @@
 {
-    "__type__": "meteor",
-    "n_resamples": 3
+    "__type__": "meteor"
 }

--- a/src/unitxt/catalog/metrics/meteor_hf.json
+++ b/src/unitxt/catalog/metrics/meteor_hf.json
@@ -1,0 +1,6 @@
+{
+    "__type__": "huggingface_metric",
+    "hf_metric_name": "meteor",
+    "main_score": "meteor",
+    "prediction_type": "str"
+}


### PR DESCRIPTION
Removed the n_resamples=3 from the catalog, and added, for nostaligia, also the hf version.