### PR TITLE
Improved error messages

### DIFF
--- a/examples/evaluate_tool_calling.py
+++ b/examples/evaluate_tool_calling.py
@@ -7,7 +7,7 @@ from unitxt.inference import (
 logger = get_logger()
 
 sum_tool = {
-    "name": "add_numbers",
+    "mame": "add_numbers",
     "description": "Add two numbers together and return the result.",
     "parameters": {
         "type": "object",

--- a/src/unitxt/api.py
+++ b/src/unitxt/api.py
@@ -169,10 +169,18 @@ def _source_to_dataset(
             stream = {split: stream[split]}
         ds_builder._generators = stream
 
-        ds_builder.download_and_prepare(
-            verification_mode="no_checks",
-            download_mode=None if use_cache else "force_redownload",
-        )
+        try:
+            ds_builder.download_and_prepare(
+                verification_mode="no_checks",
+                download_mode=None if use_cache else "force_redownload",
+            )
+        except DatasetGenerationError as e:
+            if e.__cause__:
+                raise e.__cause__ from None
+            elif e.__context__:
+                raise e.__context__ from None
+            else:
+                raise
 
         if streaming:
             return ds_builder.as_streaming_dataset(split=split)

--- a/src/unitxt/artifact.py
+++ b/src/unitxt/artifact.py
@@ -16,7 +16,7 @@ from .dataclass import (
     NonPositionalField,
     fields,
 )
-from .error_utils import Documentation, UnitxtError, UnitxtWarning
+from .error_utils import Documentation, UnitxtError, UnitxtWarning, error_context
 from .logging_utils import get_logger
 from .parsing_utils import (
     separate_inside_and_outside_square_brackets,
@@ -342,8 +342,10 @@ class Artifact(Dataclass):
         self.verify_data_classification_policy()
         self.prepare_args()
         if not settings.skip_artifacts_prepare_and_verify:
-            self.prepare()
-            self.verify()
+            with error_context(self, function="prepare()"):
+                self.prepare()
+            with error_context(self, function="verify()"):
+                self.verify()
 
     def _to_raw_dict(self):
         return {

--- a/src/unitxt/error_utils.py
+++ b/src/unitxt/error_utils.py
@@ -1,7 +1,12 @@
-from typing import Optional
+from contextlib import contextmanager
+from typing import Any, Optional
+
+from scipy import constants
 
 from .logging_utils import get_logger
+from .settings_utils import get_constants
 
+constants = get_constants()
 logger = get_logger()
 
 
@@ -58,3 +63,126 @@ class UnitxtWarning:
         if additional_info_id is not None:
             message += additional_info(additional_info_id)
         logger.warning(message)
+
+
+context_block_title = "Unitxt Error Context"
+
+
+def _add_context_to_exception(
+    original_error: Exception, context_object: Any = None, **context
+):
+    """Add context information to an exception by modifying its message."""
+    # Get the original message, removing any existing context
+    original_message = str(original_error)
+    if hasattr(original_error, "__error_context__"):
+        # If this error already has context, get the original message from the stored context
+        original_message = original_error.__error_context__["original_message"]
+        context = {
+            "Unitxt": constants.version,
+            "Python": constants.python,
+            **original_error.__error_context__["context"],
+            **context,
+        }
+    # Build context message from all provided context information
+    context_parts = []
+
+    # Add object context if provided
+    if context_object is not None:
+        if hasattr(context_object, "__class__"):
+            context_parts.append(f"Object: {context_object.__class__.__name__}")
+        else:
+            context_parts.append(f"Object: {type(context_object).__name__}")
+
+    for key in context.keys():
+        value = context[key]
+        if value is None:
+            value = "unknown"
+        context_parts.append(f"{key.replace('_', ' ').title()}: {value}")
+
+    # Store context message for display
+    if context_parts:
+        # Create a box around the context information
+        max_width = (
+            max(len(context_block_title), max(len(part) for part in context_parts)) + 4
+        )
+        top_line = "┌" + "─" * max_width + "┐"
+        bottom_line = "└" + "─" * max_width + "┘"
+
+        context_lines = [top_line]
+        context_lines.append(
+            f"│ {context_block_title}{' ' * (max_width - len(context_block_title) - 1)}│"
+        )
+        for part in context_parts:
+            context_lines.append(f"│  - {part}{' ' * (max_width - len(part) - 4)}│")
+        context_lines.append(bottom_line)
+
+        context_message = "\n" + "\n".join(context_lines)
+        enhanced_message = f"{context_message}\n\n{original_message}"
+    else:
+        enhanced_message = original_message
+
+    # Store context info in a special attribute
+    original_error.__error_context__ = {
+        "context_object": context_object,
+        "context": context,
+        "original_message": original_message,
+    }
+
+    # Store original information as attributes for backward compatibility
+    try:
+        original_error.original_error = type(original_error)(original_message)
+    except (TypeError, ValueError):
+        # For custom exceptions with complex constructors, create a basic Exception
+        original_error.original_error = Exception(original_message)
+
+    original_error.context_object = context_object
+    original_error.context = context
+
+    # Simply modify the exception's args to include the enhanced message
+    original_error.args = (enhanced_message,)
+
+    # Handle KeyError's special __str__ method that adds quotes
+    if isinstance(original_error, KeyError):
+
+        def enhanced_str(self):
+            return enhanced_message
+
+        # Bind the method to the instance
+        import types
+
+        original_error.__str__ = types.MethodType(enhanced_str, original_error)
+
+
+@contextmanager
+def error_context(context_object: Any = None, **context):
+    """Context manager that catches exceptions and re-raises them with additional context.
+
+    Args:
+        context_object: The object being processed (optional)
+        **context: Any additional context to include in the error message.
+                  You can provide any key-value pairs that help identify where the error occurred.
+
+    Examples:
+        # Basic usage with object and context
+        with error_context(self, operation="validation", item_id=42):
+            result = process_item(item)
+
+        # File processing context
+        with error_context(input_file="data.json", line_number=156):
+            data = parse_line(line)
+
+        # Processing context
+        with error_context(processor, step="preprocessing", batch_size=32):
+            results = process_batch(batch)
+
+        # Database context
+        with error_context(db_connection, table="users", operation="SELECT"):
+            results = execute_query(query)
+    """
+    try:
+        yield
+    except Exception as e:
+        # Add context to the original exception by modifying its message
+        _add_context_to_exception(e, context_object, **context)
+        # Re-raise the same exception - this preserves the original traceback completely
+        raise

--- a/src/unitxt/loaders.py
+++ b/src/unitxt/loaders.py
@@ -66,7 +66,7 @@ from tqdm import tqdm
 
 from .dataclass import NonPositionalField
 from .dict_utils import dict_get
-from .error_utils import Documentation, UnitxtError, UnitxtWarning
+from .error_utils import Documentation, UnitxtError, UnitxtWarning, error_context
 from .fusion import FixedFusion
 from .logging_utils import get_logger
 from .operator import SourceOperator
@@ -218,13 +218,15 @@ class Loader(SourceOperator):
         pass
 
     def load_data(self) -> MultiStream:
-        try:
+        with error_context(
+            self,
+            stage="Data Loading",
+            help="https://www.unitxt.ai/en/latest/unitxt.loaders.html#module-unitxt.loaders",
+        ):
             iterables = self.load_iterables()
-        except Exception as e:
-            raise UnitxtError(f"Error in loader:\n{self}") from e
-        if isoftype(iterables, MultiStream):
-            return iterables
-        return MultiStream.from_iterables(iterables, copying=True)
+            if isoftype(iterables, MultiStream):
+                return iterables
+            return MultiStream.from_iterables(iterables, copying=True)
 
     def process(self) -> MultiStream:
         self._maybe_set_classification_policy()

--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -347,7 +347,7 @@ class StreamOperator(MultiStreamOperator):
     def _process_stream(
         self, stream: Stream, stream_name: Optional[str] = None
     ) -> Generator:
-        with error_context(self, stream_name=stream_name):
+        with error_context(self, stream=stream_name):
             yield from self.process(stream, stream_name)
 
     @abstractmethod
@@ -392,8 +392,8 @@ class PagedStreamOperator(StreamOperator):
             if len(page) >= self.page_size:
                 with error_context(
                     self,
-                    stream_name=stream_name,
-                    page_number=page_number,
+                    stream=stream_name,
+                    page=page_number,
                     page_size=len(page),
                 ):
                     yield from self.process(page, stream_name)
@@ -402,8 +402,8 @@ class PagedStreamOperator(StreamOperator):
         if page:  # Handle any remaining instances in the last partial page
             with error_context(
                 self,
-                stream_name=stream_name,
-                page_number=page_number,
+                stream=stream_name,
+                page=page_number,
                 page_size=len(page),
                 final_page=True,
             ):
@@ -461,7 +461,7 @@ class InstanceOperator(StreamOperator):
         self, stream: Stream, stream_name: Optional[str] = None
     ) -> Generator:
         for _index, instance in enumerate(stream):
-            with error_context(self, stream_name=stream_name, instance_index=_index):
+            with error_context(self, stream=stream_name, instance=_index):
                 yield self._process_instance(instance, stream_name)
 
     def _process_instance(

--- a/src/unitxt/operator.py
+++ b/src/unitxt/operator.py
@@ -6,6 +6,7 @@ from pkg_resources import DistributionNotFound, VersionConflict, require
 
 from .artifact import Artifact
 from .dataclass import FinalField, InternalField, NonPositionalField
+from .error_utils import error_context
 from .settings_utils import get_constants
 from .stream import DynamicStream, EmptyStreamError, MultiStream, Stream
 
@@ -346,7 +347,8 @@ class StreamOperator(MultiStreamOperator):
     def _process_stream(
         self, stream: Stream, stream_name: Optional[str] = None
     ) -> Generator:
-        yield from self.process(stream, stream_name)
+        with error_context(self, stream_name=stream_name):
+            yield from self.process(stream, stream_name)
 
     @abstractmethod
     def process(self, stream: Stream, stream_name: Optional[str] = None) -> Generator:
@@ -384,12 +386,28 @@ class PagedStreamOperator(StreamOperator):
         self, stream: Stream, stream_name: Optional[str] = None
     ) -> Generator:
         page = []
+        page_number = 0
         for instance in stream:
             page.append(instance)
             if len(page) >= self.page_size:
-                yield from self.process(page, stream_name)
+                with error_context(
+                    self,
+                    stream_name=stream_name,
+                    page_number=page_number,
+                    page_size=len(page),
+                ):
+                    yield from self.process(page, stream_name)
                 page = []
-        yield from self._process_page(page, stream_name)
+                page_number += 1
+        if page:  # Handle any remaining instances in the last partial page
+            with error_context(
+                self,
+                stream_name=stream_name,
+                page_number=page_number,
+                page_size=len(page),
+                final_page=True,
+            ):
+                yield from self._process_page(page, stream_name)
 
     def _process_page(
         self, page: List[Dict], stream_name: Optional[str] = None
@@ -442,17 +460,9 @@ class InstanceOperator(StreamOperator):
     def _process_stream(
         self, stream: Stream, stream_name: Optional[str] = None
     ) -> Generator:
-        try:
-            _index = None
-            for _index, instance in enumerate(stream):
+        for _index, instance in enumerate(stream):
+            with error_context(self, stream_name=stream_name, instance_index=_index):
                 yield self._process_instance(instance, stream_name)
-        except Exception as e:
-            if _index is None:
-                raise e
-            else:
-                raise ValueError(
-                    f"Error processing instance '{_index}' from stream '{stream_name}' in {self.__class__.__name__} due to the exception above."
-                ) from e
 
     def _process_instance(
         self, instance: Dict[str, Any], stream_name: Optional[str] = None

--- a/src/unitxt/settings_utils.py
+++ b/src/unitxt/settings_utils.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 import importlib.util
 import os
+import sys
 from contextlib import contextmanager
 
 from .version import version
@@ -177,6 +178,9 @@ if Constants.is_uninitilized():
     constants.dataset_url = "unitxt/data"
     constants.metric_url = "unitxt/metric"
     constants.version = version
+    constants.python = (
+        f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    )
     constants.catalog_hierarchy_sep = "."
     constants.env_local_catalogs_paths_sep = ":"
     constants.non_registered_files = [

--- a/src/unitxt/task.py
+++ b/src/unitxt/task.py
@@ -285,7 +285,7 @@ class Task(InstanceOperator, ArtifactFetcherMixin):
     ) -> Dict[str, Any]:
         instance = self.set_default_values(instance)
 
-        with error_context(self, stage="Task Verification"):
+        with error_context(self, stage="Schema Verification"):
             verify_required_schema(
                 self.input_fields,
                 instance,

--- a/src/unitxt/task.py
+++ b/src/unitxt/task.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from .artifact import fetch_artifact
 from .deprecation_utils import deprecation
-from .error_utils import Documentation, UnitxtError, UnitxtWarning
+from .error_utils import Documentation, UnitxtError, UnitxtWarning, error_context
 from .logging_utils import get_logger
 from .metrics import MetricsList
 from .operator import InstanceOperator
@@ -285,13 +285,14 @@ class Task(InstanceOperator, ArtifactFetcherMixin):
     ) -> Dict[str, Any]:
         instance = self.set_default_values(instance)
 
-        verify_required_schema(
-            self.input_fields,
-            instance,
-            class_name="Task",
-            id=self.__id__,
-            description=self.__description__,
-        )
+        with error_context(self, stage="Task Verification"):
+            verify_required_schema(
+                self.input_fields,
+                instance,
+                class_name="Task",
+                id=self.__id__,
+                description=self.__description__,
+            )
         input_fields = {key: instance[key] for key in self.input_fields.keys()}
         data_classification_policy = instance.get("data_classification_policy", [])
 

--- a/tests/library/test_error_utils.py
+++ b/tests/library/test_error_utils.py
@@ -1,4 +1,4 @@
-from unitxt.error_utils import Documentation, UnitxtError, UnitxtWarning
+from unitxt.error_utils import Documentation, UnitxtError, UnitxtWarning, error_context
 
 from tests.utils import UnitxtTestCase
 
@@ -22,3 +22,251 @@ class TestErrorUtils(UnitxtTestCase):
 
     def test_warning_with_additional_info(self):
         UnitxtWarning("This should fail", Documentation.ADDING_TASK)
+
+
+class TestContextEnhancedErrors(UnitxtTestCase):
+    def test_error_context_with_original_error_only(self):
+        """Test error_context with just the original error."""
+        with self.assertRaises(ValueError) as cm:
+            with error_context():
+                raise ValueError("Original error message")
+
+        error = cm.exception
+        self.assertEqual(str(error), "Original error message")
+
+    def test_error_context_with_context_object(self):
+        """Test error_context with a context object."""
+
+        class TestProcessor:
+            pass
+
+        processor = TestProcessor()
+
+        with self.assertRaises(KeyError) as cm:
+            with error_context(processor):
+                raise KeyError("Missing key")
+
+        error = cm.exception
+        # KeyError has special __str__ behavior that adds quotes, so we check the content is there
+        message = str(error)
+        self.assertIn("Error Context", message)
+        self.assertIn("Object: TestProcessor", message)
+        self.assertIn("Missing key", message)
+        # Check for box characters
+        self.assertIn("┌", message)
+        self.assertIn("└", message)
+
+    def test_error_context_with_context_fields(self):
+        """Test error_context with custom context fields."""
+        with self.assertRaises(RuntimeError) as cm:
+            with error_context(
+                file_name="data.json", line_number=42, operation="parse"
+            ):
+                raise RuntimeError("Processing failed")
+
+        error = cm.exception
+
+        message = str(error)
+        self.assertIn("Error Context", message)
+        self.assertIn("File Name: data.json", message)
+        self.assertIn("Line Number: 42", message)
+        self.assertIn("Operation: parse", message)
+        self.assertIn("Processing failed", message)
+        # Check for box characters
+        self.assertIn("┌", message)
+        self.assertIn("└", message)
+
+    def test_error_context_with_object_and_context(self):
+        """Test error_context with both context object and context fields."""
+
+        class DatabaseConnection:
+            pass
+
+        db = DatabaseConnection()
+
+        with self.assertRaises(ConnectionError) as cm:
+            with error_context(db, table="users", operation="SELECT", batch_size=1000):
+                raise ConnectionError("Connection timeout")
+
+        error = cm.exception
+        message = str(error)
+        self.assertIn("Error Context", message)
+        self.assertIn("Object: DatabaseConnection", message)
+        self.assertIn("Batch Size: 1000", message)
+        self.assertIn("Operation: SELECT", message)
+        self.assertIn("Table: users", message)
+        self.assertIn("Connection timeout", message)
+        # Check for box characters
+        self.assertIn("┌", message)
+        self.assertIn("└", message)
+
+    def test_error_context_with_none_values(self):
+        """Test error_context handles None values correctly."""
+        with self.assertRaises(ValueError) as cm:
+            with error_context(stream_name=None, valid_field="test_value"):
+                raise ValueError("Test error")
+
+        error = cm.exception
+        message = str(error)
+        self.assertIn("Error Context", message)
+        self.assertIn("Stream Name: unknown", message)
+        self.assertIn("Valid Field: test_value", message)
+        self.assertIn("Test error", message)
+        # Check for box characters
+        self.assertIn("┌", message)
+        self.assertIn("└", message)
+
+    def test_error_context_field_name_formatting(self):
+        """Test that field names are properly formatted."""
+        with self.assertRaises(ValueError) as cm:
+            with error_context(
+                field_name="input_text",
+                processing_step="tokenization",
+                model_name="bert_base",
+                gpu_device="cuda_0",
+            ):
+                raise ValueError("Test error")
+
+        error = cm.exception
+        # Check that underscores are replaced with spaces and titles are applied
+        message = str(error)
+        self.assertIn("Field Name: input_text", message)
+        self.assertIn("Processing Step: tokenization", message)
+        self.assertIn("Model Name: bert_base", message)
+        self.assertIn("Gpu Device: cuda_0", message)
+
+    def test_error_context_original_error_access(self):
+        """Test that original error is accessible via attributes."""
+        original_error = ValueError("Original error")
+
+        with self.assertRaises(ValueError) as cm:
+            with error_context():
+                raise original_error
+
+        error = cm.exception
+        # The original_error attribute should have the same type and message
+        self.assertIsInstance(error.original_error, ValueError)
+        self.assertEqual(str(error.original_error), "Original error")
+
+
+class TestErrorContext(UnitxtTestCase):
+    def test_error_context_no_error(self):
+        """Test error_context when no error occurs."""
+        with error_context("test_object", operation="test"):
+            result = "success"
+
+        self.assertEqual(result, "success")
+
+    def test_error_context_with_error(self):
+        """Test error_context when an error occurs."""
+
+        class TestProcessor:
+            pass
+
+        processor = TestProcessor()
+
+        with self.assertRaises(ValueError) as cm:
+            with error_context(processor, operation="validation", item_id=42):
+                raise ValueError("Something went wrong")
+
+        error = cm.exception
+        self.assertIsInstance(error, ValueError)
+        self.assertEqual(str(error.original_error), "Something went wrong")
+        self.assertEqual(error.context_object, processor)
+        self.assertEqual(error.context, {"operation": "validation", "item_id": 42})
+
+    def test_error_context_without_object(self):
+        """Test error_context without a context object."""
+        with self.assertRaises(KeyError) as cm:
+            with error_context(input_file="data.json", line_number=156):
+                raise KeyError("Missing field")
+
+        error = cm.exception
+        self.assertIsInstance(error, KeyError)
+        self.assertIsNone(error.context_object)
+        self.assertEqual(error.context, {"input_file": "data.json", "line_number": 156})
+
+    def test_error_context_preserves_original_traceback(self):
+        """Test that error_context preserves the original exception's traceback."""
+        caught_error = None
+
+        try:
+            with error_context(operation="test"):
+                raise ValueError("Original error")  # This is line 180
+        except ValueError as e:
+            caught_error = e
+
+        self.assertIsNotNone(caught_error)
+        self.assertIsInstance(caught_error, ValueError)
+        self.assertEqual(str(caught_error.original_error), "Original error")
+
+        # Test that the traceback is preserved and points to the original raise location
+        self.assertIsNotNone(caught_error.__traceback__)
+        # The traceback should show the line number where the error was processed
+        # The traceback points to the raise statement where the original error was raised
+        self.assertEqual(
+            caught_error.__traceback__.tb_lineno, 191
+        )  # Line where raise ValueError occurs
+
+    def test_error_context_nested_contexts(self):
+        """Test nested error_context calls."""
+
+        class OuterProcessor:
+            pass
+
+        class InnerProcessor:
+            pass
+
+        outer = OuterProcessor()
+        inner = InnerProcessor()
+
+        # In nested contexts, the outer context catches and re-raises the inner error
+        with self.assertRaises(RuntimeError) as cm:
+            with error_context(outer, stage="outer", step=1):
+                with error_context(inner, stage="inner", step=2, index=1):
+                    raise RuntimeError("Nested error")
+
+        # Should get the outermost context (outer catches the inner enhanced error)
+        error = cm.exception
+        self.assertEqual(error.context_object, outer)
+        self.assertEqual(error.context, {"stage": "outer", "step": 1, "index": 1})
+
+        # The error message should include both contexts
+        message = str(error)
+        self.assertIn("Object: OuterProcessor", message)
+        self.assertIn("Stage: outer", message)
+
+    def test_error_context_empty_context(self):
+        """Test error_context with empty context."""
+        with self.assertRaises(ValueError) as cm:
+            with error_context():
+                raise ValueError("Test error")
+
+        error = cm.exception
+        self.assertIsNone(error.context_object)
+        self.assertEqual(error.context, {})
+        self.assertEqual(str(error), "Test error")
+
+    def test_error_context_complex_objects(self):
+        """Test error_context with complex context objects."""
+
+        class ComplexProcessor:
+            def __init__(self, name):
+                self.name = name
+
+            def __str__(self):
+                return f"ComplexProcessor({self.name})"
+
+        processor = ComplexProcessor("test_processor")
+
+        with self.assertRaises(OSError) as cm:
+            with error_context(processor, config_file="settings.json"):
+                raise OSError("File not found")
+
+        error = cm.exception
+        self.assertEqual(error.context_object, processor)
+
+        # Should identify object by class name, not __str__
+        message = str(error)
+        self.assertIn("Object: ComplexProcessor", message)
+        self.assertIn("Config File: settings.json", message)


### PR DESCRIPTION
Above every error message there is context for the error:
```bash
raise ValueError(
┌──────────────────────────────┐
│ Unitxt Error Context         │
│  - Object: LoadFromDictionary│
│  - Unitxt: 1.24.0            │
│  - Python: 3.10.18           │
│  - Function: verify()        │
│  - Help: link                │
└──────────────────────────────┘

ValueError: Passed data to LoadFromDictionary is not of type Dict[str, List[Dict[str, Any]]].
Expected data should map between split name and list of instances.
Received value: 
```
Where the object name link to its docs, and the help link is set differently in different places.

