### PR TITLE
Fixed problematic load of json with a single dictionary line.

### DIFF
--- a/src/unitxt/loaders.py
+++ b/src/unitxt/loaders.py
@@ -439,7 +439,7 @@ class LoadWithPandas(LazyLoader):
                             dataframe = self.read_dataframe(file)
                         break
                 except Exception as e:
-                    logger.debug(f"Attempt csv load {attempt + 1} failed: {e}")
+                    logger.warning(f"Attempt  load {attempt + 1} failed: {e}")
                     if attempt < settings.loaders_max_retries - 1:
                         time.sleep(2)
                     else:
@@ -527,8 +527,8 @@ class LoadJsonFile(LoadWithPandas):
         chunksize : Size of the chunks to load at a time.
         loader_limit: Optional integer to specify a limit on the number of records to load.
         streaming: Bool indicating if streaming should be used.
-        lines: Bool indicate if it is json lines file structure.
-        record_path: a field containing the list of instances.
+        lines: Bool indicate if it is json lines file structure. Otherwise, assumes a single json object in the file.
+        data_field: optional field within the json object, that contains the list of instances.
 
     Example:
         Loading json lines
@@ -545,19 +545,27 @@ class LoadJsonFile(LoadWithPandas):
 
         args =  self.get_args()
         if not self.lines:
-            args.pop("nrows", None)
-
-        if self.data_field is None:
+            data = json.loads(read_file(file))
+            if (self.data_field):
+                instances = dict_get(data, self.data_field)
+                if not isoftype(instances,List[Dict[str,Any]]):
+                    raise UnitxtError(f"{self.data_field} of file {file} is not a list of dictionariess in LoadJsonFile loader")
+            else:
+                if isoftype(data,Dict[str,Any]):
+                    instances = data
+                elif isoftype(data,List[Dict[str,Any]]):
+                    instances=data
+                else:
+                    raise UnitxtError(f"data of file {file} is not dictionary or a list of dictionaries in LoadJsonFile loader")
+            dataframe = pd.DataFrame(instances)
+        else:
+            if self.data_field is not None:
+                raise UnitxtError("Can not load from a specific 'data_field' when loading multiple lines (lines=True)")
             dataframe = pd.read_json(
                 file,
                 lines=self.lines,
                 **args
             )
-        else:
-            data_dict = json.loads(read_file(file))
-            data = dict_get(data_dict, self.data_field)
-            dataframe = pd.DataFrame(data)
-
         return dataframe
 
 

--- a/tests/library/test_loaders.py
+++ b/tests/library/test_loaders.py
@@ -134,6 +134,18 @@ class TestLoaders(UnitxtTestCase):
         for i, instance in enumerate(result):
             self.assertEqual(instance["id"], i)
 
+    def test_load_json_single_object(self):
+        data = {"id": 0, "name": ["test1","test2"]}
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "json_object.json")
+            with open(path, mode="w+") as f:
+                json.dump(data, f)
+            result = list(LoadJsonFile(files={"train": path})()["train"])
+
+        self.assertEqual(len(result),1)
+        final_data = {"id": 0, "name": ["test1","test2"],"data_classification_policy":["proprietary"]}
+        self.assertEqual(result[0],final_data)
+
     def test_load_json_lines(self):
         data = [
             {"id": 0},
@@ -166,6 +178,8 @@ class TestLoaders(UnitxtTestCase):
 
         for i, instance in enumerate(result):
             self.assertEqual(instance["id"], i)
+
+
 
     def test_load_from_ibm_cos(self):
         import ibm_boto3


### PR DESCRIPTION
This json
{"api_version_id": "v2", "tools": ["a", "b", "c", "d", "e", "f"]}

was   loaded as
0       v2   a
1       v2   b
2       v2   c
3       v2   d
4       v2   e
5       v2   f

Now loads right, as a single instance.

Added error message to clarify other mistakes,