### PR TITLE
add 'show more' button for imports from unitxt modules

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -206,3 +206,8 @@ div.document div.documentwrapper {
 .red {
   color: red;
 }
+
+#unitxtImports {
+  /* Display nothing for the element */
+  display: none;
+}         


### PR DESCRIPTION
E.g.:
![image](https://github.com/user-attachments/assets/27875de2-e6e3-43e5-9f68-8847986288fa)
and 
![image](https://github.com/user-attachments/assets/ef8a9c0a-7f6f-4761-b238-2386e769cad7)
