### PR TITLE
Remove more red lines from make docs-server, and rehab lost sons 

### DIFF
--- a/docs/docs/cli.rst
+++ b/docs/docs/cli.rst
@@ -1,8 +1,8 @@
-.. _unitxt_evaluate_cli:
+.. _cli:
 
-######################
-Unitxt Evaluate CLI
-######################
+############
+Evaluate CLI
+############
 
 This document describes the command-line interface (CLI) provided by the ``evaluate_cli.py`` script for running language model evaluations using the ``unitxt`` library.
 
@@ -114,8 +114,10 @@ Model Arguments
     * **Format (Key-Value):** ``key1=value1,key2=value2,...`` (Values automatically typed as int, float, bool, or string). Example: ``torch_dtype=bfloat16,device=cuda,trust_remote_code=true``
     * **Format (JSON):** ``'{"key1": "value1", "key2": 123, "key3": true}'`` (Use double quotes for JSON keys and string values).
     * **Required Keys:**
-        * For ``--model hf``: Must include ``pretrained=<model_id_or_path>``.
-        * For ``--model cross_provider``: Must include ``model_name=<provider/model_id>``.
+
+      * For ``--model hf``: Must include ``pretrained=<model_id_or_path>``.
+      * For ``--model cross_provider``: Must include ``model_name=<provider/model_id>``.
+    
     * **Engine-Specific Args:** Refer to the documentation for ``HFAutoModelInferenceEngine`` and ``CrossProviderInferenceEngine`` (and potentially ``litellm`` for ``cross_provider``) for available arguments (e.g., ``torch_dtype``, ``device``, ``quantization_config`` for ``hf``; ``api_base``, ``api_key``, ``max_tokens``, ``temperature`` for ``cross_provider``). Note: Sensitive keys like ``api_key`` are often better handled via environment variables.
     * **Merging with ``--gen_kwargs``:** Arguments from ``--gen_kwargs`` are merged into this dictionary *before* initializing the inference engine. See ``--gen_kwargs`` description.
     * **Default:** ``{}``

--- a/docs/docs/tutorials.rst
+++ b/docs/docs/tutorials.rst
@@ -14,6 +14,7 @@ Guides ✨
    adding_format
    adding_operator
    adding_metric
+   cli
    data_classification_policy
    ../modules
    rag_support
@@ -31,5 +32,6 @@ Guides ✨
    tags_and_descriptions
    types_and_serializers
    contributors_guide
+   demo
    settings
 

--- a/docs/use_cases/special_tools.rst
+++ b/docs/use_cases/special_tools.rst
@@ -8,12 +8,12 @@ This section will cover adding metrics and operators in Unitxt.
 Adding Custom Metrics
 -----------------------
 
-.. include:: ../docs/adding_metric
+.. include:: ../docs/adding_metric.rst
    :start-line: 11
 
 
 Adding Custom Operators
 -----------------------
 
-.. include:: ../docs/adding_operator
+.. include:: ../docs/adding_operator.rst
    :start-line: 10

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -25,7 +25,7 @@ Some operators are specialized in specific data or specific operations such as:
 - :class:`collections_operators<unitxt.collections_operators>` for handling collections such as lists and dictionaries.
 - :class:`dialog_operators<unitxt.dialog_operators>` for handling dialogs.
 - :class:`string_operators<unitxt.string_operators>` for handling strings.
-- :class:`span_labeling_operators<unitxt.span_labeling_operators>` for handling strings.
+- :class:`span_labeling_operators<unitxt.span_lableing_operators>` for handling strings.
 - :class:`fusion<unitxt.fusion>` for fusing and mixing datasets.
 
 Other specialized operators are used by unitxt internally:


### PR DESCRIPTION
E.g.:
from:
![image](https://github.com/user-attachments/assets/8120a0c8-605b-4240-b8d2-725d6212aa01)
to:
![image](https://github.com/user-attachments/assets/36960c1f-44ef-4c23-bf7b-517d8c68a043)


and from:
![image](https://github.com/user-attachments/assets/2972b022-2181-4266-9ac2-c86eac68f09e)
to:
![image](https://github.com/user-attachments/assets/f277501f-c880-4697-8d3d-1c8d22863a19)
