### PR TITLE
present catalog entries as pieces of python code

### DIFF
--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from docutils.core import publish_parts
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
-from pygments.lexers import YamlLexer
+from pygments.lexers import PythonLexer
 from unitxt.artifact import Artifact
-from unitxt.text_utils import print_dict_as_yaml
+from unitxt.text_utils import print_dict_as_python
 from unitxt.utils import load_json
 
 
@@ -36,12 +36,12 @@ def convert_rst_text_to_html(rst_text):
 
 
 def dict_to_syntax_highlighted_html(nested_dict):
-    # Convert the dictionary to a YAML string with indentation
-    yaml_str = print_dict_as_yaml(nested_dict)
+    # Convert the dictionary to a python string with indentation
+    py_str = print_dict_as_python(nested_dict, indent_delta=4)
     # Initialize the HTML formatter with no additional wrapper
     formatter = HtmlFormatter(nowrap=True)
     # Apply syntax highlighting
-    return highlight(yaml_str, YamlLexer(), formatter)
+    return highlight(py_str, PythonLexer(), formatter)
 
 
 def write_title(title, label):
@@ -163,12 +163,14 @@ def make_content(artifact, label, all_labels):
         )
 
     for type_name in type_elements:
-        source = f'<span class="nt">__type__</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">{type_name}</span>'
+        # source = f'<span class="nt">__type__</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">{type_name}</span>'
+        source = f'<span class="n">__type__{type_name}</span><span class="p">(</span>'
         target = artifact_type_to_link(type_name)
         html_for_dict = html_for_dict.replace(
             source,
-            '<span class="nt">&quot;type&quot;</span><span class="p">:</span><span class="w"> </span>'
-            + target,
+            f'<span class="n" STYLE="font-size:108%">{target}</span><span class="p">(</span>'
+            # '<span class="nt">&quot;type&quot;</span><span class="p">:</span><span class="w"> </span>'
+            # + target,
         )
 
     pattern = r'(<span class="nt">)&quot;(.*?)&quot;(</span>)'

--- a/docs/catalog.py
+++ b/docs/catalog.py
@@ -164,11 +164,11 @@ def make_content(artifact, label, all_labels):
 
     for type_name in type_elements:
         # source = f'<span class="nt">__type__</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">{type_name}</span>'
-        source = f'<span class="n">__type__{type_name}</span><span class="p">(</span>'
+        source = f'<span class="n">__type__{type_name}</span><span class="p">'
         target = artifact_type_to_link(type_name)
         html_for_dict = html_for_dict.replace(
             source,
-            f'<span class="n" STYLE="font-size:108%">{target}</span><span class="p">(</span>'
+            f'<span class="n" STYLE="font-size:108%">{target}</span><span class="p">'
             # '<span class="nt">&quot;type&quot;</span><span class="p">:</span><span class="w"> </span>'
             # + target,
         )

--- a/src/unitxt/inference.py
+++ b/src/unitxt/inference.py
@@ -2985,7 +2985,9 @@ class CrossProviderInferenceEngine(InferenceEngine, StandardAPIParamsMixin):
             mapping each supported API to a corresponding
             model identifier string. This mapping allows consistent access to models
             across different API backends.
-        provider_specific_args: (Optional[Dict[str, Dict[str,str]]]) Args specific to a provider for example provider_specific_args={"watsonx": {"max_requests_per_second": 4}}
+        provider_specific_args:
+            (Optional[Dict[str, Dict[str,str]]]) Args specific to a provider for example provider_specific_args={"watsonx": {"max_requests_per_second": 4}}
+
     """
 
     label: str = "cross_provider"

--- a/src/unitxt/llm_as_judge_from_template.py
+++ b/src/unitxt/llm_as_judge_from_template.py
@@ -37,6 +37,7 @@ class LLMAsJudgeBase(BulkInstanceMetric, ArtifactFetcherMixin):
         inference_model (InferenceEngine): The module that creates the inference of the judge llm.
         reduction_map (dict): A dictionary specifying the reduction method for the metric.
         batch_size (int): The size of the bulk.
+
     """
 
     main_score: str = "llm_as_judge"

--- a/src/unitxt/text_utils.py
+++ b/src/unitxt/text_utils.py
@@ -201,7 +201,7 @@ def construct_dict_as_yaml_lines(d, indent_delta=2) -> List[str]:
     assert (
         indent_delta >= 2
     ), f"Needs at least 2 position indentations, for the case of list elements, that are to be preceded each by ' -'. Got indent_delta={indent_delta}."
-    res = []  # conputed hereunder as a list of lines, that are indented only at the end
+    res = []  # computed hereunder as a list of lines, that are indented only at the end
 
     if isinstance(d, dict):
         if len(d) == 0:
@@ -236,6 +236,76 @@ def construct_dict_as_yaml_lines(d, indent_delta=2) -> List[str]:
         d1 = f'"{d1}"'
     return [d1]
 
+def construct_dict_as_python_lines(d, indent_delta=4) -> List[str]:
+    """Constructs the lines of a dictionary formatted as a piece of python code.
+
+    Args:
+        d: The element to be formatted.
+        indent_delta (int, optional): The amount of spaces to add for each level of indentation. Defaults to 2.
+    """
+
+    def is_simple(val) -> bool:
+        # if can show in same line as dictionary's key
+        return val is None or not isinstance(val, (dict, list)) or (len(val) == 0)
+
+    indent_delta_str = " " * indent_delta
+    res = []  # computed hereunder as a list of lines, that are indented only at the end
+
+    if isinstance(d, dict):
+        istype = False
+        if len(d) == 0:
+            return ["{}"]
+        if "__type__" in d:
+            istype = True
+            res = ["__type__" + d["__type__"] + "("]
+        else:
+            res = ["{"]
+        for key, val in d.items():
+            if key == "__type__":
+                continue
+            printable_key = f'"{key}"' if not istype else key
+            res.append(printable_key + ("=" if istype else ": "))
+            py_for_val = construct_dict_as_python_lines(val, indent_delta=indent_delta)
+            assert len(py_for_val) > 0
+            if is_simple(val):
+                assert len(py_for_val) == 1
+                res[-1] += (py_for_val[0] +",")
+            else:
+                assert len(py_for_val) > 1
+                res[-1] += py_for_val[0]
+                if py_for_val[0].startswith("{") or py_for_val[0].startswith("["):
+                    for line in py_for_val[1:-1]:
+                        res.append(indent_delta_str + line)
+                else:
+                    # val is type, its inner lines are already indented
+                    res.extend(py_for_val[1:-1])
+                res.append(py_for_val[-1]+",")
+        res.append(")" if istype else "}")
+        if istype:
+            for i in range(1,len(res)-1):
+                res[i] = indent_delta_str+res[i]
+        return res
+
+    if isinstance(d, list):
+        if len(d) == 0:
+            return ["[]"]
+        res = ["["]
+        for val in d:
+            py_for_val = construct_dict_as_python_lines(val, indent_delta=indent_delta)
+            assert len(py_for_val) > 0
+            for line in py_for_val[:-1]:
+                res.append(line)
+            res.append(py_for_val[-1] + ",")
+        res.append("]")
+        return res
+
+    # d1 = re.sub(r"(\n+)", r'"\1"', str(d))
+    if isinstance(d, str):
+        return [f'"{d}"']
+    if d is None or isinstance (d, (int, float, bool)):
+        return [f"{d}"]
+    raise RuntimeError(f"unrecognized value to print as python: {d}")
+
 
 def print_dict(
     d, indent=0, indent_delta=4, max_chars=None, keys_to_print=None, log_level="info"
@@ -246,11 +316,15 @@ def print_dict(
 
 
 def print_dict_as_yaml(d: dict, indent_delta=2) -> str:
-    yaml_lines = construct_dict_as_yaml_lines(d)
+    yaml_lines = construct_dict_as_yaml_lines(d, indent_delta=indent_delta)
     # yaml_lines = [re.sub(r"(\n+)", r'"\1"', line) for line in yaml_lines]
     # yaml_lines = [line.replace("\n", "\\n") for line in yaml_lines]
     return "\n".join(yaml_lines)
 
+def print_dict_as_python(d: dict, indent_delta=4) -> str:
+    py_lines = construct_dict_as_python_lines(d, indent_delta=indent_delta)
+    assert len(py_lines)> 1
+    return "\n".join(py_lines)
 
 def nested_tuple_to_string(nested_tuple: tuple) -> str:
     """Converts a nested tuple to a string, with elements separated by underscores.

--- a/src/unitxt/text_utils.py
+++ b/src/unitxt/text_utils.py
@@ -243,11 +243,6 @@ def construct_dict_as_python_lines(d, indent_delta=4) -> List[str]:
         d: The element to be formatted.
         indent_delta (int, optional): The amount of spaces to add for each level of indentation. Defaults to 2.
     """
-
-    def is_simple(val) -> bool:
-        # if can show in same line as dictionary's key
-        return val is None or not isinstance(val, (dict, list)) or (len(val) == 0)
-
     indent_delta_str = " " * indent_delta
     res = []  # computed hereunder as a list of lines, that are indented only at the end
 
@@ -258,6 +253,9 @@ def construct_dict_as_python_lines(d, indent_delta=4) -> List[str]:
         if "__type__" in d:
             istype = True
             res = ["__type__" + d["__type__"] + "("]
+            if len(d) == 1:
+                res[0] += ")"
+                return res
         else:
             res = ["{"]
         for key, val in d.items():
@@ -267,11 +265,9 @@ def construct_dict_as_python_lines(d, indent_delta=4) -> List[str]:
             res.append(printable_key + ("=" if istype else ": "))
             py_for_val = construct_dict_as_python_lines(val, indent_delta=indent_delta)
             assert len(py_for_val) > 0
-            if is_simple(val):
-                assert len(py_for_val) == 1
+            if len(py_for_val) == 1:
                 res[-1] += (py_for_val[0] +",")
             else:
-                assert len(py_for_val) > 1
                 res[-1] += py_for_val[0]
                 if py_for_val[0].startswith("{") or py_for_val[0].startswith("["):
                     for line in py_for_val[1:-1]:
@@ -323,7 +319,7 @@ def print_dict_as_yaml(d: dict, indent_delta=2) -> str:
 
 def print_dict_as_python(d: dict, indent_delta=4) -> str:
     py_lines = construct_dict_as_python_lines(d, indent_delta=indent_delta)
-    assert len(py_lines)> 1
+    assert len(py_lines)> 0
     return "\n".join(py_lines)
 
 def nested_tuple_to_string(nested_tuple: tuple) -> str:


### PR DESCRIPTION
E.g.:
![image](https://github.com/user-attachments/assets/ef80831a-0ec0-48f8-9403-1b1a5014ea55)

and fixed two docstrings against red lines in `make docs-server`