### PR TITLE
Mitigate HTTP 403 errors in pandas

### DIFF
--- a/prepare/cards/CFPB_product.py
+++ b/prepare/cards/CFPB_product.py
@@ -40,7 +40,12 @@ mappers = {
 }
 for subset, url in subset_and_urls.items():
     card = TaskCard(
-        loader=LoadCSV(files={"train": url}, streaming=False),
+        loader=LoadCSV(
+            files={"train": url},
+            streaming=False,
+            indirect_read=True,
+            data_classification_policy=["public"],
+        ),
         preprocess_steps=[
             SplitRandomMix(
                 {

--- a/src/unitxt/catalog/cards/CFPB/product/2023.json
+++ b/src/unitxt/catalog/cards/CFPB/product/2023.json
@@ -5,7 +5,11 @@
         "files": {
             "train": "https://www.consumerfinance.gov/data-research/consumer-complaints/search/api/v1/?date_received_max=2023-01-04&date_received_min=2022-01-04&field=all&format=csv&has_narrative=true&lens=product&no_aggs=true&size=340390&sub_lens=sub_product&trend_depth=5&trend_interval=month"
         },
-        "streaming": false
+        "streaming": false,
+        "indirect_read": true,
+        "data_classification_policy": [
+            "public"
+        ]
     },
     "preprocess_steps": [
         {

--- a/src/unitxt/catalog/cards/CFPB/product/watsonx.json
+++ b/src/unitxt/catalog/cards/CFPB/product/watsonx.json
@@ -5,7 +5,11 @@
         "files": {
             "train": "https://raw.githubusercontent.com/IBM/watson-machine-learning-samples/master/cloud/data/cfpb_complaints/cfpb_compliants.csv"
         },
-        "streaming": false
+        "streaming": false,
+        "indirect_read": true,
+        "data_classification_policy": [
+            "public"
+        ]
     },
     "preprocess_steps": [
         {


### PR DESCRIPTION
This PR introduces an optional flag to pre-open remote URLS with urllib before reading them with pandas. This resolves HTTP 403 errors received sometimes when the pandas implementation is used directly.
