### PR TITLE
fix typo in azure_openai_host variable name

### DIFF
--- a/src/unitxt/inference.py
+++ b/src/unitxt/inference.py
@@ -1905,17 +1905,17 @@ class AzureOpenAIInferenceEngine(OpenAiInferenceEngine):
             f"Please set the env variable: '{api_key_var_name}'"
         )
 
-        azure_openapi_host = self.credentials.get(
-            "azure_openapi_host", os.environ.get(f"{self.label.upper()}_HOST", None)
+        azure_openai_host = self.credentials.get(
+            "azure_openai_host", os.environ.get(f"{self.label.upper()}_HOST", None)
         )
 
         api_version = self.credentials.get(
             "api_version", os.environ.get("OPENAI_API_VERSION", None)
         )
-        assert api_version and azure_openapi_host, (
+        assert api_version and azure_openai_host, (
             "Error while trying to run AzureOpenAIInferenceEngine: Missing environment variable param AZURE_OPENAI_HOST or OPENAI_API_VERSION"
         )
-        api_url = f"{azure_openapi_host}/openai/deployments/{self.model_name}/chat/completions?api-version={api_version}"
+        api_url = f"{azure_openai_host}/openai/deployments/{self.model_name}/chat/completions?api-version={api_version}"
 
         return {"api_key": api_key, "api_url": api_url, "api_version": api_version}
 


### PR DESCRIPTION
- Fix type in `azure_openai_host` variable name & credential dictionary key.