### PR TITLE
watsonx.ai mistral small support

### DIFF
--- a/prepare/engines/classification/classification_engines.py
+++ b/prepare/engines/classification/classification_engines.py
@@ -17,6 +17,7 @@ model_names_to_provider = {
     "meta-llama/llama-3-3-70b-instruct": ["ibm_wml"],
     "meta-llama/llama-3-1-70b-instruct": ["ibm_wml"],
     "meta-llama/llama-3-405b-instruct": ["ibm_wml"],
+    "mistralai/mistral-small-3-1-24b-instruct-2503": ["ibm_wml"],
     "llama-3-1-405b-instruct-fp8": ["rits"],
 }
 

--- a/prepare/metrics/llm_as_judge/rag_judge.py
+++ b/prepare/metrics/llm_as_judge/rag_judge.py
@@ -103,6 +103,7 @@ inference_models_v2 = {
     "llama_3_3_70b_instruct_rits": "engines.classification.llama_3_3_70b_instruct_rits",
     "gpt_4o_azure": "engines.classification.gpt_4o_2024_08_06_azure_openai",
     "mistral_large_instruct_watsonx": "engines.classification.mistral_large_watsonx",
+    "mistral_small_3_1_24b_instruct_2503_wml": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
     "mistral_large_instruct_rits": "engines.classification.mistral_large_instruct_2407_rits",
     generic_engine_label: GenericInferenceEngine(),
 }

--- a/src/unitxt/catalog/engines/classification/mistral_small_3_1_24b_instruct_2503_wml.json
+++ b/src/unitxt/catalog/engines/classification/mistral_small_3_1_24b_instruct_2503_wml.json
@@ -1,0 +1,7 @@
+{
+    "__type__": "wml_inference_engine_generation",
+    "model_name": "mistralai/mistral-small-3-1-24b-instruct-2503",
+    "max_new_tokens": 5,
+    "random_seed": 42,
+    "decoding_method": "greedy"
+}

--- a/src/unitxt/catalog/metrics/rag/end_to_end/answer_correctness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/end_to_end/answer_correctness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,13 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.answer_correctness.judge_loose_match_no_context_numeric",
+    "task": "tasks.rag_eval.answer_correctness.binary",
+    "format": null,
+    "main_score": "answer_correctness_judge",
+    "prediction_field": "answer",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {
+        "ground_truths": "reference_answers"
+    }
+}

--- a/src/unitxt/catalog/metrics/rag/end_to_end/answer_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/end_to_end/answer_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,13 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.answer_relevance.judge_answer_relevance_numeric",
+    "task": "tasks.rag_eval.answer_relevance.binary",
+    "format": null,
+    "main_score": "answer_relevance_judge",
+    "prediction_field": "answer",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {
+        "ground_truths": "reference_answers"
+    }
+}

--- a/src/unitxt/catalog/metrics/rag/end_to_end/context_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/end_to_end/context_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,13 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.context_relevance.judge_context_relevance_ares_numeric",
+    "task": "tasks.rag_eval.context_relevance.binary",
+    "format": null,
+    "main_score": "context_relevance_judge",
+    "prediction_field": "contexts",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {
+        "ground_truths": "reference_answers"
+    }
+}

--- a/src/unitxt/catalog/metrics/rag/end_to_end/faithfulness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/end_to_end/faithfulness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,13 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.faithfulness.judge_with_question_simplified_verbal",
+    "task": "tasks.rag_eval.faithfulness.binary",
+    "format": null,
+    "main_score": "faithfulness_judge",
+    "prediction_field": "answer",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {
+        "ground_truths": "reference_answers"
+    }
+}

--- a/src/unitxt/catalog/metrics/rag/external_rag/answer_correctness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/external_rag/answer_correctness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,11 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.answer_correctness.judge_loose_match_no_context_numeric",
+    "task": "tasks.rag_eval.answer_correctness.binary",
+    "format": null,
+    "main_score": "answer_correctness_judge",
+    "prediction_field": "answer",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {}
+}

--- a/src/unitxt/catalog/metrics/rag/external_rag/answer_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/external_rag/answer_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,11 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.answer_relevance.judge_answer_relevance_numeric",
+    "task": "tasks.rag_eval.answer_relevance.binary",
+    "format": null,
+    "main_score": "answer_relevance_judge",
+    "prediction_field": "answer",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {}
+}

--- a/src/unitxt/catalog/metrics/rag/external_rag/context_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/external_rag/context_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,11 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.context_relevance.judge_context_relevance_ares_numeric",
+    "task": "tasks.rag_eval.context_relevance.binary",
+    "format": null,
+    "main_score": "context_relevance_judge",
+    "prediction_field": "contexts",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {}
+}

--- a/src/unitxt/catalog/metrics/rag/external_rag/faithfulness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/external_rag/faithfulness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,11 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.faithfulness.judge_with_question_simplified_verbal",
+    "task": "tasks.rag_eval.faithfulness.binary",
+    "format": null,
+    "main_score": "faithfulness_judge",
+    "prediction_field": "answer",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {}
+}

--- a/src/unitxt/catalog/metrics/rag/response_generation/answer_correctness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/response_generation/answer_correctness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,13 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.answer_correctness.judge_loose_match_no_context_numeric",
+    "task": "tasks.rag_eval.answer_correctness.binary",
+    "format": null,
+    "main_score": "answer_correctness_judge",
+    "prediction_field": "answer",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {
+        "ground_truths": "reference_answers"
+    }
+}

--- a/src/unitxt/catalog/metrics/rag/response_generation/answer_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/response_generation/answer_relevance/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,13 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.answer_relevance.judge_answer_relevance_numeric",
+    "task": "tasks.rag_eval.answer_relevance.binary",
+    "format": null,
+    "main_score": "answer_relevance_judge",
+    "prediction_field": "answer",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {
+        "ground_truths": "reference_answers"
+    }
+}

--- a/src/unitxt/catalog/metrics/rag/response_generation/faithfulness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
+++ b/src/unitxt/catalog/metrics/rag/response_generation/faithfulness/mistral_small_3_1_24b_instruct_2503_wml_judge.json
@@ -1,0 +1,13 @@
+{
+    "__type__": "task_based_ll_mas_judge",
+    "inference_model": "engines.classification.mistral_small_3_1_24b_instruct_2503_wml",
+    "template": "templates.rag_eval.faithfulness.judge_with_question_simplified_verbal",
+    "task": "tasks.rag_eval.faithfulness.binary",
+    "format": null,
+    "main_score": "faithfulness_judge",
+    "prediction_field": "answer",
+    "infer_log_probs": false,
+    "judge_to_generator_fields_mapping": {
+        "ground_truths": "reference_answers"
+    }
+}


### PR DESCRIPTION
LLMaJ with mistral-small from watsonx.ai (via ibm-watsonx-ai SDK).