### PR TITLE
Performance to report accurate times based on end-to-end time() diffs, rather than accumulate cProfile numbers over methods whose names seem relevant

### DIFF
--- a/.github/workflows/examples_tests.yml
+++ b/.github/workflows/examples_tests.yml
@@ -43,7 +43,7 @@ jobs:
      - run: uv pip install --system ".[tests,watsonx,inference_tests]"
 
      - name:  Hugging Face Login
-        run: |
+       run: |
           for i in {1..5}; do
             huggingface-cli login --token ${{ secrets.UNITXT_READ_HUGGINGFACE_HUB_FOR_TESTS }} && break || sleep $((2 ** i));
           done

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -36,6 +36,7 @@ jobs:
         uv pip install --system ".[tests,watsonx,inference-tests]"
         uv pip install --system litellm
         uv pip install --system diskcache
+        
     - name:  Hugging Face Login
       run: |
         for i in {1..5}; do
@@ -46,10 +47,6 @@ jobs:
         mkdir -p performance_action
         cp performance/bluebench_profiler.py performance_action/bluebench_profiler.py
         cp performance/compare_benchmark_performance_results.py performance_action/compare_benchmark_performance_results.py
-
-    - name: Run performance on PR just to warm the cache, output will be overwritten
-      run : |
-        python performance_action/bluebench_profiler.py --output_file performance_action/pr_results.json
 
     - name: Checkout main branch
       uses: actions/checkout@v4

--- a/performance/bluebench_profiler.py
+++ b/performance/bluebench_profiler.py
@@ -4,32 +4,59 @@ import json
 import os
 import pstats
 import tempfile
+from collections import defaultdict
 from io import StringIO
-from typing import Any, Dict, List, Union
+from time import time
+from typing import Dict, Generator
 
-from datasets import Dataset, DatasetDict, IterableDataset, IterableDatasetDict
-from unitxt.api import evaluate, load_dataset, load_recipe
+from unitxt.api import _source_to_dataset, evaluate, load_dataset, load_recipe
+from unitxt.dataclass import Dataclass
+from unitxt.generator_utils import ReusableGenerator
 from unitxt.inference import (
     CrossProviderInferenceEngine,
     InferenceEngine,
-    TextGenerationInferenceOutput,
 )
 from unitxt.logging_utils import get_logger
+from unitxt.operator import MultiStreamOperator
 from unitxt.settings_utils import get_settings
-from unitxt.stream import MultiStream
+from unitxt.stream import MultiStream, Stream
 
 logger = get_logger()
 settings = get_settings()
 
-settings.allow_unverified_code = True
-settings.disable_hf_datasets_cache = False
-settings.mock_inference_mode = True
+os.environ["UNITXT_MOCK_INFERENCE_MODE"] = "True"
+os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = "60"
+os.environ["HF_HUB_ETAG_TIMEOUT"] = "60"
+os.environ["UNITXT_ALLOW_UNVERIFIED_CODE"] = "True"
+os.environ["UNITXT_DISABLE_HF_DATASETS_CACHE"] = "False"
 
-
-dataset_query = "benchmarks.bluebench[loader_limit=30,max_samples_per_subset=30,splits=[test]]"
+dataset_query = "benchmarks.bluebench[loader_limit=30,splits=[test]]"
 # dataset_query = ["card=cards.cola", "card=cards.wnli"]
 # dataset_query = "recipes.bluebench.knowledge.mmlu_pro_math"
 # dataset_query = "card=cards.rag.documents.clap_nq.en"     # assaf's example
+# dataset_query = "card=cards.cola"
+
+class WaterMarkGenerator(Dataclass):
+    measured_stream: Stream
+    water_mark: int = -1
+
+    def stream_counter(self)->Generator:
+        for i, instance in enumerate (self.measured_stream):
+            if i > self.water_mark:
+                self.water_mark = i
+            yield instance
+
+class WaterMarkStreamer(MultiStreamOperator):
+
+    generators: Dict[str, WaterMarkGenerator] = None
+
+    def process(self, multi_stream: MultiStream) -> MultiStream:
+        if not self.generators:
+            self.generators = {k: WaterMarkGenerator(measured_stream=multi_stream[k]) for k in multi_stream}
+        reusable_generators = {k: ReusableGenerator(generator=self.generators[k].stream_counter) for k in multi_stream}
+
+        return MultiStream.from_generators(reusable_generators)
+
 
 class BlueBenchProfiler:
     """Profiles the execution-time of loading, total-time (including loading) of recipe, inferenfe, and evaluate.
@@ -40,16 +67,21 @@ class BlueBenchProfiler:
 
     from unitxt root dir, run the following linux commands:
 
-    python performance/bluebench_profiler.py --output_file=<path_to_a_json_file>
+    python performance/bluebench_profiler.py --output_file=<path_to_a_json_file> --employ_cProfile
 
-    The script computes the total runtime of the benchmark, and the time spent in loading the datasets,
+    The script computes the total runtime of the dataset query hardcoded therein, specifying the time spent in loading the datasets,
     prepare it for inference (running throughout the recipes)
-    then the inference of the overall dataset (made by grouping the many recipes products), and then
-    the evaluation, and wraps all results into a json output_file, which is written in the path provided.
+    then the inference of the overall dataset (in case of benchmark -- that overall dataset is made by grouping the many
+    recipes products), and then the evaluation, and wraps all results into a json output_file, which is written in the path provided.
+
+    Several example dataset queries are included in the script, of which exactly one is to be uncommented, which
+    is the dataset evaluated. You can edit, change the dataset query per your need.
+    A list of dataset_queries is also allowed, showing as one of the examples. The reported times in this case
+    are accumulated over all the members of the list.
 
     If --output_file cmd line argument is not provided, the default path is taken to be 'performance/logs/bluebench.json'.
 
-    In addition, the script generates a binary file named xxx.prof, as specified in field
+    In addition, if --employ_cProfile is used, the script generates a binary file named xxx.prof, as specified in field
     "performance.prof file" of the json output_file,
     which can be nicely and interactively visualized via snakeviz:
 
@@ -61,31 +93,15 @@ class BlueBenchProfiler:
     (can also use the -s flag for snakeviz which will only set up a server and print out the url
     to use from another computer in order to view results shown by that server)
 
-    In the browser window, look (ctrl-F) for methods named  profiler_...  to read profiling data for the major steps in the process.
-    You will find the total time of each step, accumulated over all recipes in the benchmark.
+    In the browser window, you can look (ctrl-F) for any unitxt function name, or the profile_ functions in this script, to read profiling data for the major steps in the process.
+    You can also sort by time. You will find the total time of each step (function), accumulated over all recipes in the benchmark.
+
     """
 
-    def profiler_instantiate_recipe_result(
-        self, dataset_query: str, **kwargs
-    ) -> MultiStream:
-        recipe = load_recipe(dataset_query, **kwargs)
-        return recipe()
-
-    def profiler_load_dataset(
-        self, dataset_query: str, **kwargs
-    ) -> Union[Dataset, IterableDataset, DatasetDict, IterableDatasetDict]:
-        return load_dataset(dataset_query, **kwargs)
-
-    def profiler_list_from_recipes_ms(self, ms)-> Dict[str, List[Dict[str, Any]]]:
-        if not isinstance(ms, dict):
-            to_return = list(ms)
-            logger.critical(f"Listing {len(to_return)} instances from dataset.")
-            return to_return
-
-        to_return = {k: list(ms[k]) for k in ms}
-        for k in to_return:
-            logger.critical(f"Listing {len(to_return[k])} instances from Split '{k}'.")
-        return to_return
+    def list_from_dataset(self, dataset):
+        if not isinstance(dataset, dict):
+            return list(dataset)
+        return {k: list(dataset[k]) for k in dataset}
 
     def profiler_instantiate_model(self) -> InferenceEngine:
         return CrossProviderInferenceEngine(
@@ -93,66 +109,83 @@ class BlueBenchProfiler:
             max_tokens=30,
         )
 
-    def profiler_infer_predictions(
-        self, model: InferenceEngine, dataset: List[Dict[str, Any]]
-    ) -> Union[List[str], List[TextGenerationInferenceOutput]]:
-        return model.infer(dataset=dataset)
-
-    def profiler_evaluate_predictions(self, predictions, dataset) -> dict:
-        return evaluate(predictions=predictions, data=dataset)
-
     def profiler_do_the_profiling(self, dataset_query: str, **kwargs):
         logger.info(f"profiling the run of dataset_query = '{dataset_query}'")
 
-        # first, the official way -- end-to-end
-        dataset = self.profiler_load_dataset(
-            dataset_query=dataset_query, **kwargs
-        )
-
-        if isinstance(dataset, dict):
-            # continue with the first split can find:
-            alternative_split = next(iter(sorted(dataset.keys())))
-            dataset = dataset[alternative_split]
-
-        if len(dataset) > 500:
-            dataset = dataset[:500]
-
+        # The official way -- based on api.py
+        current_loader_cache_size = settings.loader_cache_size
+        settings.loader_cache_size = 1000   # cover all needs
+        t0 = time()
+        recipe = load_recipe(dataset_query, **kwargs)
+        t0_5 = time()
+        #exhaust recipe to ensure all data is loaded, and hopefully saved in the expanded loader-cache
+        ms = recipe()
+        for stream_name in ms:
+            len(list(ms[stream_name]))
+        dataset = _source_to_dataset(source=recipe)
+        # and now begin again, with same recipe in which the loaders enjoy the cache
+        t1 = time()
+        ms = recipe()
+        t2 = time()
+        dataset = _source_to_dataset(source=recipe)
+        t3 = time()
         model = self.profiler_instantiate_model()
+        t4 = time()
+        # reduce to one split, and infer
+        if isinstance(dataset, dict):
+            if "test" in dataset:
+                dataset = dataset["test"]
+            else:
+                split_name = next(iter(sorted(dataset.keys())))
+                dataset = dataset[split_name]
+        predictions = model.infer(dataset=dataset)
+        t5 = time()
+        evaluate(predictions=predictions, data=dataset)
+        t6 = time()
+        # now just streaming through recipe, without generating an HF dataset:
+        ms = recipe()
+        total_production_length_of_recipe = {k: len(list(ms[k])) for k in ms}
+        logger.critical(f"lengths of total production of recipe: {total_production_length_of_recipe}")
 
-        predictions = self.profiler_infer_predictions(model=model, dataset=dataset)
+        settings.loader_cache_size = current_loader_cache_size
+        return {
+            "load_recipe" : t0_5 - t0,
+            "recipe()": t2 - t1,
+            "source_to_dataset": t3-t2,
+            "instantiate_model": t4 - t3,
+            "inference_time" : t5 - t4,
+            "evaluation_time" : t6 - t5,
+            "load_data_time": t1-t0
+        }
 
-        evaluation_result = self.profiler_evaluate_predictions(
-            predictions=predictions, dataset=dataset
-        )
-        logger.critical(f"length of evaluation_result, following Unitxt.load_dataset: {len(evaluation_result)}")
-
-        # and now the old way, just to report time of generating a dataset, listed out from a ms
-        ms = self.profiler_instantiate_recipe_result(
-            dataset_query=dataset_query, **kwargs
-        )
-
-        dataset = self.profiler_list_from_recipes_ms(ms=ms)
-        if not isinstance(dataset, dict):
-            lengths = len(dataset)
-        else:
-            lengths = {k: len(dataset[k]) for k in dataset}
-
-        logger.critical(f"length of recipe-result just listed: {lengths}")
-
-
-
-def profile_benchmark_blue_bench():
+def profile_benchmark():
+    # profile the official way, with cProfile
     bluebench_profiler = BlueBenchProfiler()
-    if isinstance(dataset_query, list):
-        for dsq in dataset_query:
-            bluebench_profiler.profiler_do_the_profiling(
+    queries = dataset_query if isinstance(dataset_query, list) else [dataset_query]
+    for dsq in queries:
+        dataset = load_dataset(dataset_query=dsq)
+        model = bluebench_profiler.profiler_instantiate_model()
+        if isinstance(dataset, dict):
+            if "test" in dataset:
+                dataset = dataset["test"]
+            else:
+                split_name = next(iter(sorted(dataset.keys())))
+                dataset = dataset[split_name]
+        predictions = model.infer(dataset=dataset)
+        evaluation_result = evaluate(predictions=predictions, data=dataset)
+        logger.info(f"length of evaluation result from cProfiling: {len(evaluation_result)}")
+
+def profile_no_cprofile():
+    bluebench_profiler = BlueBenchProfiler()
+    queries = dataset_query if isinstance(dataset_query, list) else [dataset_query]
+    res = defaultdict(float)
+    for dsq in queries:
+        dsq_time = bluebench_profiler.profiler_do_the_profiling(
             dataset_query=dsq
         )
-    else:
-        bluebench_profiler.profiler_do_the_profiling(
-            dataset_query=dataset_query
-        )
-
+        for k in dsq_time:
+            res[k] += dsq_time[k]
+    return {k: round(res[k], 3) for k in res}
 
 def find_cummtime_of(func_name: str, file_name: str, pst_printout: str) -> float:
     relevant_lines = list(
@@ -169,6 +202,49 @@ def find_cummtime_of(func_name: str, file_name: str, pst_printout: str) -> float
     return round(sumtimes, 3)
 
 
+def use_cprofile():
+    # Create a temporary .prof file
+    with tempfile.NamedTemporaryFile(suffix=".prof", delete=False) as temp_prof_file:
+        temp_prof_file_path = temp_prof_file.name
+        cProfile.run("profile_benchmark()", temp_prof_file_path)
+
+        f = StringIO()
+        pst = pstats.Stats(temp_prof_file_path, stream=f)
+        pst.strip_dirs()
+        pst.sort_stats("name")  # sort by function name
+        pst.print_stats(
+            "profile_benchmark|load_dataset|load_recipe|profiler_do_the_load_and_list_only|profiler_instantiate_model|infer|evaluate|load_data|load_iterables|split_generator"
+        )
+        s = f.getvalue()
+        assert s.split("\n")[7].split()[3] == "cumtime"
+        load_recipe = find_cummtime_of("load_recipe", "api.py", s)
+        source_to_dataset = find_cummtime_of("_source_to_dataset", "api.py", s)
+        list_out_dataset = find_cummtime_of("list_from_dataset", "bluebench_profiler.py", s)
+        just_load_and_list = find_cummtime_of(
+            "profiler_do_the_load_and_list_only", "bluebench_profiler.py", s
+        )
+        instantiate_model = find_cummtime_of(
+            "profiler_instantiate_model", "bluebench_profiler.py", s
+        )
+        inference_time = find_cummtime_of(
+            "infer", "inference.py", s
+        )
+        evaluation_time = find_cummtime_of(
+            "evaluate", "api.py", s
+        )
+
+    return {
+        "load_recipe" : load_recipe,
+        "source_to_dataset": source_to_dataset,
+        "list_out_dataset" : list_out_dataset,
+        "just_load_and_list": just_load_and_list,
+        "instantiate_model": instantiate_model,
+        "inference_time" : inference_time,
+        "evaluation_time" : evaluation_time,
+        "performance.prof file": temp_prof_file_path,
+    }
+
+
 def main():
     # Parse command-line arguments
     parser = argparse.ArgumentParser(description="Bluebench Profiler")
@@ -178,6 +254,11 @@ def main():
         default="performance/logs/bluebench.json",
         help="Path to save the json output file",
     )
+    parser.add_argument(
+        "--employ_cProfile",
+        action="store_true",
+        help="whether to employ cProfile or just time diffs.",
+    )
     args = parser.parse_args()
 
     # Ensure the directory for the output file exists
@@ -185,64 +266,24 @@ def main():
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
 
-    # Create a temporary .prof file
-    with tempfile.NamedTemporaryFile(suffix=".prof", delete=False) as temp_prof_file:
-        temp_prof_file_path = temp_prof_file.name
-        cProfile.run("profile_benchmark_blue_bench()", temp_prof_file_path)
+    dict_to_print = profile_no_cprofile()
 
-        f = StringIO()
-        pst = pstats.Stats(temp_prof_file_path, stream=f)
-        pst.strip_dirs()
-        pst.sort_stats("name")  # sort by function name
-        pst.print_stats(
-            "profile_benchmark_blue_bench|profiler_load_dataset|profiler_instantiate_recipe_result|profiler_list_from_recipes_ms|profiler_instantiate_model|profiler_infer_predictions|profiler_evaluate_predictions|load_data|load_iterables|split_generator"
-        )
-        s = f.getvalue()
-        assert s.split("\n")[7].split()[3] == "cumtime"
-        load_dataset_time = find_cummtime_of(
-            "profiler_load_dataset", "bluebench_profiler.py", s
-        )
-        # load_time = find_cummtime_of("load_data", "loaders.py", s)
-        # load_time = find_cummtime_of(
-        #     "load_iterables", "loaders.py", s
-        # )
-        # load_time += find_cummtime_of(
-        #     "split_generator", "loaders.py", s
-        # )
-        instantiate_benchmark_time = find_cummtime_of(
-            "profiler_instantiate_recipe_result", "bluebench_profiler.py", s
-        )
-        list_a_ms = find_cummtime_of(
-            "profiler_list_from_recipes_ms", "bluebench_profiler.py", s
-        )
-        instantiate_model_time = find_cummtime_of(
-            "profiler_instantiate_model", "bluebench_profiler.py", s
-        )
-        inference_time = find_cummtime_of(
-            "profiler_infer_predictions", "bluebench_profiler.py", s
-        )
-        evaluation_time = find_cummtime_of(
-            "profiler_evaluate_predictions", "bluebench_profiler.py", s
-        )
+    cprofile_dict = None
+    if args.employ_cProfile:
+        cprofile_dict = use_cprofile()
 
-        # Data to be written
-        dictionary = {
-            "dataset_query": dataset_query,
-            "total_time": load_dataset_time,
-            "instantiate_benchmark_time": instantiate_benchmark_time,
-            "generate_benchmark_dataset_time": list_a_ms,
-            "instantiate_model_time": instantiate_model_time,
-            "inference_time": inference_time,
-            "evaluation_time": evaluation_time,
-            "used_eager_mode": settings.use_eager_execution,
-            "performance.prof file": temp_prof_file_path,
-        }
+    if cprofile_dict:
+        dict_to_print["performance.prof file"] = cprofile_dict["performance.prof file"]
 
-        # Write the profiling results to the JSON file (user-specified)
-        with open(args.output_file, "w+") as outfile:
-            json.dump(dictionary, outfile)
+    dict_to_print["dataset_query"] = dataset_query
+    dict_to_print["used_eager_mode"] = settings.use_eager_execution
 
-        logger.info(f"JSON output saved to: {args.output_file}")
+
+    # Write the profiling results to the JSON file (user-specified)
+    with open(args.output_file, "w+") as outfile:
+        json.dump(dict_to_print, outfile)
+
+    logger.info(f"JSON output saved to: {args.output_file}")
 
 
 if __name__ == "__main__":

--- a/performance/compare_benchmark_performance_results.py
+++ b/performance/compare_benchmark_performance_results.py
@@ -21,41 +21,38 @@ with open(args.pr_perf_file) as openfile:
     pr_perf = json.load(openfile)
 
 print(f'dataset_query = "{main_perf["dataset_query"]}"')
+print(f'Time to fetch the needed datasets from their hubs and save them in the local file-system: {round(max(main_perf["load_data_time"], pr_perf["load_data_time"]),3)} seconds')
 print(f"used_eager_mode in main = {main_perf['used_eager_mode']}")
 print(f"used_eager_mode in PR = {pr_perf['used_eager_mode']}")
 print(f"use Mocked inference = {os.environ['UNITXT_MOCK_INFERENCE_MODE']}")
-print("Raw datasets, that are loaded and processed here, are assumed to reside in local file ststem when the run starts.")
+print("Given the raw datasets stored in the local file system, their processing through the Unitxt pipeline lasts as detailed below.")
 
-ratio0 = pr_perf["total_time"] / main_perf["total_time"]
+ratios = {}
+for k in pr_perf:
+    if not isinstance(pr_perf[k], float):
+        continue
+    ratios[k] = pr_perf[k] / main_perf[k] if main_perf[k] > 0 else 1
 
-gen_via_recipe_pr = round(pr_perf["instantiate_benchmark_time"] + pr_perf["generate_benchmark_dataset_time"], 3)
-gen_via_recipe_main = round(main_perf["instantiate_benchmark_time"] + main_perf["generate_benchmark_dataset_time"], 3)
-ratio1 = gen_via_recipe_pr / gen_via_recipe_main if gen_via_recipe_main > 0 else 1
-ratio2 = (
-    pr_perf["evaluation_time"] / main_perf["evaluation_time"]
-    if main_perf["evaluation_time"] > 0
-    else 1
-)
+
 # Markdown table formatting
 
 line1 = "  What is Measured  | Main Branch |  PR Branch  | PR/Main ratio \n"
-line2 = "--------------------|-------------|-------------|---------------\n"
-line3 = f" Unitxt load_dataset| {main_perf['total_time']:>11} | {pr_perf['total_time']:>11} | {ratio0:.2f}\n"
-line4 = f" DS Gen via recipe  | {gen_via_recipe_main:>11} | {gen_via_recipe_pr:>11} | {ratio1:.2f}\n"
-line5 = f" Model Instantiation| {main_perf['instantiate_model_time']:>11} | {pr_perf['instantiate_model_time']:>11} | {pr_perf['instantiate_model_time'] / main_perf['instantiate_model_time']:.2f}\n"
-line6 = f" Inference time     | {main_perf['inference_time']:>11} | {pr_perf['inference_time']:>11} | {pr_perf['inference_time'] / main_perf['inference_time']:.2f}\n"
-line7 = f" Evaluate  time     | {main_perf['evaluation_time']:>11} | {pr_perf['evaluation_time']:>11} | {ratio2:.2f}\n"
+line2 = "--------------------|------------:|------------:|--------------:\n"
+line3 = f" Unitxt load_recipe | {main_perf['load_recipe']} | {pr_perf['load_recipe']} | {ratios['load_recipe']:.2f}\n"
+line4 = f" Source_to_dataset  | {main_perf['source_to_dataset']} | {pr_perf['source_to_dataset']} | {ratios['source_to_dataset']:.2f}\n"
+line7 = f" Inference time     | {main_perf['inference_time']} | {pr_perf['inference_time']} | {ratios['inference_time']:.2f}\n"
+line8 = f" Evaluate  time     | {main_perf['evaluation_time']} | {pr_perf['evaluation_time']} | {ratios['evaluation_time']:.2f}\n"
 
 print("### Performance Comparison Results, time expressed in seconds:\n")
-print(line1 + line2 + line3 + line4 + line5 + line6 + line7)
+print(line1 + line2 + line3 + line4 + line7 + line8)
 print("\n\n")
 # Performance degradation check (15% threshold)
-if (ratio0 > 1.15) and (ratio1 > 1.15 or ratio2 > 1.15):
+if (ratios["source_to_dataset"] > 1.15) or (ratios["evaluation_time"] > 1.15):
     print(
         "\n**Warning**: Performance degradation in Dataset Generation and/or Evaluation exceeds 15%!"
     )
     print(
-        "Explore branch performance via 'python performance/bluebench_profiler.py --output_file=``path to json file``',"
+        "Explore branch performance via 'python performance/bluebench_profiler.py --output_file=``path to json file`` --employ_cProfile',"
         "followed by 'snakeviz ``the performance.prof file specified in the output json file``'."
     )
     sys.exit(1)


### PR DESCRIPTION
`bluebench_profiler` now reports times based on time() diffs, rather than accumulating over reports of cProfile, over methods whose names seem to be relevant.   Still, a full cProfile report (nicely viewable by snakeviz) is generated with the flag `--employ_cProfile` 