### PR TITLE
potential fix for preparation file: prepare/cards/mtrag.py

### DIFF
--- a/prepare/cards/mtrag.py
+++ b/prepare/cards/mtrag.py
@@ -105,7 +105,7 @@ for subset in ["clapnq", "cloud", "fiqa", "govt"]:
     card = TaskCard(
         loader=LoadJsonFile(
             files={
-                "test": f"https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/{subset}.jsonl.zip"
+                "test": f"https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/document_level/{subset}.jsonl.zip"
             },
             compression="zip",
             lines=True,

--- a/src/unitxt/catalog/cards/rag/mtrag/documents/clapnq.json
+++ b/src/unitxt/catalog/cards/rag/mtrag/documents/clapnq.json
@@ -3,7 +3,7 @@
     "loader": {
         "__type__": "load_json_file",
         "files": {
-            "test": "https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/clapnq.jsonl.zip"
+            "test": "https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/document_level/clapnq.jsonl.zip"
         },
         "compression": "zip",
         "lines": true,

--- a/src/unitxt/catalog/cards/rag/mtrag/documents/cloud.json
+++ b/src/unitxt/catalog/cards/rag/mtrag/documents/cloud.json
@@ -3,7 +3,7 @@
     "loader": {
         "__type__": "load_json_file",
         "files": {
-            "test": "https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/cloud.jsonl.zip"
+            "test": "https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/document_level/cloud.jsonl.zip"
         },
         "compression": "zip",
         "lines": true,

--- a/src/unitxt/catalog/cards/rag/mtrag/documents/fiqa.json
+++ b/src/unitxt/catalog/cards/rag/mtrag/documents/fiqa.json
@@ -3,7 +3,7 @@
     "loader": {
         "__type__": "load_json_file",
         "files": {
-            "test": "https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/fiqa.jsonl.zip"
+            "test": "https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/document_level/fiqa.jsonl.zip"
         },
         "compression": "zip",
         "lines": true,

--- a/src/unitxt/catalog/cards/rag/mtrag/documents/govt.json
+++ b/src/unitxt/catalog/cards/rag/mtrag/documents/govt.json
@@ -3,7 +3,7 @@
     "loader": {
         "__type__": "load_json_file",
         "files": {
-            "test": "https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/govt.jsonl.zip"
+            "test": "https://github.com/IBM/mt-rag-benchmark/raw/refs/heads/main/corpora/document_level/govt.jsonl.zip"
         },
         "compression": "zip",
         "lines": true,


### PR DESCRIPTION
needed to add `documents` or `passages` to the path.
Please review if indeed `documents` is the correct choice.  
Took it for the names of fields and paths in the prepare file.