### PR TITLE
Add tool calling support + Berekley Tool Calling Benchmark (simple-v3)

### DIFF
--- a/docs/docs/tool_calling.rst
+++ b/docs/docs/tool_calling.rst
@@ -1,0 +1,293 @@
+.. _tool_calling:
+
+===========
+Tool Calling
+===========
+
+.. note::
+
+   This tutorial requires a :ref:`Unitxt installation <install_unitxt>`.
+
+Introduction
+------------
+
+This tutorial explores tool calling with Unitxt, focusing on handling tool-based datasets and creating an evaluation and inference pipeline. By the end, you'll be equipped to process complex tool calling tasks efficiently.
+
+Part 1: Understanding Tool Calling Tasks
+---------------------------------------
+
+Tool calling tasks involve providing a model with instructions or prompts that require the use of specific tools to generate the correct response. These tasks are increasingly important in modern AI applications that need to interact with external systems.
+
+Tool Calling Schema
+^^^^^^^^^^^^^^^^^
+
+Unitxt uses specific typed structures for tool calling:
+
+.. code-block:: python
+
+    class Parameter(TypedDict):
+        name: str
+        type: Optional[Type]  # Using actual Python type objects
+
+    class Tool(TypedDict):
+        name: str
+        description: str
+        parameters: List[Parameter]
+
+    class ToolCall(TypedDict):
+        name: str
+        arguments: Dict[str, Any]
+
+The task schema for supervised tool calling is defined as:
+
+.. code-block:: python
+
+    Task(
+        __description__="""Task to test tool calling capabilities.""",
+        input_fields={"query": str, "tools": List[Tool]},
+        reference_fields={"call": ToolCall},
+        prediction_type=ToolCall,
+        metrics=["metrics.tool_calling"],
+        default_template="templates.tool_calling.base",
+    )
+
+This schema appears in the catalog as ``tasks.tool_calling.supervised`` and is the foundation for our tool calling evaluation pipeline.
+
+Tutorial Overview
+^^^^^^^^^^^^^^^^^
+
+We'll create a tool calling evaluation pipeline using Unitxt, concentrating on tasks where models need to select the right tool and provide appropriate arguments for the tool's parameters. We'll use the Berkeley Function Calling Leaderboard as our example dataset.
+
+Part 2: Data Preparation
+-----------------------
+
+Creating a Unitxt DataCard
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Our first step is to prepare the data using a Unitxt DataCard. If it's your first time adding a DataCard, we recommend reading the :ref:`Adding Datasets Tutorial <adding_dataset>`.
+
+Dataset Selection
+^^^^^^^^^^^^^^^
+
+We'll use the Berkeley Function Calling Leaderboard dataset, which is designed to evaluate LLMs' ability to call functions correctly across diverse categories and use cases.
+
+DataCard Implementation
+^^^^^^^^^^^^^^^^^^^^^
+
+Create a Python file named ``bfcl.py`` and implement the DataCard as follows:
+
+.. code-block:: python
+
+    import unitxt
+    from unitxt.card import TaskCard
+    from unitxt.catalog import add_to_catalog
+    from unitxt.collections_operators import DictToTuplesList, Wrap
+    from unitxt.loaders import LoadCSV
+    from unitxt.operators import Copy
+    from unitxt.stream_operators import JoinStreams
+    from unitxt.test_utils.card import test_card
+    from unitxt.tool_calling import ToTool
+
+    # Base path to the Berkeley Function Calling Leaderboard data
+    base_path = "https://raw.githubusercontent.com/ShishirPatil/gorilla/70b6a4a2144597b1f99d1f4d3185d35d7ee532a4/berkeley-function-call-leaderboard/data/"
+
+    with unitxt.settings.context(allow_unverified_code=True):
+        card = TaskCard(
+            loader=LoadCSV(
+                files={"questions": base_path + "BFCL_v3_simple.json", "answers": base_path + "possible_answer/BFCL_v3_simple.json"},
+                file_type="json",
+                lines=True,
+                data_classification_policy=["public"],
+            ),
+            preprocess_steps=[
+                # Join the questions and answers streams
+                JoinStreams(left_stream="questions", right_stream="answers", how="inner", on="id", new_stream_name="test"),
+                # Extract the query from the question content
+                Copy(field="question/0/0/content", to_field="query"),
+                # Convert function data to a tool format
+                ToTool(field="function/0", to_field="tool"),
+                # Wrap the tool in a list for compatibility
+                Wrap(field="tool", inside="list", to_field="tools"),
+                # Process ground truth data
+                DictToTuplesList(field="ground_truth/0", to_field="call_tuples"),
+                # Extract tool name and arguments from ground truth
+                Copy(field="call_tuples/0/0", to_field="call/name"),
+                Copy(field="call_tuples/0/1", to_field="call/arguments"),
+            ],
+            task="tasks.tool_calling.supervised",
+            templates=["templates.tool_calling.base"],
+            __description__=(
+                """The Berkeley function calling leaderboard is a live leaderboard to evaluate the ability of different LLMs to call functions (also referred to as tools). We built this dataset from our learnings to be representative of most users' function calling use-cases, for example, in agents, as a part of enterprise workflows, etc. To this end, our evaluation dataset spans diverse categories, and across multiple languages."""
+            ),
+        )
+
+        # Test and add the card to the catalog
+        test_card(card, strict=False)
+        add_to_catalog(card, "cards.bfcl.simple_v3", overwrite=True)
+
+Preprocessing for Task Schema
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each preprocessing step serves a specific purpose in transforming the raw data into the required task schema:
+
+1. ``JoinStreams``: Combines question and answer data based on ID
+2. ``Copy(field="question/0/0/content", to_field="query")``: Creates the ``query`` input field
+3. ``ToTool(field="function/0", to_field="tool")``: Converts function definitions to the ``Tool`` structure
+4. ``Wrap(field="tool", inside="list", to_field="tools")``: Creates the ``tools`` list input field
+5. ``DictToTuplesList`` and subsequent ``Copy`` operations: Create the reference ``call`` field with the proper ``ToolCall`` structure
+
+After preprocessing, each example will have:
+- A ``query`` that the model should respond to
+- Available ``tools`` that the model can choose from
+- A reference ``call`` showing which tool should be called with what arguments
+
+The ToTool Operator
+^^^^^^^^^^^^^^^^^
+
+The ``ToTool`` operator is a key component that converts function definitions into the ``Tool`` format expected by the task schema. This allows inference engines to understand the available tools and their parameters.
+
+Part 3: Inference and Evaluation
+-------------------------------
+
+With our data prepared, we can now test model performance on tool calling tasks.
+
+Pipeline Setup
+^^^^^^^^^^^^^
+
+Set up the inference and evaluation pipeline:
+
+.. code-block:: python
+
+    from unitxt import get_logger
+    from unitxt.api import evaluate, load_dataset
+    from unitxt.inference import CrossProviderInferenceEngine
+
+    logger = get_logger()
+
+    # Load and prepare the dataset
+    dataset = load_dataset(
+        card="cards.bfcl.simple_v3",
+        split="test",
+        format="formats.chat_api",  # Format suitable for tool calling
+    )
+
+    # Initialize the inference model with a compatible provider
+    model = CrossProviderInferenceEngine(
+        model="granite-3-3-8b-instruct",  # Or other models supporting tool calling
+        provider="watsonx"
+    )
+
+Executing Inference and Evaluation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Run the model and evaluate the results:
+
+.. code-block:: python
+
+    # Perform inference
+    predictions = model(dataset)
+
+    # Evaluate the predictions
+    results = evaluate(predictions=predictions, data=dataset)
+
+    # Print the results
+    print("Global Results:")
+    print(results.global_scores.summary)
+
+    print("Instance Results:")
+    print(results.instance_scores.summary)
+
+Part 4: Understanding the Tool Calling Metrics
+--------------------------------------------
+
+The ToolCallingMetric in Unitxt provides several useful scores:
+
+.. code-block:: python
+
+    class ToolCallingMetric(ReductionInstanceMetric[str, Dict[str, float]]):
+        main_score = "exact_match"
+        reduction = MeanReduction()
+        prediction_type = ToolCall
+
+        def map(
+            self, prediction: ToolCall, references: List[ToolCall], task_data: Dict[str, Any]
+        ) -> Dict[str, float]:
+            # Implementation details...
+            return {
+                self.main_score: exact_match,
+                "tool_choice": tool_choice,
+                "parameter_choice": parameter_choice,
+                "parameters_types": parameters_types,
+                "parameter_values": parameter_values
+            }
+
+The metrics evaluate different aspects of tool calling accuracy:
+
+1. **exact_match**: Measures if the tool call exactly matches a reference
+2. **tool_choice**: Evaluates if the correct tool was selected
+3. **parameter_choice**: Checks if the correct parameters were identified
+4. **parameter_values**: Assesses if the parameter values are correct
+5. **parameters_types**: Verifies if parameter types match the tool definition
+
+Custom Evaluation
+^^^^^^^^^^^^^^^
+
+For more specialized evaluation, you can define custom metrics:
+
+.. code-block:: python
+
+    from unitxt.metrics import ToolCallingMetric
+
+    # Evaluate with a specialized tool calling metric
+    custom_results = evaluate(
+        predictions=predictions,
+        data=dataset,
+        metrics=[ToolCallingMetric()]
+    )
+
+    print("Custom Metric Results:")
+    print(custom_results.global_scores.summary)
+
+Example Analysis
+^^^^^^^^^^^^^^^
+
+To better understand your model's performance, analyze individual instances:
+
+.. code-block:: python
+
+    # Display detailed results for the first few instances
+    for i, instance in enumerate(results.instance_scores.data[:3]):
+        print(f"\nInstance {i+1}:")
+        print(f"Query: {dataset[i]['query']}")
+        print(f"Available tools: {dataset[i]['tools']}")
+        print(f"Expected tool call: {dataset[i]['call']}")
+        print(f"Model prediction: {predictions[i]}")
+        print(f"Scores: {instance}")
+
+Testing with Different Models
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can easily compare different models' performance:
+
+.. code-block:: python
+
+    # Test with a different model
+    alternative_model = CrossProviderInferenceEngine(
+        model="gpt-3.5-turbo",
+        provider="openai"
+    )
+
+    alt_predictions = alternative_model(dataset)
+    alt_results = evaluate(predictions=alt_predictions, data=dataset)
+
+    print("Alternative Model Results:")
+    print(alt_results.global_scores.summary)
+
+Conclusion
+---------
+
+You have now successfully implemented a tool calling evaluation pipeline with Unitxt using the Berkeley Function Calling Leaderboard dataset. This capability enables the assessment of models' ability to use tools correctly, opening up new possibilities for AI applications that interact with external systems.
+
+The structured approach using typed definitions (``Parameter``, ``Tool``, and ``ToolCall``) provides a standardized way to evaluate tool calling capabilities across different models and providers.
+
+We encourage you to explore further by experimenting with different datasets, models, and evaluation metrics to fully leverage Unitxt's capabilities in tool calling assessment.

--- a/docs/docs/tutorials.rst
+++ b/docs/docs/tutorials.rst
@@ -19,6 +19,7 @@ Guides ✨
    ../modules
    rag_support
    multimodality
+   tool_calling
    operators
    saving_and_loading_from_catalog
    inference

--- a/examples/evaluate_tool_calling.py
+++ b/examples/evaluate_tool_calling.py
@@ -1,0 +1,26 @@
+from unitxt import get_logger
+from unitxt.api import evaluate, load_dataset
+from unitxt.inference import (
+    CrossProviderInferenceEngine,
+)
+
+logger = get_logger()
+
+
+dataset = load_dataset(
+    card="cards.bfcl.simple_v3",
+    split="test",
+    format="formats.chat_api",
+)
+
+model = CrossProviderInferenceEngine(model="llama-3-3-70b-instruct", provider="watsonx")
+
+
+predictions = model(dataset)
+results = evaluate(predictions=predictions, data=dataset)
+
+print("Global Results:")
+print(results.global_scores.summary)
+
+print("Instance Results:")
+print(results.instance_scores.summary)

--- a/examples/evaluate_tool_calling.py
+++ b/examples/evaluate_tool_calling.py
@@ -13,7 +13,7 @@ dataset = load_dataset(
     format="formats.chat_api",
 )
 
-model = CrossProviderInferenceEngine(model="llama-3-3-70b-instruct", provider="watsonx")
+model = CrossProviderInferenceEngine(model="granite-3-3-8b-instruct", provider="watsonx")
 
 
 predictions = model(dataset)

--- a/prepare/cards/bfcl.py
+++ b/prepare/cards/bfcl.py
@@ -34,6 +34,7 @@ with unitxt.settings.context(allow_unverified_code=True):
         __description__=(
             """The Berkeley function calling leaderboard is a live leaderboard to evaluate the ability of different LLMs to call functions (also referred to as tools). We built this dataset from our learnings to be representative of most users' function calling use-cases, for example, in agents, as a part of enterprise workflows, etc. To this end, our evaluation dataset spans diverse categories, and across multiple languages."""
         ),
+        __title__="Berkeley Function Calling Leaderboard - Simple V3",
         __tags__={
             "annotations_creators": "expert-generated",
             "language": ["en"],

--- a/prepare/cards/bfcl.py
+++ b/prepare/cards/bfcl.py
@@ -32,20 +32,19 @@ with unitxt.settings.context(allow_unverified_code=True):
         task="tasks.tool_calling.supervised",
         templates=["templates.tool_calling.base"],
         __description__=(
-            """gg"""
+            """The Berkeley function calling leaderboard is a live leaderboard to evaluate the ability of different LLMs to call functions (also referred to as tools). We built this dataset from our learnings to be representative of most users' function calling use-cases, for example, in agents, as a part of enterprise workflows, etc. To this end, our evaluation dataset spans diverse categories, and across multiple languages."""
         ),
         __tags__={
             "annotations_creators": "expert-generated",
             "language": ["en"],
-            "license": "cc-by-4.0",
+            "license": "apache-2.0",
             "size_categories": ["10K<n<100K"],
             "task_categories": [
                 "question-answering",
-                "multiple-choice",
                 "reading-comprehension",
+                "tool-calling"
             ],
-            "multilinguality": "monolingual",
-            "task_ids": ["extractive-qa", "reading-comprehension"],
+            "task_ids": ["tool-calling", "reading-comprehension"],
         },
     )
 

--- a/prepare/cards/bfcl.py
+++ b/prepare/cards/bfcl.py
@@ -1,0 +1,54 @@
+import unitxt
+from unitxt.card import TaskCard
+from unitxt.catalog import add_to_catalog
+from unitxt.collections_operators import DictToTuplesList, Wrap
+from unitxt.loaders import LoadCSV
+from unitxt.operators import (
+    Copy,
+)
+from unitxt.stream_operators import JoinStreams
+from unitxt.test_utils.card import test_card
+from unitxt.tool_calling import ToTool
+
+base_path = "https://raw.githubusercontent.com/ShishirPatil/gorilla/70b6a4a2144597b1f99d1f4d3185d35d7ee532a4/berkeley-function-call-leaderboard/data/"
+
+with unitxt.settings.context(allow_unverified_code=True):
+    card = TaskCard(
+        loader=LoadCSV(
+            files={"questions": base_path + "BFCL_v3_simple.json", "answers": base_path + "possible_answer/BFCL_v3_simple.json"},
+            file_type="json",
+            lines=True,
+            data_classification_policy=["public"],
+        ),
+        preprocess_steps=[
+            JoinStreams(left_stream="questions", right_stream ="answers", how="inner", on="id", new_stream_name="test" ),
+            Copy(field="question/0/0/content", to_field="query"),
+            ToTool(field="function/0", to_field="tool"),
+            Wrap(field="tool", inside="list", to_field="tools"),
+            DictToTuplesList(field="ground_truth/0", to_field="call_tuples"),
+            Copy(field="call_tuples/0/0", to_field="call/name"),
+            Copy(field="call_tuples/0/1", to_field="call/arguments"),
+        ],
+        task="tasks.tool_calling.supervised",
+        templates=["templates.tool_calling.base"],
+        __description__=(
+            """gg"""
+        ),
+        __tags__={
+            "annotations_creators": "expert-generated",
+            "language": ["en"],
+            "license": "cc-by-4.0",
+            "size_categories": ["10K<n<100K"],
+            "task_categories": [
+                "question-answering",
+                "multiple-choice",
+                "reading-comprehension",
+            ],
+            "multilinguality": "monolingual",
+            "task_ids": ["extractive-qa", "reading-comprehension"],
+        },
+    )
+
+    # Test and add the card to the catalog
+    test_card(card, strict=False)
+    add_to_catalog(card, "cards.bfcl.simple_v3", overwrite=True)

--- a/prepare/metrics/tool_calling.py
+++ b/prepare/metrics/tool_calling.py
@@ -1,0 +1,10 @@
+from unitxt.catalog import add_to_catalog
+from unitxt.metrics import ToolCallingMetric
+
+add_to_catalog(
+    ToolCallingMetric(
+        __description__="""Metric for tool calling"""
+    ),
+    "metrics.tool_calling",
+    overwrite=True,
+)

--- a/prepare/processors/tool_calling.py
+++ b/prepare/processors/tool_calling.py
@@ -1,0 +1,11 @@
+from unitxt import add_to_catalog
+from unitxt.processors import (
+    PostProcess,
+)
+from unitxt.struct_data_operators import LoadJson
+
+add_to_catalog(
+    PostProcess(LoadJson(allow_failure=True, failure_value={"name": "null", "arguments": {}})),
+    "processors.load_json_or_empty_tool_call",
+    overwrite=True,
+)

--- a/prepare/tasks/tool_calling/tasks.py
+++ b/prepare/tasks/tool_calling/tasks.py
@@ -1,0 +1,18 @@
+from typing import List
+
+from unitxt.catalog import add_to_catalog
+from unitxt.task import Task
+from unitxt.types import Tool, ToolCall
+
+add_to_catalog(
+    Task(
+        __description__="""Task to test tool calling capabilities.""",
+        input_fields={"query": str, "tools": List[Tool]},
+        reference_fields={"call": ToolCall},
+        prediction_type=ToolCall,
+        metrics=["metrics.tool_calling"],
+        default_template="templates.tool_calling.base",
+    ),
+    "tasks.tool_calling.supervised",
+    overwrite=True,
+)

--- a/prepare/templates/tool_calling/templates.py
+++ b/prepare/templates/tool_calling/templates.py
@@ -1,0 +1,8 @@
+from unitxt.catalog import add_to_catalog
+from unitxt.templates import InputOutputTemplate
+
+add_to_catalog(
+    InputOutputTemplate(input_format="{query}", output_format="{call}", postprocessors=["processors.load_json_or_empty_tool_call"]),
+    "templates.tool_calling.base",
+    overwrite=True,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ docs = [
     "scikit-learn",
     "jiwer",
     "editdistance",
-    "fuzzywuzzy"
+    "fuzzywuzzy",
+    "pydantic"
 ]
 helm = [
     "crfm-helm[unitxt]>=0.5.3"
@@ -105,7 +106,8 @@ tests = [
     "Wikipedia-API",
     "sqlglot",
     "sqlparse",
-    "diskcache"
+    "diskcache",
+    "pydantic"
 ]
 ui = [
     "gradio",

--- a/src/unitxt/catalog/cards/bfcl/simple_v3.json
+++ b/src/unitxt/catalog/cards/bfcl/simple_v3.json
@@ -1,0 +1,81 @@
+{
+    "__type__": "task_card",
+    "loader": {
+        "__type__": "load_csv",
+        "files": {
+            "questions": "https://raw.githubusercontent.com/ShishirPatil/gorilla/70b6a4a2144597b1f99d1f4d3185d35d7ee532a4/berkeley-function-call-leaderboard/data/BFCL_v3_simple.json",
+            "answers": "https://raw.githubusercontent.com/ShishirPatil/gorilla/70b6a4a2144597b1f99d1f4d3185d35d7ee532a4/berkeley-function-call-leaderboard/data/possible_answer/BFCL_v3_simple.json"
+        },
+        "file_type": "json",
+        "lines": true,
+        "data_classification_policy": [
+            "public"
+        ]
+    },
+    "preprocess_steps": [
+        {
+            "__type__": "join_streams",
+            "left_stream": "questions",
+            "right_stream": "answers",
+            "how": "inner",
+            "on": "id",
+            "new_stream_name": "test"
+        },
+        {
+            "__type__": "copy",
+            "field": "question/0/0/content",
+            "to_field": "query"
+        },
+        {
+            "__type__": "to_tool",
+            "field": "function/0",
+            "to_field": "tool"
+        },
+        {
+            "__type__": "wrap",
+            "field": "tool",
+            "inside": "list",
+            "to_field": "tools"
+        },
+        {
+            "__type__": "dict_to_tuples_list",
+            "field": "ground_truth/0",
+            "to_field": "call_tuples"
+        },
+        {
+            "__type__": "copy",
+            "field": "call_tuples/0/0",
+            "to_field": "call/name"
+        },
+        {
+            "__type__": "copy",
+            "field": "call_tuples/0/1",
+            "to_field": "call/arguments"
+        }
+    ],
+    "task": "tasks.tool_calling.supervised",
+    "templates": [
+        "templates.tool_calling.base"
+    ],
+    "__description__": "gg",
+    "__tags__": {
+        "annotations_creators": "expert-generated",
+        "language": [
+            "en"
+        ],
+        "license": "cc-by-4.0",
+        "size_categories": [
+            "10K<n<100K"
+        ],
+        "task_categories": [
+            "question-answering",
+            "multiple-choice",
+            "reading-comprehension"
+        ],
+        "multilinguality": "monolingual",
+        "task_ids": [
+            "extractive-qa",
+            "reading-comprehension"
+        ]
+    }
+}

--- a/src/unitxt/catalog/cards/bfcl/simple_v3.json
+++ b/src/unitxt/catalog/cards/bfcl/simple_v3.json
@@ -57,24 +57,23 @@
     "templates": [
         "templates.tool_calling.base"
     ],
-    "__description__": "gg",
+    "__description__": "The Berkeley function calling leaderboard is a live leaderboard to evaluate the ability of different LLMs to call functions (also referred to as tools). We built this dataset from our learnings to be representative of most users' function calling use-cases, for example, in agents, as a part of enterprise workflows, etc. To this end, our evaluation dataset spans diverse categories, and across multiple languages.",
     "__tags__": {
         "annotations_creators": "expert-generated",
         "language": [
             "en"
         ],
-        "license": "cc-by-4.0",
+        "license": "apache-2.0",
         "size_categories": [
             "10K<n<100K"
         ],
         "task_categories": [
             "question-answering",
-            "multiple-choice",
-            "reading-comprehension"
+            "reading-comprehension",
+            "tool-calling"
         ],
-        "multilinguality": "monolingual",
         "task_ids": [
-            "extractive-qa",
+            "tool-calling",
             "reading-comprehension"
         ]
     }

--- a/src/unitxt/catalog/cards/bfcl/simple_v3.json
+++ b/src/unitxt/catalog/cards/bfcl/simple_v3.json
@@ -58,6 +58,7 @@
         "templates.tool_calling.base"
     ],
     "__description__": "The Berkeley function calling leaderboard is a live leaderboard to evaluate the ability of different LLMs to call functions (also referred to as tools). We built this dataset from our learnings to be representative of most users' function calling use-cases, for example, in agents, as a part of enterprise workflows, etc. To this end, our evaluation dataset spans diverse categories, and across multiple languages.",
+    "__title__": "Berkeley Function Calling Leaderboard - Simple V3",
     "__tags__": {
         "annotations_creators": "expert-generated",
         "language": [

--- a/src/unitxt/catalog/metrics/tool_calling.json
+++ b/src/unitxt/catalog/metrics/tool_calling.json
@@ -1,0 +1,4 @@
+{
+    "__type__": "tool_calling_metric",
+    "__description__": "Metric for tool calling"
+}

--- a/src/unitxt/catalog/processors/load_json_or_empty_tool_call.json
+++ b/src/unitxt/catalog/processors/load_json_or_empty_tool_call.json
@@ -1,0 +1,11 @@
+{
+    "__type__": "post_process",
+    "operator": {
+        "__type__": "load_json",
+        "allow_failure": true,
+        "failure_value": {
+            "name": "null",
+            "arguments": {}
+        }
+    }
+}

--- a/src/unitxt/catalog/tasks/tool_calling/supervised.json
+++ b/src/unitxt/catalog/tasks/tool_calling/supervised.json
@@ -1,0 +1,16 @@
+{
+    "__type__": "task",
+    "__description__": "Task to test tool calling capabilities.",
+    "input_fields": {
+        "query": "str",
+        "tools": "List[Tool]"
+    },
+    "reference_fields": {
+        "call": "ToolCall"
+    },
+    "prediction_type": "ToolCall",
+    "metrics": [
+        "metrics.tool_calling"
+    ],
+    "default_template": "templates.tool_calling.base"
+}

--- a/src/unitxt/catalog/templates/tool_calling/base.json
+++ b/src/unitxt/catalog/templates/tool_calling/base.json
@@ -1,0 +1,8 @@
+{
+    "__type__": "input_output_template",
+    "input_format": "{query}",
+    "output_format": "{call}",
+    "postprocessors": [
+        "processors.load_json_or_empty_tool_call"
+    ]
+}

--- a/src/unitxt/collections_operators.py
+++ b/src/unitxt/collections_operators.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator, List, Optional
+from typing import Any, Dict, Generator, List, Optional
 
 from .dict_utils import dict_get, dict_set
 from .operators import FieldOperator, StreamOperator
@@ -12,6 +12,10 @@ class Dictify(FieldOperator):
     def process_value(self, tup: Any) -> Any:
         return dict(zip(self.with_keys, tup))
 
+class DictToTuplesList(FieldOperator):
+
+    def process_value(self, dic: Dict) -> Any:
+        return list(dic.items())
 
 class Wrap(FieldOperator):
     inside: str

--- a/src/unitxt/dataset.py
+++ b/src/unitxt/dataset.py
@@ -62,6 +62,7 @@ from .system_prompts import __file__ as _
 from .task import __file__ as _
 from .templates import __file__ as _
 from .text_utils import __file__ as _
+from .tool_calling import __file__ as _
 from .type_utils import __file__ as _
 from .types import __file__ as _
 from .utils import is_package_installed

--- a/src/unitxt/inference.py
+++ b/src/unitxt/inference.py
@@ -3286,6 +3286,7 @@ class CrossProviderInferenceEngine(InferenceEngine, StandardAPIParamsMixin):
         "watsonx-sdk": {  # checked from ibm_watsonx_ai.APIClient().foundation_models.ChatModels
             "granite-20b-code-instruct": "ibm/granite-20b-code-instruct",
             "granite-3-2-8b-instruct": "ibm/granite-3-2-8b-instruct",
+            "granite-3-3-8b-instruct": "ibm/granite-3-3-8b-instruct",
             "granite-3-2b-instruct": "ibm/granite-3-2b-instruct",
             "granite-3-8b-instruct": "ibm/granite-3-8b-instruct",
             "granite-34b-code-instruct": "ibm/granite-34b-code-instruct",

--- a/src/unitxt/metric.py
+++ b/src/unitxt/metric.py
@@ -60,6 +60,7 @@ from .system_prompts import __file__ as _
 from .task import __file__ as _
 from .templates import __file__ as _
 from .text_utils import __file__ as _
+from .tool_calling import __file__ as _
 from .type_utils import __file__ as _
 from .types import __file__ as _
 from .utils import is_package_installed

--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -63,7 +63,9 @@ from .operators import ArtifactFetcherMixin, Copy, Set
 from .random_utils import get_seed
 from .settings_utils import get_settings
 from .stream import MultiStream, Stream
+from .tool_calling import convert_chat_api_format_to_tool
 from .type_utils import Type, isoftype, parse_type_string, to_type_string
+from .types import ToolCall
 from .utils import deep_copy, recursive_copy, retry_connection_with_exponential_backoff
 
 logger = get_logger()
@@ -785,6 +787,77 @@ class F1Fast(MapReduceMetric[str, Tuple[int, int]]):
                 result[f"f1_{class_name}"] = float(score)
 
         return result
+
+class ToolCallingMetric(ReductionInstanceMetric[str, Dict[str, float]]):
+    main_score = "exact_match"
+    reduction = MeanReduction()
+    prediction_type = ToolCall
+
+    def map(
+        self, prediction: ToolCall, references: List[ToolCall], task_data: Dict[str, Any]
+    ) -> Dict[str, float]:
+
+
+        exact_match = float(
+            str(prediction) in [str(reference) for reference in references]
+        )
+
+        tool_choice = float(
+            str(prediction["name"]) in [str(reference["name"]) for reference in references]
+        )
+
+        parameter_choice = 0.0
+        for reference in references:
+            if len(prediction["arguments"]) > 0:
+
+                score = len(set(prediction["arguments"]).intersection(set(reference["arguments"]))) / len(set(prediction["arguments"]))
+            else:
+                score = 1.0
+            if score > parameter_choice:
+                parameter_choice = score
+
+
+        parameter_values = 0.0
+        for reference in references:
+            value_matches = 0
+            for key, val in prediction["arguments"].items():
+                try:
+                    if val in reference["arguments"][key] or reference["arguments"][key] in val:
+                        value_matches += 1
+                except:
+                    pass
+
+            if len(prediction["arguments"]) > 0:
+
+                score = value_matches / len(prediction["arguments"])
+            else:
+                score = 1.0
+            if score > parameter_values:
+                parameter_values = score
+
+        for tool in task_data["__tools__"]:
+            tool = convert_chat_api_format_to_tool(tool)
+            tool_params_types = {}
+            for param in tool["parameters"]:
+                tool_params_types[param["name"]] = param["type"]
+            correct_parameters_types = 0
+            for key, value in prediction["arguments"].items():
+                typing_type = tool_params_types.get(key, Any)
+                if isoftype(value, typing_type):
+                    correct_parameters_types += 1
+            if len(prediction["arguments"]) > 0:
+                parameters_types = correct_parameters_types / len(prediction["arguments"])
+            else:
+                parameters_types = 1.0
+
+
+        return {
+            self.main_score: exact_match,
+            "tool_choice": tool_choice,
+            "parameter_choice": parameter_choice,
+            "parameters_types": parameters_types,
+            "parameter_values": parameter_values
+        }
 
 
 class MetricWithConfidenceInterval(Metric):

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -930,7 +930,7 @@ class Cast(FieldOperator):
     failure_default: Optional[Any] = "__UNDEFINED__"
 
     def prepare(self):
-        self.types = {"int": int, "float": float, "str": str, "bool": bool}
+        self.types = {"int": int, "float": float, "str": str, "bool": bool, "tuple": tuple}
 
     def process_value(self, value):
         try:

--- a/src/unitxt/schema.py
+++ b/src/unitxt/schema.py
@@ -141,6 +141,9 @@ class FinalizeDataset(InstanceOperatorValidator):
         }
         if use_reference_fields:
             task_data = {**task_data, **instance["reference_fields"]}
+
+        if "__tools__" in instance:
+            task_data["__tools__"] = instance["__tools__"]
         return task_data
 
     def serialize_instance_fields(self, instance, task_data):

--- a/src/unitxt/serializers.py
+++ b/src/unitxt/serializers.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Union
 from .dataclass import AbstractField, Field
 from .operators import InstanceFieldOperator
 from .settings_utils import get_constants
+from .tool_calling import convert_to_chat_api_format
 from .type_utils import isoftype, to_type_string
 from .types import (
     Dialog,
@@ -16,6 +17,8 @@ from .types import (
     Number,
     SQLDatabase,
     Table,
+    Tool,
+    ToolCall,
     Video,
 )
 
@@ -161,15 +164,43 @@ class MultiDocumentSerializer(DocumentSerializer):
         return "\n\n".join(documents)
 
 
+
+class ToolsSerializer(SingleTypeSerializer):
+
+    serialized_type = List[Tool]
+    _requirements_list: List[str] = ["pydantic"]
+
+    def serialize(self, value: List[Tool], instance: Dict[str, Any]) -> str:
+        if "__tools__" not in instance:
+            instance["__tools__"] = []
+        tool = []
+        for tool in value:
+            chat_api_tool = convert_to_chat_api_format(tool=tool)
+            instance["__tools__"].append(
+                chat_api_tool
+            )
+            tool["parameters"] = chat_api_tool["function"]["parameters"]
+        return json.dumps(instance["__tools__"], indent=4)
+
+class ToolCallSerializer(SingleTypeSerializer):
+
+    serialized_type = ToolCall
+    _requirements_list: List[str] = ["pydantic"]
+
+    def serialize(self, value: ToolCall, instance: Dict[str, Any]) -> str:
+        return json.dumps(value)
+
 class MultiTypeSerializer(Serializer):
     serializers: List[SingleTypeSerializer] = Field(
         default_factory=lambda: [
             DocumentSerializer(),
+            ToolCallSerializer(),
             DialogSerializer(),
             MultiDocumentSerializer(),
             ImageSerializer(),
             VideoSerializer(),
             TableSerializer(),
+            ToolsSerializer(),
             DialogSerializer(),
         ]
     )

--- a/src/unitxt/templates.py
+++ b/src/unitxt/templates.py
@@ -19,6 +19,8 @@ from .serializers import (
     Serializer,
     SQLDatabaseAsSchemaSerializer,
     TableSerializer,
+    ToolCallSerializer,
+    ToolsSerializer,
     VideoSerializer,
 )
 from .settings_utils import get_constants
@@ -63,6 +65,8 @@ class Template(InstanceOperator):
                 ImageSerializer(),
                 VideoSerializer(),
                 TableSerializer(),
+                ToolCallSerializer(),
+                ToolsSerializer(),
                 DialogSerializer(),
                 ListSerializer(),
                 SQLDatabaseAsSchemaSerializer(),

--- a/src/unitxt/tool_calling.py
+++ b/src/unitxt/tool_calling.py
@@ -1,0 +1,119 @@
+from typing import Any, Dict, List, Type
+
+from .operators import FieldOperator
+from .types import Parameter, Tool
+
+
+def convert_to_chat_api_format(tool: Tool) -> Dict[str, Any]:
+
+    from pydantic import create_model
+
+    field_definitions = {}
+    for param in tool["parameters"]:
+        param_name = param["name"]
+        param_type = param.get("type", Any)
+        field_definitions[param_name] = (param_type, ...)  # ... means required in Pydantic
+
+    model = create_model(f"{tool['name']}Params", **field_definitions)
+
+    schema = model.model_json_schema()
+
+    return {
+        "type": "function",
+        "function": {
+            "name": tool["name"],
+            "description": tool["description"],
+            "parameters": schema
+        }
+    }
+
+
+def convert_chat_api_format_to_tool(chat_api_tool: Dict[str, Any]) -> Tool:
+    """Convert a Chat API formatted tool back to the original Tool structure.
+
+    Args:
+        chat_api_tool: A dictionary representing a tool in Chat API format
+
+    Returns:
+        A Tool dictionary with name, description, and parameters
+    """
+    # Extract function information
+    function_info = chat_api_tool.get("function", {})
+    name = function_info.get("name", chat_api_tool.get("name", ""))
+    description = function_info.get("description", chat_api_tool.get("description", ""))
+
+    # Extract parameters from schema
+    parameters: List[Parameter] = []
+    schema = function_info.get("parameters",  chat_api_tool.get("parameters", ""))
+    properties = schema.get("properties", {})
+
+    for param_name, param_schema in properties.items():
+        # Map JSON schema type to Python type
+        param_type = json_schema_to_python_type(param_schema)
+
+        parameter: Parameter = {
+            "name": param_name,
+            "type": param_type
+        }
+        parameters.append(parameter)
+
+    # Construct and return the Tool
+    tool: Tool = {
+        "name": name,
+        "description": description,
+        "parameters": parameters
+    }
+
+    return tool
+
+def json_schema_to_python_type(schema: Dict[str, Any]) -> Type:
+    """Convert JSON schema type to Python type."""
+    from typing import Any, Dict, List, Union
+
+    schema_type = schema.get("type")
+
+    # Handle simple types
+    simple_types = {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+        "null": type(None)
+    }
+
+    if schema_type in simple_types:
+        return simple_types[schema_type]
+
+    # Handle arrays
+    if schema_type == "array":
+        items = schema.get("items", {})
+        if not items:
+            return List[Any]
+
+        item_type = json_schema_to_python_type(items)
+        return List[item_type]
+
+    # Handle objects
+    if schema_type == "object":
+        return Dict[str, Any]
+
+    # Handle unions with anyOf/oneOf
+    if "anyOf" in schema or "oneOf" in schema:
+        union_schemas = schema.get("anyOf", []) or schema.get("oneOf", [])
+        union_types = [json_schema_to_python_type(s) for s in union_schemas]
+        # Use Union for Python 3.9+ or create Union using typing module
+        return Union[tuple(union_types)] if union_types else Any
+
+    # Handle references (simplified)
+    if "$ref" in schema:
+        # In a real implementation, you'd resolve references
+        return Any
+
+    # Default to Any for unrecognized schema types
+    return Any
+
+
+class ToTool(FieldOperator):
+
+    def process_value(self, value: Dict[str, Any]) -> Tool:
+        return convert_chat_api_format_to_tool(value)

--- a/src/unitxt/type_utils.py
+++ b/src/unitxt/type_utils.py
@@ -54,7 +54,6 @@ _generics = [
     Optional[Any],
     Any,
     Literal,
-    typing.Type,
 ]
 
 _generics_types = [type(t) for t in _generics]
@@ -70,6 +69,8 @@ def is_typed_dict(object):
 
 def is_type(object):
     """Checks if the provided object is a type, including generics, Literal, TypedDict, and NewType."""
+    if object is typing.Type:
+        return True
     return (
         isinstance(object, (type, *_generics_types))
         or is_new_type(object)

--- a/src/unitxt/type_utils.py
+++ b/src/unitxt/type_utils.py
@@ -54,6 +54,7 @@ _generics = [
     Optional[Any],
     Any,
     Literal,
+    typing.Type,
 ]
 
 _generics_types = [type(t) for t in _generics]
@@ -486,6 +487,9 @@ def isoftype(object, typing_type):
     """
     if not is_type(typing_type):
         raise UnsupportedTypeError(typing_type)
+
+    if typing_type is typing.Type:
+        return is_type(object)
 
     if is_new_type(typing_type):
         typing_type = typing_type.__supertype__

--- a/src/unitxt/types.py
+++ b/src/unitxt/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, NewType, Optional, TypedDict, Union
+from typing import Any, Dict, List, Literal, NewType, Optional, Type, TypedDict, Union
 
 from .type_utils import register_type
 
@@ -51,6 +51,18 @@ class SQLDatabase(TypedDict):
     dbms: Optional[str]
     data: Optional[Dict[str, Dict]]
 
+class Parameter(TypedDict):
+    name: str
+    type: Optional[Type]  # Using actual Python type objects
+
+class Tool(TypedDict):
+    name: str
+    description: str
+    parameters: List[Parameter]
+
+class ToolCall(TypedDict):
+    name: str
+    arguments: Dict[str, Any]
 
 register_type(Text)
 register_type(Number)
@@ -64,3 +76,7 @@ register_type(Document)
 register_type(MultiDocument)
 register_type(RagResponse)
 register_type(SQLDatabase)
+register_type(Parameter)
+register_type(Tool)
+register_type(ToolCall)
+

--- a/tests/library/test_tool_calling.py
+++ b/tests/library/test_tool_calling.py
@@ -1,0 +1,218 @@
+
+import unittest
+from typing import Any, Dict, List, Union
+
+from unitxt.tool_calling import (
+    convert_chat_api_format_to_tool,
+    convert_to_chat_api_format,
+    json_schema_to_python_type,
+)
+
+
+class TestConvertToChatAPIFormat(unittest.TestCase):
+    def test_basic_conversion(self):
+        """Test basic conversion of a simple tool to Chat API format."""
+        tool = {
+            "name": "test_tool",
+            "description": "A test tool",
+            "parameters": [
+                {"name": "param1", "type": str},
+                {"name": "param2", "type": int}
+            ]
+        }
+
+        result = convert_to_chat_api_format(tool)
+
+        # Check main structure
+        self.assertEqual(result["type"], "function")
+        self.assertEqual(result["function"]["name"], "test_tool")
+        self.assertEqual(result["function"]["description"], "A test tool")
+
+        # Check parameter schema
+        schema = result["function"]["parameters"]
+        self.assertEqual(schema["title"], "test_toolParams")
+        self.assertEqual(schema["type"], "object")
+        self.assertEqual(set(schema["required"]), {"param1", "param2"})
+        self.assertEqual(schema["properties"]["param1"]["type"], "string")
+        self.assertEqual(schema["properties"]["param2"]["type"], "integer")
+
+    def test_complex_parameters(self):
+        """Test conversion with complex parameter types."""
+        tool = {
+            "name": "complex_tool",
+            "description": "A complex tool",
+            "parameters": [
+                {"name": "list_param", "type": List[str]},
+                {"name": "dict_param", "type": Dict[str, Any]},
+                {"name": "any_param", "type": Any}
+            ]
+        }
+
+        result = convert_to_chat_api_format(tool)
+
+        # Check parameter schema
+        schema = result["function"]["parameters"]
+        self.assertEqual(schema["properties"]["list_param"]["type"], "array")
+        self.assertEqual(schema["properties"]["list_param"]["items"]["type"], "string")
+        self.assertEqual(schema["properties"]["dict_param"]["type"], "object")
+        # For Any type, the schema should be empty or very minimal
+        self.assertIn("any_param", schema["properties"])
+
+
+class TestConvertChatAPIFormatToTool(unittest.TestCase):
+    def test_basic_conversion(self):
+        """Test basic conversion from Chat API format back to Tool."""
+        chat_api_tool = {
+            "type": "function",
+            "function": {
+                "name": "test_tool",
+                "description": "A test tool",
+                "parameters": {
+                    "properties": {
+                        "param1": {"type": "string"},
+                        "param2": {"type": "integer"}
+                    }
+                }
+            }
+        }
+
+        expected_tool = {
+            "name": "test_tool",
+            "description": "A test tool",
+            "parameters": [
+                {"name": "param1", "type": str},
+                {"name": "param2", "type": int}
+            ]
+        }
+
+        result = convert_chat_api_format_to_tool(chat_api_tool)
+
+        self.assertEqual(result["name"], expected_tool["name"])
+        self.assertEqual(result["description"], expected_tool["description"])
+
+        # Check that parameters are correctly converted
+        params_by_name = {p["name"]: p for p in result["parameters"]}
+        self.assertEqual(len(params_by_name), 2)
+        self.assertEqual(params_by_name["param1"]["type"], str)
+        self.assertEqual(params_by_name["param2"]["type"], int)
+
+    def test_alternate_format(self):
+        """Test conversion with an alternate format (without nested 'function')."""
+        chat_api_tool = {
+            "name": "alt_tool",
+            "description": "An alternate tool",
+            "parameters": {
+                "properties": {
+                    "param1": {"type": "string"}
+                }
+            }
+        }
+
+        result = convert_chat_api_format_to_tool(chat_api_tool)
+
+        self.assertEqual(result["name"], "alt_tool")
+        self.assertEqual(result["description"], "An alternate tool")
+        self.assertEqual(len(result["parameters"]), 1)
+        self.assertEqual(result["parameters"][0]["name"], "param1")
+        self.assertEqual(result["parameters"][0]["type"], str)
+
+    def test_complex_parameter_types(self):
+        """Test conversion with complex parameter types."""
+        chat_api_tool = {
+            "type": "function",
+            "function": {
+                "name": "complex_tool",
+                "description": "A complex tool",
+                "parameters": {
+                    "properties": {
+                        "array_param": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        },
+                        "object_param": {"type": "object"},
+                        "union_param": {
+                            "anyOf": [
+                                {"type": "string"},
+                                {"type": "integer"}
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+
+        result = convert_chat_api_format_to_tool(chat_api_tool)
+
+        params_by_name = {p["name"]: p for p in result["parameters"]}
+
+        # Check array parameter
+        self.assertEqual(params_by_name["array_param"]["type"].__origin__, list)
+        self.assertEqual(params_by_name["array_param"]["type"].__args__[0], str)
+
+        # Check object parameter
+        self.assertEqual(params_by_name["object_param"]["type"].__origin__, dict)
+
+        # Check union parameter
+        self.assertEqual(params_by_name["union_param"]["type"].__origin__, Union)
+        self.assertTrue(str in params_by_name["union_param"]["type"].__args__)
+        self.assertTrue(int in params_by_name["union_param"]["type"].__args__)
+
+
+class TestJsonSchemaToType(unittest.TestCase):
+    def test_simple_types(self):
+        """Test conversion of simple JSON schema types to Python types."""
+        self.assertEqual(json_schema_to_python_type({"type": "string"}), str)
+        self.assertEqual(json_schema_to_python_type({"type": "integer"}), int)
+        self.assertEqual(json_schema_to_python_type({"type": "number"}), float)
+        self.assertEqual(json_schema_to_python_type({"type": "boolean"}), bool)
+        self.assertEqual(json_schema_to_python_type({"type": "null"}), type(None))
+
+    def test_array_types(self):
+        """Test conversion of array types."""
+        # Array of strings
+        array_schema = {
+            "type": "array",
+            "items": {"type": "string"}
+        }
+        result = json_schema_to_python_type(array_schema)
+        self.assertEqual(result.__origin__, list)
+        self.assertEqual(result.__args__[0], str)
+
+        # Array of any type
+        array_schema = {"type": "array"}
+        result = json_schema_to_python_type(array_schema)
+        self.assertEqual(result.__origin__, list)
+        self.assertEqual(result.__args__[0], Any)
+
+    def test_object_type(self):
+        """Test conversion of object type."""
+        object_schema = {"type": "object"}
+        result = json_schema_to_python_type(object_schema)
+        self.assertEqual(result.__origin__, dict)
+        self.assertEqual(result.__args__[0], str)
+        self.assertEqual(result.__args__[1], Any)
+
+    def test_union_types(self):
+        """Test conversion of union types (anyOf/oneOf)."""
+        union_schema = {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ]
+        }
+        result = json_schema_to_python_type(union_schema)
+        self.assertEqual(result.__origin__, Union)
+        self.assertTrue(str in result.__args__)
+        self.assertTrue(int in result.__args__)
+
+    def test_ref_type(self):
+        """Test handling of $ref in schema."""
+        ref_schema = {"$ref": "#/definitions/SomeType"}
+        result = json_schema_to_python_type(ref_schema)
+        self.assertEqual(result, Any)
+
+    def test_unknown_type(self):
+        """Test handling of unknown schema types."""
+        unknown_schema = {"type": "unknown_type"}
+        result = json_schema_to_python_type(unknown_schema)
+        self.assertEqual(result, Any)

--- a/tests/library/test_type_utils.py
+++ b/tests/library/test_type_utils.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Literal, NewType, TypedDict
+from typing import Literal, NewType, Type, TypedDict
 
 from unitxt.type_utils import (
     UnsupportedTypeError,
@@ -428,6 +428,7 @@ Task description: This is my task.""",
         self.assertTrue(is_type(int))
         self.assertTrue(is_type(list))
         self.assertTrue(is_type(dict))
+        self.assertTrue(is_type(Type))
         self.assertTrue(is_type(Literal[1, 2, 3]))
         self.assertFalse(is_type([1, 2]))
         self.assertFalse(is_type(print))


### PR DESCRIPTION
`python examples/evaluate_tool_calling.py`

```
Inferring batch 4 / 5 with 100 instances (found 0 instances in ./inference_engine_cache/CrossProviderInferenceEngine)
LiteLLM Inference (watsonx/ibm/granite-3-3-8b-instruct): 100%|█████████████████| 100/100 [00:17<00:00,  5.71it/s]
Global Results:
| score_name       |   score |   ci_low |   ci_high |
|:-----------------|--------:|---------:|----------:|
| exact_match      |    0    |     0    |      0    |
| parameter_choice |    1    |     1    |      1    |
| parameter_values |    0.83 |     0.8  |      0.85 |
| parameters_types |    1    |     0.99 |      1    |
| score            |    0    |     0    |      0    |
| tool_choice      |    0.98 |     0.96 |      0.99 |
```