### PR TITLE
Added to_yaml shorthand function to artifact

### DIFF
--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -22,7 +22,7 @@ from .parsing_utils import (
     separate_inside_and_outside_square_brackets,
 )
 from .settings_utils import get_constants, get_settings
-from .text_utils import camel_to_snake_case, is_camel_case
+from .text_utils import camel_to_snake_case, is_camel_case, print_dict_as_yaml
 from .type_utils import isoftype, issubtype
 from .utils import (
     artifacts_json_cache,
@@ -368,6 +368,10 @@ class Artifact(Dataclass):
     def to_json(self):
         data = self.to_dict()
         return json_dump(data)
+
+    def to_yaml(self):
+        data = self.to_dict()
+        return print_dict_as_yaml(data)
 
     def serialize(self):
         if self.__id__ is not None:


### PR DESCRIPTION
This is required to allow exporting a python representation of the artficat to systems that expect yaml input.