### PR TITLE
Added MILU and Indic BoolQ Support

### DIFF
--- a/prepare/cards/boolq_indic.py
+++ b/prepare/cards/boolq_indic.py
@@ -1,0 +1,99 @@
+from unitxt.blocks import (
+    LoadHF,
+    Set,
+    TaskCard,
+)
+from unitxt.catalog import add_to_catalog
+from unitxt.operators import (
+    CastFields,
+    FilterByCondition,
+    Rename,
+)
+from unitxt.test_utils.card import test_card
+
+languages = ["bn", "gu", "hi", "kn", "mr", "ml", "or", "pa", "ta", "te"]
+
+for language in languages:
+    card = TaskCard(
+        loader=LoadHF(path="sarvamai/boolq-indic"),
+        preprocess_steps=[
+            FilterByCondition(values={"language": language}, condition="eq"),
+            "splitters.small_no_test",
+            Set(
+                {
+                    "text_a_type": "passage",
+                    "text_b_type": "question",
+                    "classes": ["yes", "no"],
+                    "type_of_relation": "answer",
+                },
+            ),
+            CastFields(fields={"answer": "str"}),
+            Rename(
+                field_to_field={
+                    "passage": "text_a",
+                    "question": "text_b",
+                    "answer": "label",
+                }
+            ),
+        ],
+        task="tasks.classification.multi_class.relation",
+        templates="templates.classification.multi_class.relation.all",
+        __tags__={
+            "annotations_creators": "Sarvam AI",
+            "arxiv": "1905.10044",
+            "license": "cc-by-sa-3.0",
+            "multilinguality": "multilingual",
+            "region": "in",
+            "size_categories": "10K<n<100K",
+            "source_datasets": "translation",
+            "task_categories": "text-classification",
+            "task_ids": "natural-language-inference",
+        },
+        __description__=(
+            "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+        ),
+    )
+
+    test_card(card, demos_taken_from="test")
+    add_to_catalog(card, f"cards.boolq_indic.{language}.classification", overwrite=True)
+
+    card = TaskCard(
+        loader=LoadHF(path="sarvamai/boolq-indic"),
+        preprocess_steps=[
+            FilterByCondition(values={"language": language}, condition="eq"),
+            "splitters.small_no_test",
+            Set(
+                {
+                    "context_type": "passage",
+                    "choices": ["yes", "no"],
+                },
+            ),
+            CastFields(fields={"answer": "str"}),
+            Rename(
+                field_to_field={
+                    "passage": "context",
+                }
+            ),
+        ],
+        task="tasks.qa.multiple_choice.with_context",
+        templates="templates.qa.multiple_choice.with_context.all",
+        __tags__={
+            "annotations_creators": "Sarvam AI",
+            "arxiv": "1905.10044",
+            "license": "cc-by-sa-3.0",
+            "multilinguality": "multilingual",
+            "region": "in",
+            "size_categories": "10K<n<100K",
+            "source_datasets": "translation",
+            "task_categories": "text-classification",
+            "task_ids": "natural-language-inference",
+        },
+        __description__=(
+            "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+        ),
+    )
+
+    test_card(card, demos_taken_from="test", strict=False)
+    add_to_catalog(
+        card, f"cards.boolq_indic.{language}.multiple_choice", overwrite=True
+    )

--- a/prepare/cards/milu.py
+++ b/prepare/cards/milu.py
@@ -1,0 +1,99 @@
+from unitxt.card import TaskCard
+from unitxt.catalog import add_to_catalog
+from unitxt.loaders import LoadHF
+from unitxt.operators import (
+    Deduplicate,
+    FilterByCondition,
+    ListFieldValues,
+    MapInstanceValues,
+    Rename,
+    Set,
+)
+from unitxt.splitters import RenameSplits
+from unitxt.test_utils.card import test_card
+
+languages = [
+    ["Bengali", "bn"],
+    ["English", "en"],
+    ["Gujarati", "gu"],
+    ["Hindi", "hi"],
+    ["Kannada", "kn"],
+    ["Malayalam", "ml"],
+    ["Marathi", "mr"],
+    ["Odia", "or"],
+    ["Punjabi", "pa"],
+    ["Tamil", "ta"],
+    ["Telugu", "te"],
+]
+
+subtasks = [
+    "Arts & Humanities",
+    "Business Studies",
+    "Engineering & Tech",
+    "Environmental Sciences",
+    "Health & Medicine",
+    "Law & Governance",
+    "Science",
+    "Social Sciences",
+]
+
+is_first = True
+for language in languages:
+    for subtask in subtasks:
+        card = TaskCard(
+            loader=LoadHF(
+                path="ai4bharat/MILU",
+                data_dir=language[0],
+                splits=["validation", "test"],
+            ),
+            preprocess_steps=[
+                FilterByCondition(values={"domain": subtask}, condition="eq"),
+                Deduplicate(by=["question", "subject", "target"]),
+                RenameSplits({"validation": "train"}),
+                Rename(field_to_field={"target": "answer"}),
+                MapInstanceValues(
+                    mappers={
+                        "answer": {
+                            "option1": 0,
+                            "option2": 1,
+                            "option3": 2,
+                            "option4": 3,
+                        }
+                    }
+                ),
+                ListFieldValues(
+                    fields=["option1", "option2", "option3", "option4"],
+                    to_field="choices",
+                ),
+                Set({"topic": subtask}),
+            ],
+            task="tasks.qa.multiple_choice.with_topic",
+            templates=["templates.qa.multiple_choice.with_topic.all"],
+            __tags__={
+                "annotations_creators": "no-annotation",
+                "arxiv": ["2411.02538"],
+                "language": language[1],
+                "language_creators": "expert-generated",
+                "license": "CC BY 4.0",
+                "multilinguality": "multilingual",
+                "region": "in",
+                "size_categories": "10K<n<100K",
+                "source_datasets": "original",
+                "task_categories": "question-answering",
+                "task_ids": "multiple-choice-qa",
+            },
+            __description__=(
+                "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+            ),
+        )
+
+        if is_first:
+            test_card(card, strict=False)
+            is_first = False
+
+        subject = subtask.replace("&", "and").replace(" ", "_")
+        add_to_catalog(
+            card,
+            f"cards.milu.{language[0]}.{subject}",
+            overwrite=True,
+        )

--- a/src/unitxt/catalog/cards/boolq_indic/bn/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/bn/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "bn"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/bn/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/bn/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "bn"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/gu/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/gu/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "gu"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/gu/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/gu/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "gu"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/hi/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/hi/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "hi"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/hi/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/hi/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "hi"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/kn/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/kn/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "kn"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/kn/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/kn/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "kn"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/ml/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/ml/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "ml"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/ml/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/ml/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "ml"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/mr/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/mr/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "mr"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/mr/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/mr/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "mr"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/or/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/or/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "or"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/or/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/or/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "or"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/pa/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/pa/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "pa"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/pa/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/pa/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "pa"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/ta/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/ta/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "ta"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/ta/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/ta/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "ta"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/te/classification.json
+++ b/src/unitxt/catalog/cards/boolq_indic/te/classification.json
@@ -1,0 +1,57 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "te"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "text_a_type": "passage",
+                "text_b_type": "question",
+                "classes": [
+                    "yes",
+                    "no"
+                ],
+                "type_of_relation": "answer"
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "text_a",
+                "question": "text_b",
+                "answer": "label"
+            }
+        }
+    ],
+    "task": "tasks.classification.multi_class.relation",
+    "templates": "templates.classification.multi_class.relation.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/boolq_indic/te/multiple_choice.json
+++ b/src/unitxt/catalog/cards/boolq_indic/te/multiple_choice.json
@@ -1,0 +1,53 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "sarvamai/boolq-indic"
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "language": "te"
+            },
+            "condition": "eq"
+        },
+        "splitters.small_no_test",
+        {
+            "__type__": "set",
+            "fields": {
+                "context_type": "passage",
+                "choices": [
+                    "yes",
+                    "no"
+                ]
+            }
+        },
+        {
+            "__type__": "cast_fields",
+            "fields": {
+                "answer": "str"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "passage": "context"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_context",
+    "templates": "templates.qa.multiple_choice.with_context.all",
+    "__tags__": {
+        "annotations_creators": "Sarvam AI",
+        "arxiv": "1905.10044",
+        "license": "cc-by-sa-3.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "translation",
+        "task_categories": "text-classification",
+        "task_ids": "natural-language-inference"
+    },
+    "__description__": "A multilingual version of the BoolQ (Boolean Questions) dataset, translated from English into 10 Indian languages. It is a question-answering dataset for yes/no questions containing ~12k naturally occurring questions."
+}

--- a/src/unitxt/catalog/cards/milu/Bengali/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Bengali/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Bengali",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "bn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Bengali/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Bengali/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Bengali",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "bn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Bengali/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Bengali/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Bengali",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "bn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Bengali/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Bengali/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Bengali",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "bn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Bengali/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Bengali/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Bengali",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "bn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Bengali/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Bengali/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Bengali",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "bn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Bengali/Science.json
+++ b/src/unitxt/catalog/cards/milu/Bengali/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Bengali",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "bn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Bengali/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Bengali/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Bengali",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "bn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/English/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/English/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "English",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "en",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/English/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/English/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "English",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "en",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/English/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/English/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "English",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "en",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/English/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/English/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "English",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "en",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/English/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/English/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "English",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "en",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/English/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/English/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "English",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "en",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/English/Science.json
+++ b/src/unitxt/catalog/cards/milu/English/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "English",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "en",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/English/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/English/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "English",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "en",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Gujarati/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Gujarati/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Gujarati",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "gu",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Gujarati/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Gujarati/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Gujarati",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "gu",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Gujarati/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Gujarati/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Gujarati",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "gu",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Gujarati/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Gujarati/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Gujarati",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "gu",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Gujarati/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Gujarati/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Gujarati",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "gu",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Gujarati/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Gujarati/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Gujarati",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "gu",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Gujarati/Science.json
+++ b/src/unitxt/catalog/cards/milu/Gujarati/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Gujarati",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "gu",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Gujarati/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Gujarati/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Gujarati",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "gu",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Hindi/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Hindi/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Hindi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "hi",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Hindi/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Hindi/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Hindi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "hi",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Hindi/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Hindi/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Hindi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "hi",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Hindi/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Hindi/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Hindi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "hi",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Hindi/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Hindi/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Hindi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "hi",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Hindi/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Hindi/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Hindi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "hi",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Hindi/Science.json
+++ b/src/unitxt/catalog/cards/milu/Hindi/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Hindi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "hi",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Hindi/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Hindi/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Hindi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "hi",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Kannada/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Kannada/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Kannada",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "kn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Kannada/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Kannada/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Kannada",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "kn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Kannada/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Kannada/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Kannada",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "kn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Kannada/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Kannada/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Kannada",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "kn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Kannada/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Kannada/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Kannada",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "kn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Kannada/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Kannada/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Kannada",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "kn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Kannada/Science.json
+++ b/src/unitxt/catalog/cards/milu/Kannada/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Kannada",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "kn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Kannada/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Kannada/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Kannada",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "kn",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Malayalam/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Malayalam/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Malayalam",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ml",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Malayalam/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Malayalam/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Malayalam",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ml",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Malayalam/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Malayalam/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Malayalam",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ml",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Malayalam/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Malayalam/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Malayalam",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ml",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Malayalam/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Malayalam/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Malayalam",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ml",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Malayalam/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Malayalam/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Malayalam",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ml",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Malayalam/Science.json
+++ b/src/unitxt/catalog/cards/milu/Malayalam/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Malayalam",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ml",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Malayalam/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Malayalam/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Malayalam",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ml",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Marathi/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Marathi/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Marathi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "mr",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Marathi/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Marathi/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Marathi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "mr",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Marathi/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Marathi/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Marathi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "mr",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Marathi/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Marathi/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Marathi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "mr",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Marathi/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Marathi/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Marathi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "mr",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Marathi/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Marathi/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Marathi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "mr",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Marathi/Science.json
+++ b/src/unitxt/catalog/cards/milu/Marathi/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Marathi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "mr",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Marathi/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Marathi/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Marathi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "mr",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Odia/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Odia/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Odia",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "or",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Odia/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Odia/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Odia",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "or",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Odia/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Odia/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Odia",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "or",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Odia/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Odia/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Odia",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "or",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Odia/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Odia/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Odia",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "or",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Odia/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Odia/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Odia",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "or",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Odia/Science.json
+++ b/src/unitxt/catalog/cards/milu/Odia/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Odia",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "or",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Odia/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Odia/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Odia",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "or",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Punjabi/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Punjabi/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Punjabi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "pa",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Punjabi/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Punjabi/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Punjabi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "pa",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Punjabi/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Punjabi/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Punjabi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "pa",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Punjabi/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Punjabi/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Punjabi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "pa",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Punjabi/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Punjabi/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Punjabi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "pa",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Punjabi/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Punjabi/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Punjabi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "pa",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Punjabi/Science.json
+++ b/src/unitxt/catalog/cards/milu/Punjabi/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Punjabi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "pa",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Punjabi/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Punjabi/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Punjabi",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "pa",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Tamil/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Tamil/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Tamil",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ta",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Tamil/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Tamil/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Tamil",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ta",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Tamil/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Tamil/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Tamil",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ta",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Tamil/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Tamil/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Tamil",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ta",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Tamil/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Tamil/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Tamil",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ta",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Tamil/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Tamil/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Tamil",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ta",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Tamil/Science.json
+++ b/src/unitxt/catalog/cards/milu/Tamil/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Tamil",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ta",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Tamil/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Tamil/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Tamil",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "ta",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Telugu/Arts_and_Humanities.json
+++ b/src/unitxt/catalog/cards/milu/Telugu/Arts_and_Humanities.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Telugu",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Arts & Humanities"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Arts & Humanities"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "te",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Telugu/Business_Studies.json
+++ b/src/unitxt/catalog/cards/milu/Telugu/Business_Studies.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Telugu",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Business Studies"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Business Studies"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "te",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Telugu/Engineering_and_Tech.json
+++ b/src/unitxt/catalog/cards/milu/Telugu/Engineering_and_Tech.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Telugu",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Engineering & Tech"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Engineering & Tech"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "te",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Telugu/Environmental_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Telugu/Environmental_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Telugu",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Environmental Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Environmental Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "te",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Telugu/Health_and_Medicine.json
+++ b/src/unitxt/catalog/cards/milu/Telugu/Health_and_Medicine.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Telugu",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Health & Medicine"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Health & Medicine"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "te",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Telugu/Law_and_Governance.json
+++ b/src/unitxt/catalog/cards/milu/Telugu/Law_and_Governance.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Telugu",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Law & Governance"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Law & Governance"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "te",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Telugu/Science.json
+++ b/src/unitxt/catalog/cards/milu/Telugu/Science.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Telugu",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Science"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Science"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "te",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}

--- a/src/unitxt/catalog/cards/milu/Telugu/Social_Sciences.json
+++ b/src/unitxt/catalog/cards/milu/Telugu/Social_Sciences.json
@@ -1,0 +1,88 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_hf",
+        "path": "ai4bharat/MILU",
+        "data_dir": "Telugu",
+        "splits": [
+            "validation",
+            "test"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "filter_by_condition",
+            "values": {
+                "domain": "Social Sciences"
+            },
+            "condition": "eq"
+        },
+        {
+            "__type__": "deduplicate",
+            "by": [
+                "question",
+                "subject",
+                "target"
+            ]
+        },
+        {
+            "__type__": "rename_splits",
+            "mapper": {
+                "validation": "train"
+            }
+        },
+        {
+            "__type__": "rename",
+            "field_to_field": {
+                "target": "answer"
+            }
+        },
+        {
+            "__type__": "map_instance_values",
+            "mappers": {
+                "answer": {
+                    "option1": 0,
+                    "option2": 1,
+                    "option3": 2,
+                    "option4": 3
+                }
+            }
+        },
+        {
+            "__type__": "list_field_values",
+            "fields": [
+                "option1",
+                "option2",
+                "option3",
+                "option4"
+            ],
+            "to_field": "choices"
+        },
+        {
+            "__type__": "set",
+            "fields": {
+                "topic": "Social Sciences"
+            }
+        }
+    ],
+    "task": "tasks.qa.multiple_choice.with_topic",
+    "templates": [
+        "templates.qa.multiple_choice.with_topic.all"
+    ],
+    "__tags__": {
+        "annotations_creators": "no-annotation",
+        "arxiv": [
+            "2411.02538"
+        ],
+        "language": "te",
+        "language_creators": "expert-generated",
+        "license": "CC BY 4.0",
+        "multilinguality": "multilingual",
+        "region": "in",
+        "size_categories": "10K<n<100K",
+        "source_datasets": "original",
+        "task_categories": "question-answering",
+        "task_ids": "multiple-choice-qa"
+    },
+    "__description__": "MILU (Multi-task Indic Language Understanding Benchmark) is a comprehensive evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages. It spans 8 domains and 41 subjects, reflecting both general and culturally specific knowledge from India. See the full description on the dataset page: https://huggingface.co/datasets/ai4bharat/MILU."
+}


### PR DESCRIPTION
This PR adds support for [MILU](https://huggingface.co/datasets/ai4bharat/MILU) which is an evaluation dataset designed to assess the performance of Large Language Models (LLMs) across 11 Indic languages and [BoolQ Indic](https://huggingface.co/datasets/sarvamai/boolq-indic) which is BoolQ data translated to Indic languages.