### PR TITLE
Add test to verify integrity of loaded datasets, Avoid copying=True for LoadHF and two more loaders. Remove loader cache (python knows how to manage main memory).

### DIFF
--- a/tests/library/test_loaders.py
+++ b/tests/library/test_loaders.py
@@ -4,6 +4,7 @@ import tempfile
 from unittest.mock import patch
 
 import pandas as pd
+from datasets import Dataset, DatasetDict, IterableDataset, IterableDatasetDict
 from unitxt.error_utils import UnitxtError
 from unitxt.loaders import (
     LoadCSV,
@@ -231,6 +232,23 @@ class TestLoaders(UnitxtTestCase):
             list(ms.keys()), ["test"]
         )  # that HF dataset only has the 'test' split
         self.assertEqual(instance["language"], "eng")
+
+    def test_load_HF_lazily(self):
+        lazy_loader = LoadHF(path="ibm/finqa", streaming=True)
+        dataset = lazy_loader.load_dataset(split="test")
+        self.assertIsInstance(dataset, (Dataset, IterableDataset))
+        # we just assured that load_dataset completed OK. LoadHF changed the value of streaming from True to False,
+        # the only value by which HF allows for the loading of this specific dataset.
+        # Now we try to touch the arriving dataset, which in current main is only done by the split generator when yielding
+        # and there, it is too late to change the value of Streaming.
+        first_example = next(iter(dataset))
+        self.assertIsNotNone (first_example)
+        # the same goes when split=None:
+        dataset = lazy_loader.load_dataset(split=None)
+        self.assertIsInstance(dataset, (DatasetDict, IterableDatasetDict))
+        for k in dataset.keys():
+            first_example = next(iter(dataset[k]))
+            self.assertIsNotNone (first_example)
 
     def test_load_from_HF_split(self):
         loader = LoadHF(path="sst2", split="train")

--- a/utils/.secrets.baseline
+++ b/utils/.secrets.baseline
@@ -143,15 +143,6 @@
         "line_number": 1808
       }
     ],
-    "src/unitxt/loaders.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/unitxt/loaders.py",
-        "hashed_secret": "840268f77a57d5553add023cfa8a4d1535f49742",
-        "is_verified": false,
-        "line_number": 602
-      }
-    ],
     "src/unitxt/metrics.py": [
       {
         "type": "Hex High Entropy String",
@@ -167,16 +158,16 @@
         "filename": "tests/library/test_loaders.py",
         "hashed_secret": "8d814baafe5d8412572dc520dcab83f60ce1375c",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 126
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/library/test_loaders.py",
         "hashed_secret": "42a472ac88cd8d43a2c5ae0bd0bdf4626cdaba31",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 136
       }
     ]
   },
-  "generated_at": "2025-02-25T18:27:39Z"
+  "generated_at": "2025-02-25T19:39:10Z"
 }


### PR DESCRIPTION
avoid copying=true (upon iterating over the loaded dataset) for the streams generated by the loader for loaders which watch out after the datasets they load - letting no one modify them. This is the case for LoadHF, LoadCSV, and LoadSKLearn.  For the rest -- copying=True remains.   Also, remove the loader cache. We are not sure what goes there (a whole listed dataset? just its generators?) and python better manages its main memory knowing the whole picture (and remove to file system whole pages as it sees fit)

E.g that demonstrates how the HF dataset, returned by LoadHF, is not modifiable.
``` python

    from datasets import load_dataset as hf_load_dataset
    ds = hf_load_dataset("PrimeQA/clapnq_passages")
    print(ds)
    iter_train = iter(ds["train"])
    iter_train2 = iter(ds["train"])
    for _ in range(5):
        instance = next(iter_train)
        print(instance["id"])
        instance["id"] = 5
    
    for _ in range(5):
        instance = next(iter_train2)
        print(instance["id"])
        
    iter_train = iter(ds["train"])
    iter_train2 = iter(ds["train"])
    for _ in range(5):
        instance = next(iter_train)
        old_value = instance.pop("id")
        instance["id_new"] = old_value
    
    for _ in range(5):
        instance = next(iter_train2)
        print(instance["id"])
        print("id_new" in instance)


```
```python

    DatasetDict({
        train: Dataset({
            features: ['id', 'text', 'title'],
            num_rows: 178890
        })
    })
    827849752_115-357
    827849752_358-743
    827849752_744-1186
    827849752_1187-1426
    827849752_1604-3189
    827849752_115-357
    827849752_358-743
    827849752_744-1186
    827849752_1187-1426
    827849752_1604-3189
    827849752_115-357
    False
    827849752_358-743
    False
    827849752_744-1186
    False
    827849752_1187-1426
    False
    827849752_1604-3189
    False
```