### PR TITLE
fix the only 4 erroneous global_mmlu cards that do not pass _source_to_dataset

### DIFF
--- a/prepare/cards/global_mmlu.py
+++ b/prepare/cards/global_mmlu.py
@@ -3,6 +3,7 @@ from unitxt.catalog import add_to_catalog
 from unitxt.loaders import LoadHF
 from unitxt.operators import (
     Deduplicate,
+    FilterByExpression,
     ListFieldValues,
     MapInstanceValues,
     Set,
@@ -141,8 +142,19 @@ for language in languages:
                     fields=["option_a", "option_b", "option_c", "option_d"],
                     to_field="choices",
                 ),
-                Set({"topic": subject.replace("_", " ")}),
-            ],
+            ]
+            + (
+                [FilterByExpression(expression="None not in choices")]
+                if (language, subject)
+                in [
+                    ("am", "clinical_knowledge"),
+                    ("am", "college_medicine"),
+                    ("ig", "college_computer_science"),
+                    ("vi", "conceptual_physics"),
+                ]
+                else []
+            )
+            + [Set({"topic": subject.replace("_", " ")})],
             task="tasks.qa.multiple_choice.with_topic",
             templates="templates.qa.multiple_choice.with_topic.all",
             __tags__={

--- a/src/unitxt/catalog/cards/global_mmlu/am/clinical_knowledge.json
+++ b/src/unitxt/catalog/cards/global_mmlu/am/clinical_knowledge.json
@@ -43,6 +43,10 @@
             "to_field": "choices"
         },
         {
+            "__type__": "filter_by_expression",
+            "expression": "None not in choices"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "topic": "clinical knowledge"

--- a/src/unitxt/catalog/cards/global_mmlu/am/college_medicine.json
+++ b/src/unitxt/catalog/cards/global_mmlu/am/college_medicine.json
@@ -43,6 +43,10 @@
             "to_field": "choices"
         },
         {
+            "__type__": "filter_by_expression",
+            "expression": "None not in choices"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "topic": "college medicine"

--- a/src/unitxt/catalog/cards/global_mmlu/ig/college_computer_science.json
+++ b/src/unitxt/catalog/cards/global_mmlu/ig/college_computer_science.json
@@ -43,6 +43,10 @@
             "to_field": "choices"
         },
         {
+            "__type__": "filter_by_expression",
+            "expression": "None not in choices"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "topic": "college computer science"

--- a/src/unitxt/catalog/cards/global_mmlu/vi/conceptual_physics.json
+++ b/src/unitxt/catalog/cards/global_mmlu/vi/conceptual_physics.json
@@ -43,6 +43,10 @@
             "to_field": "choices"
         },
         {
+            "__type__": "filter_by_expression",
+            "expression": "None not in choices"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "topic": "conceptual physics"


### PR DESCRIPTION
`global_mmlu` cards constitute 75% of the cards in the catalog. It is nice to observe that only 4 of them generate recipes that do not pass `_source_to_dataset`.   These cards are fixed in this PR.

global_mmlu in main (with the 4 errors):  
[global_mmlu.pdf](https://github.com/user-attachments/files/21754792/global_mmlu.pdf)

and checking the 4 fixed cards: