### PR TITLE
Fix: number of batches calculation is incorrect

### DIFF
--- a/src/unitxt/inference.py
+++ b/src/unitxt/inference.py
@@ -6,6 +6,7 @@ import hashlib
 import io
 import json
 import logging
+import math
 import os
 import re
 import sys
@@ -239,7 +240,7 @@ class InferenceEngine(Artifact):
             result = self._mock_infer(dataset)
         else:
             if self.use_cache:
-                number_of_batches = len(dataset) // self.cache_batch_size + 1
+                number_of_batches = math.ceil(len(dataset) / self.cache_batch_size)
                 result = []
                 for batch_index, batch in enumerate(
                     batched(dataset, self.cache_batch_size)


### PR DESCRIPTION
This PR corrects the following line:

```python
number_of_batches = len(dataset) // self.cache_batch_size + 1
```

If the result of the `//` calculation has no decimal part it is not required to add 1. For example if dataset len is 200 and batch_size is 100: 200 // 100 + 1 = 3 and not 2.

Correcte line:

```python
number_of_batches = math.ceil(len(dataset) / self.cache_batch_size)
```