### PR TITLE
trying to fix PERFORMANCE:  use a github repository as a replacement for the gone HF 'lmsys/arena-hard-browser'

### DIFF
--- a/prepare/cards/arena_hard/generation/english_gpt-4-0314_reference.py
+++ b/prepare/cards/arena_hard/generation/english_gpt-4-0314_reference.py
@@ -17,8 +17,8 @@ from unitxt.test_utils.card import test_card
 # https://paperswithcode.com/dataset/arena-hard points at git repository  https://github.com/lmarena/arena-hard-auto
 # from which the dataset is now fetched:
 
-question_git_repo_file_path = "https://raw.githubusercontent.com/lmarena/arena-hard-auto/main/data/arena-hard-v0.1/question.jsonl"
-model_answer_git_repo_file_path = "https://raw.githubusercontent.com/lmarena/arena-hard-auto/main/data/arena-hard-v0.1/model_answer/gpt-4-0314.jsonl"
+question_git_repo_file_path = "https://raw.githubusercontent.com/lmarena/arena-hard-auto/57451f35d2be7fef9f05d5567f36e4c959bb6630/data/arena-hard-v0.1/question.jsonl"
+model_answer_git_repo_file_path = "https://raw.githubusercontent.com/lmarena/arena-hard-auto/57451f35d2be7fef9f05d5567f36e4c959bb6630/data/arena-hard-v0.1/model_answer/gpt-4-0314.jsonl"
 
 card = TaskCard(
     loader=LoadCSV(

--- a/src/unitxt/catalog/cards/arena_hard/generation/english_gpt_4_0314_reference.json
+++ b/src/unitxt/catalog/cards/arena_hard/generation/english_gpt_4_0314_reference.json
@@ -1,13 +1,13 @@
 {
     "__type__": "task_card",
     "loader": {
-        "__type__": "load_from_hf_space",
-        "space_name": "lmsys/arena-hard-browser",
-        "revision": "03b91ca",
-        "data_files": {
-            "questions": "data/arena-hard-v0.1/question.jsonl",
-            "model_answer": "data/arena-hard-v0.1/model_answer/gpt-4-0314.jsonl"
+        "__type__": "load_csv",
+        "files": {
+            "questions": "https://raw.githubusercontent.com/lmarena/arena-hard-auto/main/data/arena-hard-v0.1/question.jsonl",
+            "model_answer": "https://raw.githubusercontent.com/lmarena/arena-hard-auto/main/data/arena-hard-v0.1/model_answer/gpt-4-0314.jsonl"
         },
+        "file_type": "json",
+        "lines": true,
         "data_classification_policy": [
             "public"
         ]
@@ -25,7 +25,7 @@
         {
             "__type__": "copy",
             "field_to_field": {
-                "turns/0/content": "model_input"
+                "prompt": "model_input"
             },
             "apply_to_streams": [
                 "questions"
@@ -43,8 +43,7 @@
         {
             "__type__": "copy",
             "field_to_field": {
-                "choices/0/turns/0/content": "reference_model_output",
-                "choices/0/turns/0/token_len": "reference_model_output_token_len"
+                "messages/1/content/answer": "reference_model_output"
             },
             "apply_to_streams": [
                 "model_answer"
@@ -53,7 +52,7 @@
         {
             "__type__": "rename",
             "field_to_field": {
-                "model_id": "reference_model"
+                "model": "reference_model"
             },
             "apply_to_streams": [
                 "model_answer"
@@ -76,7 +75,7 @@
             "right_stream": "model_answer",
             "how": "inner",
             "on": [
-                "question_id",
+                "uid",
                 "reference_model"
             ],
             "new_stream_name": "test"
@@ -91,7 +90,7 @@
         {
             "__type__": "select_fields",
             "fields": [
-                "question_id",
+                "uid",
                 "category",
                 "model_input",
                 "reference_model",
@@ -101,6 +100,7 @@
         {
             "__type__": "rename",
             "field_to_field": {
+                "uid": "question_id",
                 "model_input": "input",
                 "category": "group",
                 "reference_model_output": "output"

--- a/src/unitxt/catalog/cards/arena_hard/generation/english_gpt_4_0314_reference.json
+++ b/src/unitxt/catalog/cards/arena_hard/generation/english_gpt_4_0314_reference.json
@@ -3,8 +3,8 @@
     "loader": {
         "__type__": "load_csv",
         "files": {
-            "questions": "https://raw.githubusercontent.com/lmarena/arena-hard-auto/main/data/arena-hard-v0.1/question.jsonl",
-            "model_answer": "https://raw.githubusercontent.com/lmarena/arena-hard-auto/main/data/arena-hard-v0.1/model_answer/gpt-4-0314.jsonl"
+            "questions": "https://raw.githubusercontent.com/lmarena/arena-hard-auto/57451f35d2be7fef9f05d5567f36e4c959bb6630/data/arena-hard-v0.1/question.jsonl",
+            "model_answer": "https://raw.githubusercontent.com/lmarena/arena-hard-auto/57451f35d2be7fef9f05d5567f36e4c959bb6630/data/arena-hard-v0.1/model_answer/gpt-4-0314.jsonl"
         },
         "file_type": "json",
         "lines": true,


### PR DESCRIPTION
`'lmsys/arena-hard-browser'` was gone from HF.  `test_preparation` does not catch faulty `prepare/cards/arena_hard/generation/english_gpt-4-0314_reference.py` that tries to access this (gone) dataset, because a missing dataset is considered by `test_preparation`  an error to be ignored.   Performance, however, failed on it. 
So here a potentially good enough dataset is used instead:     
https://github.com/lmarena/arena-hard-auto  that is pointed at from https://paperswithcode.com/dataset/arena-hard