### PR TITLE
Improve LLM as Judge consistency

### DIFF
--- a/prepare/metrics/llm_as_judge/llm_as_judge.py
+++ b/prepare/metrics/llm_as_judge/llm_as_judge.py
@@ -23,7 +23,7 @@ def get_evaluator(
     provider: ModelProviderEnum,
 ) -> Union[LLMJudgeDirect, LLMJudgePairwise]:
     evaluator_metadata = get_evaluator_metadata(name)
-    inference_params = {"max_tokens": 1024, "seed": 42}
+    inference_params = {"max_tokens": 1024, "seed": 42, "temperature": 0}
     model_name = EVALUATOR_TO_MODEL_ID[name]
 
     if provider == ModelProviderEnum.AZURE_OPENAI:

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/azure_openai/gpt_4o.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/azure_openai/gpt_4o.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "credentials": {
             "api_base": "https://eteopenai.azure-api.net/openai/deployments/gpt-4o-2024-08-06/chat/completions?api-version=2024-08-01-preview"
         },

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/azure_openai/o1_mini.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/azure_openai/o1_mini.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "credentials": {
             "api_base": "https://eteopenai.azure-api.net/openai/deployments/o1-mini/chat/completions?api-version=2024-08-01-preview"
         },

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/azure_openai/o1_preview.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/azure_openai/o1_preview.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "credentials": {
             "api_base": "https://eteopenai.azure-api.net/openai/deployments/o1-preview/chat/completions?api-version=2024-08-01-preview"
         },

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/openai/gpt_4o.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/openai/gpt_4o.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "gpt-4o-2024-08-06"
     },
     "evaluator_name": "GPT4",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/openai/o1_mini.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/openai/o1_mini.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "o1-mini"
     },
     "evaluator_name": "O1_MINI",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/openai/o1_preview.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/openai/o1_preview.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "o1-preview"
     },
     "evaluator_name": "O1_PREVIEW",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/granite3_0_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/granite3_0_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-8b-instruct"
     },
     "evaluator_name": "GRANITE3_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/granite3_1_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/granite3_1_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-1-8b-instruct"
     },
     "evaluator_name": "GRANITE3_1_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/granite3_2_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/granite3_2_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-2-8b-instruct"
     },
     "evaluator_name": "GRANITE3_2_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/llama3_1_405b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/llama3_1_405b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-405b-instruct"
     },
     "evaluator_name": "LLAMA3_1_405B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/llama3_1_70b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/llama3_1_70b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-70b-instruct"
     },
     "evaluator_name": "LLAMA3_1_70B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/llama3_1_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/llama3_1_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-70b-instruct"
     },
     "evaluator_name": "LLAMA3_1_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/llama3_3_70b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/llama3_3_70b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-3-70b-instruct"
     },
     "evaluator_name": "LLAMA3_3_70B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/mixtral8_7b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/mixtral8_7b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "mixtral-8x7b-instruct-v01"
     },
     "evaluator_name": "MIXTRAL8_7b",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/mixtral_large.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/rits/mixtral_large.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "mistral-large-instruct"
     },
     "evaluator_name": "MIXTRAL_LARGE",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/granite3_0_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/granite3_0_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-8b-instruct"
     },
     "evaluator_name": "GRANITE3_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/granite3_2_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/granite3_2_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-2-8b-instruct"
     },
     "evaluator_name": "GRANITE3_2_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/llama3_1_405b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/llama3_1_405b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-405b-instruct"
     },
     "evaluator_name": "LLAMA3_1_405B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/llama3_1_70b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/llama3_1_70b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-70b-instruct"
     },
     "evaluator_name": "LLAMA3_1_70B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/llama3_1_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/llama3_1_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-70b-instruct"
     },
     "evaluator_name": "LLAMA3_1_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/llama3_3_70b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/llama3_3_70b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-3-70b-instruct"
     },
     "evaluator_name": "LLAMA3_3_70B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/mixtral8_7b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/mixtral8_7b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "mixtral-8x7b-instruct-v01"
     },
     "evaluator_name": "MIXTRAL8_7b",

--- a/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/mixtral_large.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/direct/watsonx/mixtral_large.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "mistral-large-instruct"
     },
     "evaluator_name": "MIXTRAL_LARGE",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/azure_openai/gpt_4o.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/azure_openai/gpt_4o.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "credentials": {
             "api_base": "https://eteopenai.azure-api.net/openai/deployments/gpt-4o-2024-08-06/chat/completions?api-version=2024-08-01-preview"
         },

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/azure_openai/o1_mini.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/azure_openai/o1_mini.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "credentials": {
             "api_base": "https://eteopenai.azure-api.net/openai/deployments/o1-mini/chat/completions?api-version=2024-08-01-preview"
         },

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/azure_openai/o1_preview.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/azure_openai/o1_preview.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "credentials": {
             "api_base": "https://eteopenai.azure-api.net/openai/deployments/o1-preview/chat/completions?api-version=2024-08-01-preview"
         },

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/openai/gpt_4o.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/openai/gpt_4o.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "gpt-4o-2024-08-06"
     },
     "evaluator_name": "GPT4",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/openai/o1_mini.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/openai/o1_mini.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "o1-mini"
     },
     "evaluator_name": "O1_MINI",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/openai/o1_preview.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/openai/o1_preview.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "o1-preview"
     },
     "evaluator_name": "O1_PREVIEW",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/granite3_0_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/granite3_0_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-8b-instruct"
     },
     "evaluator_name": "GRANITE3_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/granite3_1_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/granite3_1_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-1-8b-instruct"
     },
     "evaluator_name": "GRANITE3_1_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/granite3_2_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/granite3_2_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-2-8b-instruct"
     },
     "evaluator_name": "GRANITE3_2_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/llama3_1_405b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/llama3_1_405b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-405b-instruct"
     },
     "evaluator_name": "LLAMA3_1_405B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/llama3_1_70b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/llama3_1_70b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-70b-instruct"
     },
     "evaluator_name": "LLAMA3_1_70B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/llama3_1_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/llama3_1_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-70b-instruct"
     },
     "evaluator_name": "LLAMA3_1_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/llama3_3_70b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/llama3_3_70b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-3-70b-instruct"
     },
     "evaluator_name": "LLAMA3_3_70B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/mixtral8_7b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/mixtral8_7b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "mixtral-8x7b-instruct-v01"
     },
     "evaluator_name": "MIXTRAL8_7b",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/mixtral_large.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/rits/mixtral_large.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "mistral-large-instruct"
     },
     "evaluator_name": "MIXTRAL_LARGE",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/granite3_0_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/granite3_0_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-8b-instruct"
     },
     "evaluator_name": "GRANITE3_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/granite3_2_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/granite3_2_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "granite-3-2-8b-instruct"
     },
     "evaluator_name": "GRANITE3_2_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/llama3_1_405b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/llama3_1_405b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-405b-instruct"
     },
     "evaluator_name": "LLAMA3_1_405B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/llama3_1_70b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/llama3_1_70b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-70b-instruct"
     },
     "evaluator_name": "LLAMA3_1_70B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/llama3_1_8b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/llama3_1_8b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-1-70b-instruct"
     },
     "evaluator_name": "LLAMA3_1_8B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/llama3_3_70b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/llama3_3_70b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "llama-3-3-70b-instruct"
     },
     "evaluator_name": "LLAMA3_3_70B",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/mixtral8_7b.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/mixtral8_7b.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "mixtral-8x7b-instruct-v01"
     },
     "evaluator_name": "MIXTRAL8_7b",

--- a/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/mixtral_large.json
+++ b/src/unitxt/catalog/metrics/llm_as_judge/pairwise/watsonx/mixtral_large.json
@@ -4,6 +4,7 @@
         "__type__": "cross_provider_inference_engine",
         "max_tokens": 1024,
         "seed": 42,
+        "temperature": 0,
         "model": "mistral-large-instruct"
     },
     "evaluator_name": "MIXTRAL_LARGE",

--- a/src/unitxt/llm_as_judge.py
+++ b/src/unitxt/llm_as_judge.py
@@ -270,7 +270,7 @@ class LLMJudgeDirect(LLMJudge):
         self.option_selection_task = Task(
             input_fields={
                 "criteria_description": str,
-                "score_option_instruction": str,
+                "display_options_instruction": str,
                 "options": list,
             },
             reference_fields={},
@@ -305,21 +305,17 @@ class LLMJudgeDirect(LLMJudge):
         criteria_description = criteria.description
         criteria_option_names = [o.name for o in criteria.options]
 
-        display_options_instruction = "Choose an answer:\n" + "\n".join(
+        display_options_instruction = "Choose an option:\n" + "\n".join(
             [
                 f'- "{o.name}"{f" if {o.description}" if o.description != "" else ""}'
                 for o in criteria.options
             ]
-        )
-        score_option_instruction = "".join(
-            [f"Score {o.name}: {o.description}\n" for o in criteria.options]
         )
 
         return (
             criteria_description,
             criteria_option_names,
             display_options_instruction,
-            score_option_instruction,
         )
 
     def __set_main_score(self, criterias: List[CriteriaWithOptions]):
@@ -547,7 +543,6 @@ class LLMJudgeDirect(LLMJudge):
             criteria_description_list,
             criteria_option_names_list,
             display_options_instruction_list,
-            score_option_instruction_list,
         ) = zip(*parsed_criterias)
 
         assessment_for_summaries_slice = slice(0, evaluations_count)
@@ -599,13 +594,17 @@ class LLMJudgeDirect(LLMJudge):
         option_selection_instances = [
             {
                 "criteria_description": criteria_description,
-                "score_option_instruction": score_option_instruction,
+                "display_options_instruction": display_options_instruction,
                 "options": criteria_option_names,
                 "data_classification_policy": ["public"],
             }
-            for criteria_description, score_option_instruction, criteria_option_names in zip(
+            for (
+                criteria_description,
+                display_options_instruction,
+                criteria_option_names
+            ) in zip(
                 criteria_description_list,
-                score_option_instruction_list,
+                display_options_instruction_list,
                 criteria_option_names_list,
             )
         ]

--- a/src/unitxt/llm_as_judge_chat_templates.py
+++ b/src/unitxt/llm_as_judge_chat_templates.py
@@ -30,9 +30,11 @@ Summary:"""
     ),
     "answer": InputOutputTemplate(
         input_format="""Now based on the assessment, choose a criteria option. Only include the chosen option in the response. If the assessment already contains a selected option, choose that option. Don't contradict the assessment's selected option.
+
 ###Evaluation criteria:
 {criteria_description}
-{score_option_instruction}
+{display_options_instruction}
+
 The selected criteria option is: """,
         postprocessors=["processors.match_closest_option"],
     ),

--- a/src/unitxt/llm_as_judge_chat_templates.py
+++ b/src/unitxt/llm_as_judge_chat_templates.py
@@ -29,11 +29,11 @@ Assessment: {assessment}
 Summary:"""
     ),
     "answer": InputOutputTemplate(
-        input_format="""Now consider the evaluation criteria and choose a final answer. Only include the chosen answer in the response.
+        input_format="""Now based on the assessment, choose a criteria option. Only include the chosen option in the response. If the assessment already contains a selected option, choose that option. Don't contradict the assessment's selected option.
 ###Evaluation criteria:
 {criteria_description}
 {score_option_instruction}
-The selected answer is: """,
+The selected criteria option is: """,
         postprocessors=["processors.match_closest_option"],
     ),
 }


### PR DESCRIPTION
It happens a lot that the selected options at the end of the CoT generation of the assessment in Direct Assessment LLM Judges is contradicted by the final selected option. This PR changes the option selection prompt by explicitly asking to not to contradict the assessment

```
Now based on the assessment, choose a criteria option. Only include the chosen option in the response. If the assessment already contains a selected option, choose that option. Don't contradict the assessment's selected option.
```