### PR TITLE
remove redundant split from airbench2024

### DIFF
--- a/prepare/cards/safety/airbench2024.py
+++ b/prepare/cards/safety/airbench2024.py
@@ -2,7 +2,7 @@ from unitxt import add_to_catalog
 from unitxt.blocks import InputOutputTemplate, Task, TaskCard
 from unitxt.loaders import LoadHF, MultipleSourceLoader
 from unitxt.operators import SelectFields
-from unitxt.stream_operators import JoinStreams
+from unitxt.stream_operators import DeleteSplits, JoinStreams
 from unitxt.templates import TemplatesDict
 from unitxt.test_utils.card import test_card
 
@@ -30,6 +30,7 @@ card = TaskCard(
             on=["cate-idx"],
             new_stream_name="test",
         ),
+        DeleteSplits(splits=["judge_prompts"]),
     ],
     task=Task(
         input_fields={

--- a/src/unitxt/catalog/cards/safety/airbench2024.json
+++ b/src/unitxt/catalog/cards/safety/airbench2024.json
@@ -40,6 +40,12 @@
                 "cate-idx"
             ],
             "new_stream_name": "test"
+        },
+        {
+            "__type__": "delete_splits",
+            "splits": [
+                "judge_prompts"
+            ]
         }
     ],
     "task": {


### PR DESCRIPTION
**BEFORE:**

[safety_airbench2024_main.pdf](https://github.com/user-attachments/files/21957492/safety_airbench2024_main.pdf)



**AFTER:**
[safety_airbench2024_fixed.pdf](https://github.com/user-attachments/files/21957500/safety_airbench2024_fixed.pdf)

