### PR TITLE
extend condition to also filter by field exists or not

### DIFF
--- a/prepare/cards/judge_bench/inferential_strategies.py
+++ b/prepare/cards/judge_bench/inferential_strategies.py
@@ -9,7 +9,7 @@ from unitxt.blocks import (
 from unitxt.catalog import add_to_catalog
 from unitxt.llm_as_judge_constants import DirectCriteriaCatalogEnum
 from unitxt.loaders import LoadJsonFile
-from unitxt.operators import Copy, Set
+from unitxt.operators import Copy, FilterByCondition, Set
 from unitxt.processors import GroupDictWithRegex
 from unitxt.task import Task
 from unitxt.test_utils.card import test_card
@@ -34,6 +34,9 @@ card = TaskCard(
                 r"(?P<model_reasoning>.*)"
             ),
             flags=re.DOTALL,
+        ),
+        FilterByCondition(
+            values={"instance/problem_statement": True}, condition="exists"
         ),
         Rename(
             field_to_field={

--- a/src/unitxt/catalog/cards/judge_bench/inferential_strategies/sound_reasoning.json
+++ b/src/unitxt/catalog/cards/judge_bench/inferential_strategies/sound_reasoning.json
@@ -18,6 +18,13 @@
             "flags": 16
         },
         {
+            "__type__": "filter_by_condition",
+            "values": {
+                "instance/problem_statement": true
+            },
+            "condition": "exists"
+        },
+        {
             "__type__": "rename",
             "field_to_field": {
                 "instance/problem_statement": "problem statement",

--- a/src/unitxt/operators.py
+++ b/src/unitxt/operators.py
@@ -1254,6 +1254,8 @@ class FilterByCondition(StreamOperator):
        | ``FilterByCondition(values = {"a":[4,8]}, condition = "not in")`` will yield only instances where ``"a"`` is different from ``4`` or ``8``
        | ``FilterByCondition(values = {"a/b":[4,8]}, condition = "not in")`` will yield only instances where ``"a"`` is a dict in which key ``"b"`` is mapped to a value that is neither ``4`` nor ``8``
        | ``FilterByCondition(values = {"a[2]":4}, condition = "le")`` will yield only instances where "a" is a list whose 3-rd element is ``<= 4``
+       | ``FilterByCondition(values = {"a":False}, condition = "exists")`` will yield only instances which do not contain a field named ``"a"``
+       | ``FilterByCondition(values = {"a/b":True}, condition = "exists")`` will yield only instances which contain a field named ``"a"`` whose value is a dict containing, in turn, a field named ``"b"``
 
 
     """
@@ -1269,6 +1271,7 @@ class FilterByCondition(StreamOperator):
         "ne": operator.ne,
         "in": None,  # Handled as special case
         "not in": None,  # Handled as special case
+        "exists": None,  # Handled as special case
     }
     error_on_filtered_all: bool = True
 
@@ -1295,13 +1298,25 @@ class FilterByCondition(StreamOperator):
                 raise ValueError(
                     f"The filter for key ('{key}') in FilterByCondition with condition '{self.condition}' must be list but is not : '{value}'"
                 )
+
+        if self.condition == "exists":
+            for key, value in self.values.items():
+                if not isinstance(value, bool):
+                    raise ValueError(
+                        f"For condition 'exists', the value for key ('{key}') in FilterByCondition must be boolean. But is not : '{value}'"
+                    )
+
         return super().verify()
 
     def _is_required(self, instance: dict) -> bool:
         for key, value in self.values.items():
             try:
                 instance_key = dict_get(instance, key)
+                if self.condition == "exists":
+                    return value
             except ValueError as ve:
+                if self.condition == "exists":
+                    return not value
                 raise ValueError(
                     f"Required filter field ('{key}') in FilterByCondition is not found in instance."
                 ) from ve

--- a/tests/library/test_operators.py
+++ b/tests/library/test_operators.py
@@ -375,6 +375,36 @@ class TestOperators(UnitxtTestCase):
             tester=self,
         )
 
+    def test_filter_by_condition_exists(self):
+        inputs = [
+            {"a": 1, "b": {"c": 2}},
+            {"a": 2, "b": {"c": 3}, "d": 4},
+            {"a": 1, "b": {"c": 3}},
+        ]
+
+        targets = [
+            {"a": 2, "b": {"c": 3}, "d": 4},
+        ]
+
+        check_operator(
+            operator=FilterByCondition(values={"d": True}, condition="exists"),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
+        targets = [
+            {"a": 1, "b": {"c": 2}},
+            {"a": 1, "b": {"c": 3}},
+        ]
+
+        check_operator(
+            operator=FilterByCondition(values={"d": False}, condition="exists"),
+            inputs=inputs,
+            targets=targets,
+            tester=self,
+        )
+
     def test_filter_by_condition_ne(self):
         inputs = [
             {"a": [0, 10], "b": 2},


### PR DESCRIPTION
Currently, Filter by condition throws an exception if a field participating in the condition is missing from the instance.
Suggesting here to extend conditions to also handle the very existence of the field in the instance as a measure of this instance being required.  
This can be handy for cleaning datasets in some of the cards, which now throw exception for a missing field (breaking the pre-processing pipeline), and also, indirectly, shed light on cards that are totally erroneous, and are better be removed from the catalog:
E.g. for helpful cleaning:
Currently:
<img width="1301" height="887" alt="image" src="https://github.com/user-attachments/assets/4b1bd7d3-7db1-4a3b-a528-b043929f8d0e" />

whereas [pushing the new operators in the card](https://github.com/IBM/unitxt/pull/1879/files#diff-c0511cc100f69c845f48afdd069a0e19f4c08138fd4e0cb81a8d35adefbc5ca5), yields:

<img width="1327" height="723" alt="image" src="https://github.com/user-attachments/assets/4351db89-8994-4faf-9002-c2e79fcb9b66" />


Another example, that makes us consider a removal of a totally erroneous card from the catalog:
<img width="1303" height="860" alt="image" src="https://github.com/user-attachments/assets/5ebeb6a5-bc1a-48d3-838e-47b9bc0f2010" />

while with the new filter, we find that the whole subset is missing that field, and we may want to remove the card (for subset 'experts') from the catalog altogether:

<img width="1246" height="1042" alt="image" src="https://github.com/user-attachments/assets/502a7eb8-d235-45a4-9d9f-b9900d7f6f1c" />


Just to prove the point that the whole dataset, of subset experts, does not match the preprocessing steps:
<img width="1270" height="455" alt="image" src="https://github.com/user-attachments/assets/a23a0e22-3ac2-488c-b513-4fbda4acb863" />

as compared to a subset that does match:
<img width="1267" height="684" alt="image" src="https://github.com/user-attachments/assets/00843c2f-b3c7-48ad-9a23-d782655001eb" />
