### PR TITLE
Fix CLI issues

### DIFF
--- a/src/unitxt/evaluate_cli.py
+++ b/src/unitxt/evaluate_cli.py
@@ -298,9 +298,13 @@ def cli_load_dataset(args: argparse.Namespace) -> HFDataset:
             dataset_query=task_str, **overwrite_args
         )
 
-    benchmark = Benchmark(subsets=benchmark_subsets)
+    # this hack circumvents an issue with multi-level benchmarks (such Bluebench's translation subset) that fail when wrapped with an additional Benchmark() object.
+    if len(benchmark_subsets) == 1:
+        source = next(iter(benchmark_subsets.values()))
+    else:
+        source = Benchmark(subsets=benchmark_subsets)
 
-    test_dataset = _source_to_dataset(benchmark, split=args.split)
+    test_dataset = _source_to_dataset(source, split=args.split)
     logger.info(
         f"Dataset loaded successfully. Number of instances: {len(test_dataset)}"
     )

--- a/src/unitxt/evaluate_cli.py
+++ b/src/unitxt/evaluate_cli.py
@@ -414,6 +414,8 @@ def initialize_inference_engine(
             chat_kwargs_dict=chat_kwargs_dict,
         )
 
+        # Keep the actual model name for the results
+        args.model = inference_model.model_name
     # --- Remote Model (CrossProviderInferenceEngine) ---
     elif args.model.lower() == "cross_provider":
         if "model_name" not in model_args_dict:
@@ -444,6 +446,9 @@ def initialize_inference_engine(
             model=remote_model_name,
             **model_args_dict,
         )
+
+        # Keep the actual model name for the results
+        args.model = inference_model.engine.model
     else:
         # This case should not be reached due to argparse choices
         logger.error(
@@ -682,7 +687,7 @@ def _save_results_to_disk(
 
     # prepend to the results_path name the time in a wat like this: 2025-04-04T11:37:32
 
-    timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
 
     results_path = prepend_timestamp_to_path(results_path, timestamp)
     samples_path = prepend_timestamp_to_path(samples_path, timestamp)


### PR DESCRIPTION
* Restore model name in the args so it's included in the results
* Clean results file name for better cross-OS compatibility
* Circumvent multi-level subset issues when running a single task (the multi-task issue is still open).