### PR TITLE
Normalize llm judge bench target variable

### DIFF
--- a/prepare/cards/biggen_bench.py
+++ b/prepare/cards/biggen_bench.py
@@ -3,7 +3,11 @@ from typing import Any
 from unitxt import add_to_catalog
 from unitxt.blocks import Copy, LoadHF, Set, Task, TaskCard
 from unitxt.llm_as_judge import CreateCriteriaWithOptionsFromDict
-from unitxt.operators import Cast, MergeStreams
+from unitxt.operators import (
+    ExecuteExpression,
+    FilterByCondition,
+    MergeStreams,
+)
 from unitxt.string_operators import FormatText
 from unitxt.test_utils.card import test_card
 
@@ -33,8 +37,10 @@ card = TaskCard(
             new_stream_name="test",
             add_origin_stream_name=True,
         ),
+        # Cast(field="human_score", to="str"),
+        FilterByCondition(values={"human_score": -1}, condition="ne"),
+        ExecuteExpression(expression="(human_score - 1) / 4", to_field="human_score"),
         Set(fields={"criteria": empty_criteria}),
-        Cast(field="human_score", to="float"),
         # biggen exposes to level of granularities, e.g. capability: theory_of_mind, task: guess_the_emotion
         FormatText(text="{capability}-{task}", to_field="criteria_name"),
         Copy(
@@ -56,6 +62,9 @@ card = TaskCard(
             "input": str,
             "response": str,
             "reference_answer": str,
+            "language": str,
+            "capability": str,
+            "task": str,
             "criteria": Any,
         },
         reference_fields={"human_score": float},

--- a/prepare/cards/judge_bench/newsroom.py
+++ b/prepare/cards/judge_bench/newsroom.py
@@ -6,7 +6,7 @@ from unitxt.blocks import (
 )
 from unitxt.catalog import add_to_catalog
 from unitxt.loaders import LoadJsonFile
-from unitxt.operators import Cast, Rename, Set
+from unitxt.operators import Cast, ExecuteExpression, Rename, Set
 from unitxt.processors import GroupDictWithRegex
 from unitxt.task import Task
 from unitxt.test_utils.card import test_card
@@ -32,6 +32,7 @@ for criteria_name, criteria_artifact in criteria_to_artifact.items():
                 field=f"annotations/{criteria_name}/mean_human", to_field="mean_score"
             ),
             Cast(field="mean_score", to="float"),
+            ExecuteExpression(expression="(mean_score - 1) / 4", to_field="mean_score"),
             GroupDictWithRegex(
                 field="instance",
                 pattern=r"### Generated Summary\s+(?P<generated_summary>.*?)\s+### Source Article\s+(?P<source_article>.*)",
@@ -45,9 +46,7 @@ for criteria_name, criteria_artifact in criteria_to_artifact.items():
             input_fields={"summary": str, "article": str, "criteria": Any},
             reference_fields={"mean_score": float},
             prediction_type=float,
-            metrics=[
-                "metrics.spearman",
-            ],
+            metrics=["metrics.spearman", "metrics.pearson"],
             default_template="templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]",
         ),
         templates=[],

--- a/prepare/cards/judge_bench/roscoe_overall.py
+++ b/prepare/cards/judge_bench/roscoe_overall.py
@@ -7,7 +7,14 @@ from unitxt.blocks import (
 from unitxt.catalog import add_to_catalog
 from unitxt.llm_as_judge_constants import DirectCriteriaCatalogEnum
 from unitxt.loaders import LoadJsonFile
-from unitxt.operators import Cast, Copy, MapInstanceValues, Rename, Set
+from unitxt.operators import (
+    Cast,
+    Copy,
+    ExecuteExpression,
+    MapInstanceValues,
+    Rename,
+    Set,
+)
 from unitxt.processors import GroupDictWithRegex
 from unitxt.task import Task
 from unitxt.test_utils.card import test_card
@@ -25,9 +32,10 @@ criteria_to_config = {
         "criteria_artifact": "metrics.llm_as_judge.direct.criteria.step_by_step_reasoning_coherency",
         "preprocess_steps": [
             Cast(field="mean_score", to="float"),
+            ExecuteExpression(expression="(mean_score - 1) / 4", to_field="mean_score"),
         ],
         "reference_fields": {"mean_score": float},
-        "metrics": ["metrics.spearman"],
+        "metrics": ["metrics.pearson", "metrics.spearman"],
     },
     "contradiction": {
         "label_mapping": {"annotations/Contradiction/majority_human": "label"},
@@ -72,11 +80,10 @@ criteria_to_config = {
         "criteria_artifact": "metrics.llm_as_judge.direct.criteria.step_by_step_reasoning_overall_quality",
         "preprocess_steps": [
             Cast(field="mean_score", to="float"),
+            ExecuteExpression(expression="(mean_score - 1) / 4", to_field="mean_score"),
         ],
         "reference_fields": {"mean_score": float},
-        "metrics": [
-            "metrics.spearman",
-        ],
+        "metrics": ["metrics.pearson", "metrics.spearman"],
     },
 }
 for criteria_name, config in criteria_to_config.items():

--- a/prepare/cards/judge_bench/wmt-human.py
+++ b/prepare/cards/judge_bench/wmt-human.py
@@ -57,7 +57,7 @@ for dataset_name, config in dataset_to_config.items():
             },
             reference_fields={"mean_score": float},
             prediction_type=float,
-            metrics=["metrics.spearman"],
+            metrics=["metrics.pearson", "metrics.spearman"],
             default_template="templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]",
         ),
         templates=[

--- a/src/unitxt/catalog/cards/biggen_bench/results/human_eval.json
+++ b/src/unitxt/catalog/cards/biggen_bench/results/human_eval.json
@@ -19,6 +19,18 @@
             "add_origin_stream_name": true
         },
         {
+            "__type__": "filter_by_condition",
+            "values": {
+                "human_score": -1
+            },
+            "condition": "ne"
+        },
+        {
+            "__type__": "execute_expression",
+            "expression": "(human_score - 1) / 4",
+            "to_field": "human_score"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "criteria": {
@@ -63,11 +75,6 @@
             }
         },
         {
-            "__type__": "cast",
-            "field": "human_score",
-            "to": "float"
-        },
-        {
             "__type__": "format_text",
             "text": "{capability}-{task}",
             "to_field": "criteria_name"
@@ -96,6 +103,9 @@
             "input": "str",
             "response": "str",
             "reference_answer": "str",
+            "language": "str",
+            "capability": "str",
+            "task": "str",
             "criteria": "Any"
         },
         "reference_fields": {

--- a/src/unitxt/catalog/cards/judge_bench/newswoom/coherence.json
+++ b/src/unitxt/catalog/cards/judge_bench/newswoom/coherence.json
@@ -22,6 +22,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "group_dict_with_regex",
             "field": "instance",
             "pattern": "### Generated Summary\\s+(?P<generated_summary>.*?)\\s+### Source Article\\s+(?P<source_article>.*)",
@@ -56,7 +61,8 @@
         },
         "prediction_type": "float",
         "metrics": [
-            "metrics.spearman"
+            "metrics.spearman",
+            "metrics.pearson"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"
     },

--- a/src/unitxt/catalog/cards/judge_bench/newswoom/fluency.json
+++ b/src/unitxt/catalog/cards/judge_bench/newswoom/fluency.json
@@ -22,6 +22,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "group_dict_with_regex",
             "field": "instance",
             "pattern": "### Generated Summary\\s+(?P<generated_summary>.*?)\\s+### Source Article\\s+(?P<source_article>.*)",
@@ -56,7 +61,8 @@
         },
         "prediction_type": "float",
         "metrics": [
-            "metrics.spearman"
+            "metrics.spearman",
+            "metrics.pearson"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"
     },

--- a/src/unitxt/catalog/cards/judge_bench/newswoom/informativeness.json
+++ b/src/unitxt/catalog/cards/judge_bench/newswoom/informativeness.json
@@ -22,6 +22,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "group_dict_with_regex",
             "field": "instance",
             "pattern": "### Generated Summary\\s+(?P<generated_summary>.*?)\\s+### Source Article\\s+(?P<source_article>.*)",
@@ -56,7 +61,8 @@
         },
         "prediction_type": "float",
         "metrics": [
-            "metrics.spearman"
+            "metrics.spearman",
+            "metrics.pearson"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"
     },

--- a/src/unitxt/catalog/cards/judge_bench/newswoom/relevance.json
+++ b/src/unitxt/catalog/cards/judge_bench/newswoom/relevance.json
@@ -22,6 +22,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "group_dict_with_regex",
             "field": "instance",
             "pattern": "### Generated Summary\\s+(?P<generated_summary>.*?)\\s+### Source Article\\s+(?P<source_article>.*)",
@@ -56,7 +61,8 @@
         },
         "prediction_type": "float",
         "metrics": [
-            "metrics.spearman"
+            "metrics.spearman",
+            "metrics.pearson"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"
     },

--- a/src/unitxt/catalog/cards/judge_bench/roscoe/overall/cosmos/coherence.json
+++ b/src/unitxt/catalog/cards/judge_bench/roscoe/overall/cosmos/coherence.json
@@ -33,6 +33,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "criteria": "metrics.llm_as_judge.direct.criteria.step_by_step_reasoning_coherency",
@@ -55,6 +60,7 @@
         },
         "prediction_type": "float",
         "metrics": [
+            "metrics.pearson",
             "metrics.spearman"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"

--- a/src/unitxt/catalog/cards/judge_bench/roscoe/overall/cosmos/overall_quality.json
+++ b/src/unitxt/catalog/cards/judge_bench/roscoe/overall/cosmos/overall_quality.json
@@ -33,6 +33,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "criteria": "metrics.llm_as_judge.direct.criteria.step_by_step_reasoning_overall_quality",
@@ -55,6 +60,7 @@
         },
         "prediction_type": "float",
         "metrics": [
+            "metrics.pearson",
             "metrics.spearman"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"

--- a/src/unitxt/catalog/cards/judge_bench/roscoe/overall/drop/coherence.json
+++ b/src/unitxt/catalog/cards/judge_bench/roscoe/overall/drop/coherence.json
@@ -33,6 +33,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "criteria": "metrics.llm_as_judge.direct.criteria.step_by_step_reasoning_coherency",
@@ -55,6 +60,7 @@
         },
         "prediction_type": "float",
         "metrics": [
+            "metrics.pearson",
             "metrics.spearman"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"

--- a/src/unitxt/catalog/cards/judge_bench/roscoe/overall/drop/overall_quality.json
+++ b/src/unitxt/catalog/cards/judge_bench/roscoe/overall/drop/overall_quality.json
@@ -33,6 +33,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "criteria": "metrics.llm_as_judge.direct.criteria.step_by_step_reasoning_overall_quality",
@@ -55,6 +60,7 @@
         },
         "prediction_type": "float",
         "metrics": [
+            "metrics.pearson",
             "metrics.spearman"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"

--- a/src/unitxt/catalog/cards/judge_bench/roscoe/overall/esnli/coherence.json
+++ b/src/unitxt/catalog/cards/judge_bench/roscoe/overall/esnli/coherence.json
@@ -33,6 +33,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "criteria": "metrics.llm_as_judge.direct.criteria.step_by_step_reasoning_coherency",
@@ -55,6 +60,7 @@
         },
         "prediction_type": "float",
         "metrics": [
+            "metrics.pearson",
             "metrics.spearman"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"

--- a/src/unitxt/catalog/cards/judge_bench/roscoe/overall/esnli/overall_quality.json
+++ b/src/unitxt/catalog/cards/judge_bench/roscoe/overall/esnli/overall_quality.json
@@ -33,6 +33,11 @@
             "to": "float"
         },
         {
+            "__type__": "execute_expression",
+            "expression": "(mean_score - 1) / 4",
+            "to_field": "mean_score"
+        },
+        {
             "__type__": "set",
             "fields": {
                 "criteria": "metrics.llm_as_judge.direct.criteria.step_by_step_reasoning_overall_quality",
@@ -55,6 +60,7 @@
         },
         "prediction_type": "float",
         "metrics": [
+            "metrics.pearson",
             "metrics.spearman"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"

--- a/src/unitxt/catalog/cards/judge_bench/wmt_human/chinese_to_english/quality.json
+++ b/src/unitxt/catalog/cards/judge_bench/wmt_human/chinese_to_english/quality.json
@@ -58,6 +58,7 @@
         },
         "prediction_type": "float",
         "metrics": [
+            "metrics.pearson",
             "metrics.spearman"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"

--- a/src/unitxt/catalog/cards/judge_bench/wmt_human/english_to_german/quality.json
+++ b/src/unitxt/catalog/cards/judge_bench/wmt_human/english_to_german/quality.json
@@ -58,6 +58,7 @@
         },
         "prediction_type": "float",
         "metrics": [
+            "metrics.pearson",
             "metrics.spearman"
         ],
         "default_template": "templates.empty[postprocessors=[processors.cast_to_float_return_nan_if_failed]]"


### PR DESCRIPTION
This PR normalizes the target variable (ground truth) of the judgebench and biggen cards, where applicable. They are linearly normalized using the function: `normalize(x) = (x - min(x)) / (max(x) - min(x))`. So, a Likert scale (1-5) is mapped as:
- 1 -> 0.0
- 2 -> 0.25
- 3 -> 0.5
- 4 -> 0.75
- 5 -> 1.0

We are already consitently using criteria score mappings to values between 0 and 1, so this change aims for simplifying benchmark results.