### PR TITLE
Fix: Selected option for supporting negative indexes in place_correct…

### DIFF
--- a/src/unitxt/templates.py
+++ b/src/unitxt/templates.py
@@ -696,13 +696,7 @@ class MultipleChoiceTemplate(InputFormatTemplate):
         if self.place_correct_choice_position is not None:
             fix_pos = self.place_correct_choice_position
 
-            # Option 1: Clamping the position to the valid range
-            # Force the position to be within the valid range [0, len(choices)-1].
-            # If fix_pos is less than 0, it becomes 0.
-            # If fix_pos is greater than len(choices)-1, it becomes len(choices)-1.
-            fix_pos = max(0, min(fix_pos, len(choices) - 1))
-
-            # Option 2: Supporting negative indexes similar to Python lists
+            # Supporting negative indexes similar to Python lists
             # If fix_pos is negative, convert it to a valid positive index by adding len(choices).
             # For example, -1 becomes the last index, -2 becomes the one before last, etc.
             if fix_pos < 0:

--- a/tests/library/test_templates.py
+++ b/tests/library/test_templates.py
@@ -1327,6 +1327,51 @@ class TestTemplates(UnitxtTestCase):
 
         check_operator(template, inputs, targets, tester=self)
 
+    def test_multiple_choice_template_with_negative_index(self):
+        template = MultipleChoiceTemplate(
+            input_format="Text: {text}, Choices: {choices}.",
+            enumerator="capitals",
+            place_correct_choice_position=-1,  # Negative index to place correct choice last
+        )
+
+        inputs = [
+            {
+                "input_fields": {
+                    "choices": ["Option A", "Option B", "Option C", "Option D"],
+                    "text": "example negative index",
+                },
+                "reference_fields": {
+                    "choices": ["Option A", "Option B", "Option C", "Option D"],
+                    "label": 1,  # "Option B" is the correct choice at index 1
+                },
+            }
+        ]
+
+        # After placing correct choice ("Option B") at the last index:
+        # => ["Option A", "Option C", "Option D", "Option B"]
+        # => "Option B" is now at index 3 => enumerator => "D"
+        targets = [
+            {
+                "input_fields": {
+                    "choices": ["Option A", "Option C", "Option D", "Option B"],
+                    "text": "example negative index",
+                    "options": ["A", "B", "C", "D"],
+                },
+                "reference_fields": {
+                    "choices": ["Option A", "Option C", "Option D", "Option B"],
+                    "label": 3,  # "Option B" is now at index 3
+                },
+                "source": "Text: example negative index, Choices: A. Option A, B. Option C, C. Option D, D. Option B.",
+                "target": "D",
+                "references": ["D"],
+                "instruction": "",
+                "target_prefix": "",
+                "postprocessors": ["processors.to_string_stripped"],
+            }
+        ]
+
+        check_operator(template, inputs, targets, tester=self)
+
     def test_multiple_choice_template_verify_flags(self):
         with self.subTest("shuffle_choices + sort_choices_by_length"):
             with self.assertRaises(UnitxtError) as ve:


### PR DESCRIPTION
…_choice_position

- Implemented the logic for handling negative indexes similar to Python lists.
- If the position is negative, it is converted to a valid positive index by adding len(choices).
- Added a test to validate the behavior for negative indexing (-1 places the correct choice at the last index).