### PR TITLE
fix: minor bug when only space id is provided for WML inference

### DIFF
--- a/src/unitxt/inference.py
+++ b/src/unitxt/inference.py
@@ -2004,6 +2004,8 @@ class WMLInferenceEngineBase(
                 "only one of those defined in the env."
             )
             credentials["space_id"] = space_id
+        elif space_id:
+            credentials["space_id"] = space_id
         elif project_id:
             credentials["project_id"] = project_id
         else:


### PR DESCRIPTION
WML inference is expected to support either 'WML_SPACE_ID' or 'WML_PROJECT_ID' specified, however currently the code does not handle the case where only space id is specified.