### PR TITLE
Benjams/fix bioasq card

### DIFF
--- a/prepare/cards/rag/end_to_end/bioasq.py
+++ b/prepare/cards/rag/end_to_end/bioasq.py
@@ -86,7 +86,7 @@ card = TaskCard(
         RenameSplits({"test": "train"}),
         Cast(field="id", to="str"),
         Copy(field="id", to_field="document_id"),
-        Wrap(field="passage", inside="list"),
+        Wrap(field="passage", inside="list", to_field="passages"),
         Set(
             fields={
                 "metadata_field": "",

--- a/prepare/cards/rag/end_to_end/clapnq.py
+++ b/prepare/cards/rag/end_to_end/clapnq.py
@@ -74,7 +74,6 @@ add_to_catalog(card, "cards.rag.benchmark.clap_nq.en", overwrite=True)
 card = TaskCard(
     loader=LoadHF(
         path="PrimeQA/clapnq_passages",
-        name="train",
         data_classification_policy=["public"],
     ),
     preprocess_steps=[

--- a/prepare/cards/rag/end_to_end/clapnq.py
+++ b/prepare/cards/rag/end_to_end/clapnq.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 from unitxt import add_to_catalog
 from unitxt.blocks import TaskCard
-from unitxt.loaders import LoadCSV
+from unitxt.loaders import LoadCSV, LoadHF
 from unitxt.operators import Copy, ListFieldValues, Set
 from unitxt.templates import InputOutputTemplate
 from unitxt.test_utils.card import test_card
@@ -14,12 +14,6 @@ class ClapNqBenchmark:
     # Raw_data
     TRAIN_RAW_FILE_URL: str = "https://raw.githubusercontent.com/primeqa/clapnq/main/retrieval/train/question_train_answerable.tsv"
     TEST_RAW_FILE_URL: str = "https://raw.githubusercontent.com/primeqa/clapnq/main/retrieval/dev/question_dev_answerable.tsv"
-
-
-@dataclass(frozen=True)
-class ClapNqDocuments:
-    # Raw_data
-    RAW_FILE_URL: str = "https://media.githubusercontent.com/media/primeqa/clapnq/main/retrieval/passages.tsv"
 
 
 card = TaskCard(
@@ -78,9 +72,9 @@ add_to_catalog(card, "cards.rag.benchmark.clap_nq.en", overwrite=True)
 
 # Documents
 card = TaskCard(
-    loader=LoadCSV(
-        sep="\t",
-        files={"train": ClapNqDocuments.RAW_FILE_URL},
+    loader=LoadHF(
+        path="PrimeQA/clapnq_passages",
+        name="train",
         data_classification_policy=["public"],
     ),
     preprocess_steps=[

--- a/src/unitxt/catalog/cards/rag/documents/bioasq/en.json
+++ b/src/unitxt/catalog/cards/rag/documents/bioasq/en.json
@@ -28,7 +28,8 @@
         {
             "__type__": "wrap",
             "field": "passage",
-            "inside": "list"
+            "inside": "list",
+            "to_field": "passages"
         },
         {
             "__type__": "set",

--- a/src/unitxt/catalog/cards/rag/documents/clap_nq/en.json
+++ b/src/unitxt/catalog/cards/rag/documents/clap_nq/en.json
@@ -3,7 +3,6 @@
     "loader": {
         "__type__": "load_hf",
         "path": "PrimeQA/clapnq_passages",
-        "name": "train",
         "data_classification_policy": [
             "public"
         ]

--- a/src/unitxt/catalog/cards/rag/documents/clap_nq/en.json
+++ b/src/unitxt/catalog/cards/rag/documents/clap_nq/en.json
@@ -1,11 +1,9 @@
 {
     "__type__": "task_card",
     "loader": {
-        "__type__": "load_csv",
-        "sep": "\t",
-        "files": {
-            "train": "https://media.githubusercontent.com/media/primeqa/clapnq/main/retrieval/passages.tsv"
-        },
+        "__type__": "load_hf",
+        "path": "PrimeQA/clapnq_passages",
+        "name": "train",
         "data_classification_policy": [
             "public"
         ]


### PR DESCRIPTION
Hi @elronbandel 

I made 2 things:
1 - I fixed the bioasq card - we had an error there.

2 - the clapNQ - we point now to the HF for accessing the dataset


*However*, this main fails on clap_nq!
And I do not succeed to understand why 


`from typing import Literal

from datasets import Dataset
from unitxt import load_dataset


def access_to_card(
    dataset_name,
    card_type: Literal["documents", "benchmark"],
    split: Literal["train", "test"],
) -> Dataset:

    template = "empty" if card_type == "documents" else "default"
    dataset_query = f"card=cards.rag.{card_type}.{dataset_name}.en,template_card_index={template}"
    d = load_dataset(dataset_query)
    return d[split]

if __name__ == '__main__':
    for d_name in [
        'bioasq',
        'clap_nq'
        ]:
        # Benchmark
        for s in ['train',
                  'test'
                  ]:
            print(f"#Benchmark ({s}) for {d_name} : {len(access_to_card(d_name, 'benchmark', s))}")
        # Documents:
        print(f"#Documents for {d_name} : {len(access_to_card(d_name, 'documents', 'train'))}")


`