### PR TITLE
Add prediction variable name customization to LLM as Judge

### DIFF
--- a/src/unitxt/llm_as_judge_chat_templates.py
+++ b/src/unitxt/llm_as_judge_chat_templates.py
@@ -3,20 +3,20 @@ from .templates import InputOutputTemplate
 direct_template_dict = {
     "assessment": InputOutputTemplate(
         input_format="""
-You are presented with a response generated subject to a context.
-The context includes information relevant to the nature or generation of the response.
-You will assess the quality of the response subject to an evaluation criteria.
+You are presented with a {response_variable_name} generated subject to a context.
+The context includes information relevant to the nature or generation of the {response_variable_name}.
+You will assess the quality of the {response_variable_name} subject to an evaluation criteria.
 ###Context:
 {context_variables}
 
-###Response:
+###{response_variable_name_title}:
 {response}
 
 ###Evaluation criteria:
 {criteria_description}
 {display_options_instruction}
 
-Briefly assess the quality of the response subject to the evaluation criteria.
+Briefly assess the quality of the {response_variable_name} subject to the evaluation criteria.
 Focus on the evaluation criteria during assessment, do not provide a general assessment.
 Assessment:
 
@@ -29,7 +29,7 @@ Assessment: {assessment}
 Summary:"""
     ),
     "answer": InputOutputTemplate(
-        input_format="""Now consider the evaluation criteria and choose a final answer. Only include the chosen answer in the response.
+        input_format="""Now consider the evaluation criteria and choose a final answer. Only include the chosen answer in the {response_variable_name}.
 ###Evaluation criteria:
 {criteria_description}
 {score_option_instruction}
@@ -41,8 +41,8 @@ The selected answer is: """,
 
 pairwise_template_dict = {
     "assessment": InputOutputTemplate(
-        input_format="""You are provided a pair of responses (Response {option_a} and Response {option_b}) generated subject to a context.
-You will choose the better quality response subject to the evaluation criteria.
+        input_format="""You are provided a pair of {response_variable_name}s ({response_variable_name_title} {option_a} and {response_variable_name_title} {option_b}) generated subject to a context.
+You will choose the better quality {response_variable_name} subject to the evaluation criteria.
 
 This is the context:
 {context_variables}
@@ -51,25 +51,25 @@ This is the evaluation criteria:
 {criteria_name}
 {criteria_description}
 
-Response {option_a}:
+{response_variable_name_title} {option_a}:
 {response_a}
-Response {option_b}:
+{response_variable_name_title} {option_b}:
 {response_b}
 
-Keeping the evaluation criteria in mind, briefly assess which response is better.
+Keeping the evaluation criteria in mind, briefly assess which {response_variable_name} is better.
 Focus on the evaluation criteria during assessment, do not provide a general assessment.
 Assessment:
 
 Lets think step by step """
     ),
     "summarization": InputOutputTemplate(
-        input_format="""Transform the following assessment into a concise summary that focuses on the key details, excluding references to the assessment itself. The summary must clearly state which response won.
+        input_format="""Transform the following assessment into a concise summary that focuses on the key details, excluding references to the assessment itself. The summary must clearly state which {response_variable_name} won.
 
 Assessment: {assessment}
 Summary:"""
     ),
     "answer": InputOutputTemplate(
-        input_format="""Now considering the evaluation criteria, which response is better quality? Only include the chosen response.
+        input_format="""Now considering the evaluation criteria, which {response_variable_name} is better quality? Only include the chosen {response_variable_name}.
 {score_option_instruction}
 Answer: """,
         postprocessors=["processors.match_closest_option"],


### PR DESCRIPTION
This PR implements customizing the prediction name, allowing to give the evaluator more information about what exactly is being evaluated. 

Currently, the prompts refers to a generic 'response'. This PR allows the prompt to refer to other words like: 'text', 'prediction', 'assistant_response', 'summary', etc.

The customization can be done in two ways: 
- setting `LLMJudge.response_variable_name`, which defaults to 'response', so that this is backward compatible, or
- setting `LLMJudge.response_variable_name_field` and including a key with name  being the value of `response_variable_name_field` to every task_data instance.