### PR TITLE
Performance to report accurate times based on end-to-end time() diffs, rather than accumulate cProfile numbers over methods that seemed relevant.

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -44,12 +44,17 @@ jobs:
     - name: Prepare the dirs for performance evaluation in main
       run: |
         mkdir -p performance_action
+        mkdir -p performance_action/hf_fs_cache
         cp performance/bluebench_profiler.py performance_action/bluebench_profiler.py
         cp performance/compare_benchmark_performance_results.py performance_action/compare_benchmark_performance_results.py
 
-    - name: Run performance on PR just to warm the cache, output will be overwritten
+    - name: Run performance on PR just to fill the file systems cache
+      env: 
+        UNITXT_HF_LOAD_FROM_OFFLINE: "False"
+        UNITXT_HF_SAVE_TO_OFFLINE: "True"
+        UNITXT_HF_OFFLINE_DATASETS_PATH: performance_action/hf_fs_cache
       run : |
-        python performance_action/bluebench_profiler.py --output_file performance_action/pr_results.json
+        python performance_action/bluebench_profiler.py --output_file performance_action/pr_results.json --populate_fs_cache  >> $GITHUB_STEP_SUMMARY
 
     - name: Checkout main branch
       uses: actions/checkout@v4
@@ -58,6 +63,10 @@ jobs:
         clean: false
 
     - name: Run performance on main branch
+      env: 
+        UNITXT_HF_SAVE_TO_OFFLINE: "False"        
+        UNITXT_HF_LOAD_FROM_OFFLINE: "True"
+        UNITXT_HF_OFFLINE_DATASETS_PATH: performance_action/hf_fs_cache
       run: |
         python performance_action/bluebench_profiler.py --output_file performance_action/main_results.json
 
@@ -68,6 +77,10 @@ jobs:
         clean: false
 
     - name: Run performance on PR branch
+      env:
+        UNITXT_HF_SAVE_TO_OFFLINE: "False"        
+        UNITXT_HF_LOAD_FROM_OFFLINE: "True"
+        UNITXT_HF_OFFLINE_DATASETS_PATH: performance_action/hf_fs_cache    
       run: |
         python performance_action/bluebench_profiler.py --output_file performance_action/pr_results.json
 

--- a/docs/docs/adding_dataset.rst
+++ b/docs/docs/adding_dataset.rst
@@ -64,7 +64,7 @@ If a catalogued task fits your use case, you may reference it by name:
     task='tasks.translation.directed',
 
 Loading the Dataset
----------------------
+--------------------
 
 To load data from an external source, we use a loader.
 For example, to load the `wmt16` translation dataset from the HuggingFace hub:
@@ -74,6 +74,13 @@ For example, to load the `wmt16` translation dataset from the HuggingFace hub:
     loader=LoadHF(path="wmt16", name="de-en"),
 
 More loaders for different sources are available in the  :class:`loaders <unitxt.loaders>` section.
+
+Loading from (and savig to) local file-system
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Setting env variable ``UNITXT_HF_LOAD_FROM_OFFLINE=true``, will have loaders fetch the data from the local file-system directory
+specified by env variable ``UNITXT_HF_OFFLINE_DATASET_PATH``. To have loaders save the data they fetched from an 
+outside hub, in that specified local file-system directory, set ``UNITXT_HF_SAVE_TO_OFFLINE=true``
 
 The Preprocessing Pipeline
 ---------------------------

--- a/src/unitxt/settings_utils.py
+++ b/src/unitxt/settings_utils.py
@@ -156,6 +156,8 @@ if Settings.is_uninitilized():
     settings.task_data_as_text = (bool, True)
     settings.default_provider = "watsonx"
     settings.default_format = None
+    settings.hf_load_from_offline = (bool, False)
+    settings.hf_save_to_offline = (bool, False)
     settings.hf_offline_datasets_path = None
     settings.hf_offline_metrics_path = None
     settings.hf_offline_models_path = None

--- a/tests/library/test_loaders.py
+++ b/tests/library/test_loaders.py
@@ -10,6 +10,7 @@ from unitxt.loaders import (
     LoadFromDictionary,
     LoadFromHFSpace,
     LoadFromIBMCloud,
+    LoadFromSklearn,
     LoadHF,
     MultipleSourceLoader,
 )
@@ -88,6 +89,16 @@ class TestLoaders(UnitxtTestCase):
             with self.assertRaises(FileNotFoundError):
                 list(LoadCSV(files={"test": "not_exist.csv"})()["test"])
 
+
+    def test_load_csv_with_json_files(self):
+        DummyBucket().download_file(item_name=None, local_file="local_file.jsonl", Callback=None)
+        loader = LoadCSV(files={"train":"local_file.jsonl"}, lines=2, file_type="json", loader_limit=2)
+        loaded_dataset = loader.load_data()
+        self.assertListEqual(CONTENT, list(loaded_dataset["train"]))
+
+        loader=LoadFromSklearn(dataset_name="20newsgroups", streaming=False)
+        loaded_dataset = loader.load_data()
+        self.assertEqual(11314, len(list(loaded_dataset["train"])))
 
     def test_load_csv_with_pandas_args(self):
         # Using a context for the temporary directory


### PR DESCRIPTION
-  completed the mechanism to load HF datasets from a local file-system, set up by @elronbandel, to also save into such (all pending settings values), and extended for CSV too.
-  introduced a mechanism to just load the instances that were actually pulled from the raw (typically HF) dataset into unitxt, in order to complete the recipe. Thus, together, can now report more accurately, based on genuine time() reads, the performance times of: 
   - load from HF (or other web sites) down to local file system
   - load from file system to main mem and iterate over the exact instances that actually participated in the benchmark
   - do all the rest: 
      - prepare for inference 
      - infer, and 
      - evaluate.
-  removed the `max_samples_per_subset=30` from `bluebench dataset query`, since when that limitation is in effect, most recipes do not participate in the fused result. 