### PR TITLE
Add  full generated text when running infer_log_prob() with meta data enabled.

### DIFF
--- a/examples/inference_using_ibm_watsonx_ai_log_prob.py
+++ b/examples/inference_using_ibm_watsonx_ai_log_prob.py
@@ -1,0 +1,37 @@
+from unitxt.api import load_dataset
+from unitxt.inference import WMLInferenceEngineGeneration
+from unitxt.text_utils import print_dict
+
+if __name__ == "__main__":
+    # Set required env variables using your WML credentials:
+    # os.environ["WML_URL"] = ""
+    # os.environ["WML_PROJECT_ID"] = ""
+    # os.environ["WML_APIKEY"] = ""
+
+    # Preparing WML inference engine:
+    model_name = "google/flan-t5-xl"
+    wml_inference = WMLInferenceEngineGeneration(
+        model_name=model_name,
+        data_classification_policy=["public"],
+        random_seed=111,
+        min_new_tokens=3,
+        max_new_tokens=10,
+        top_p=0.5,
+        top_k=1,
+        repetition_penalty=1.5,
+        decoding_method="greedy",
+    )
+
+    # Loading dataset:
+    dataset = load_dataset(
+        card="cards.go_emotions.simplified",
+        template="templates.classification.multi_label.default",
+        loader_limit=1,
+    )
+    test_data = dataset["test"]
+
+    # Performing inference:
+    predictions = wml_inference.infer_log_probs(test_data, return_meta_data=True)
+    for inp, prediction in zip(test_data, predictions):
+        result = {**inp, "prediction": prediction}
+        print_dict(result, keys_to_print=["source", "prediction"])


### PR DESCRIPTION
Today, there is no way to get the full generated text when running infer_log_prob().

You get a list of tokens. For example in this case you get the tokens highlighted:

source (str):
    What are the emotions expressed in following text?
    Select your answer from the options: admiration, amusement, anger, annoyance, approval, caring, confusion, curiosity, desire, disappointment, disapproval, disgust, embarrassment, excitement, fear, gratitude, grief, joy, lo
    ve, nervousness, optimism, pride, realization, relief, remorse, sadness, surprise, neutral.
    If no emotions are expressed answer none.
    Text: **I’m really sorry about your situation :( Although I love the names Sapphira, Cirilla, and Scarlett!**
    emotions:
    
prediction (TextGenerationInferenceOutput):

 TextGenerationInferenceOutput(prediction=[
 {**'text': '▁sadness',** 'logprob': -0.5234375, 'top_tokens': [{'text': '▁sadness', 'logprob': -0.5234375}, {'text': '▁caring', 'logprob': -2.234375}, {'text': '▁', 'logprob': -3.078125}, {'text': '▁love', 'logprob': -3.296875}, {'text': '▁joy', 'logprob': -3.75}]}, 
 {**'text': ',**', 'logprob': -0.036376953, 'top_tokens': [{'text': ',', 'logprob': -0.036376953}, {'text': '.', 'logprob': -3.8125}, {'text': ' ▁and', 'logprob': -6.375}, {'text': '/', 'logprob': -6.75}, {'text': '▁', 'logprob': -6.875}]}, 
**{'text': '▁',** 'logprob': -1.7421875, 'top_tokens': [{'text': '▁', 'logprob': -1.7421875}, {'text': '▁love', 'logprob': -2.0937
    5}, {'text': '▁joy', 'logprob': -2.21875}, {'text': '▁grief', 'logprob': -2.59375}, {'text': '▁fear', 'logprob': -3.078125}]}, {'**text': 're'**, 'logprob': -0.20507812, 'top_tokens': [{'text': 're', 'logprob': -0.20507812}, {
    'text': 'anno', 'logprob': -1.7265625}, {'text': 'a', 'logprob': -6.625}, {'text': 'irri', 'logprob': -7.9375}, {'text': 'p', 'logprob': -8.0625}]}, 
 {'**text': 'mor'**, 'logprob': -0.00011014938, 'top_tokens': [{'text': 'mor',
     'logprob': -0.00011014938}, {'text': 'me', 'logprob': -11.125}, {'text': 'bu', 'logprob': -11.1875}, {'text': 'sent', 'logprob': -11.3125}, {'text': 'm', 'logprob': -11.6875}]}, 
{**'text': 's'**, 'logprob': -1.7642975e-05, 't
    op_tokens': [{'text': 's', 'logprob': -1.7642975e-05}, {'text': 't', 'logprob': -12}, {'text': 'a', 'logprob': -12.1875}, {'text': '</s>', 'logprob': -12.5625}, {'text': 'c', 'logprob': -15.0625}]}, 
{**'text': 'e', 'logprob'**
    : -6.198883e-05, 'top_tokens': [{'text': 'e', 'logprob': -6.198883e-05}, {'text': 'al', 'logprob': -9.75}, {'text': '</s>', 'logprob': -13.4375}, {'text': 'ation', 'logprob': -13.9375}, {'text': 'ality', 'logprob': -15.5}]
    }, 
 {**'text': ','**, 'logprob': -0.65625, 'top_tokens': [{'text': ',', 'logprob': -0.65625}, {'text': '</s>', 'logprob': -0.734375}, {'text': '.', 'logprob': -6.6875}, {'text': '▁and', 'logprob': -7.90625}, {'text': '▁or', 'lo
    gprob': -10.4375}]}, 
  {**'text': '▁grief',** 'logprob': -1.9140625, 'top_tokens': [{'text': '▁grief', 'logprob': -1.9140625}, {'text': '▁love', 'logprob': -1.9765625}, {'text': '▁joy', 'logprob': -2.328125}, {'text': '▁sadness'
    , 'logprob': -2.625}, {'text': '▁fear', 'logprob': -3}]}, 
 {**'text': '</s>',** 'logprob': -0.34765625, 'top_tokens': [{'text': '</s>', 'logprob': -0.34765625}, {'text': ',', 'logprob': -1.234375}, {'text': '.', 'logprob': -6.75}, {'text': '▁and', 'logprob': -8.875}, {'text': '▁(', 'logprob': -10.3125}]}], input_tokens=131, output_tokens=10, stop_reason='eos_token', seed=111, input_text='What are the emotions expressed in following text?\nSelect
     your answer from the options: admiration, amusement, anger, annoyance, approval, caring, confusion, curiosity, desire, disappointment, disapproval, disgust, embarrassment, excitement, fear, gratitude, grief, joy, love, ne
    rvousness, optimism, pride, realization, relief, remorse, sadness, surprise, neutral.\nIf no emotions are expressed answer none.\nText: I’m really sorry about your situation :( Although I love the names Sapphira, Cirilla,
    and Scarlett!\nemotions: \n', model_name='google/flan-t5-xl', inference_type='wml')
    
     

 