### PR TITLE
Reverting to datasets=351 can solve problems in test catalog preparation

### DIFF
--- a/.github/workflows/catalog_preparation.yml
+++ b/.github/workflows/catalog_preparation.yml
@@ -44,6 +44,7 @@ jobs:
     - run: |
         pip install --only-binary :all: spacy
         pip install networkx==3.2.1
+        pip install datasets==3.5.1
 
     - name:  Hugging Face Login
       run: |


### PR DESCRIPTION
comparing to https://github.com/IBM/unitxt/pull/1782 , for example, [and its commit to main](https://github.com/IBM/unitxt/commit/4093178b6c2282b95f676887b5cab1e2e75f0826) .

[Example for the error raised in datasets=3.6.0.](https://github.com/IBM/unitxt/actions/runs/14921477764/job/41917525279)