### PR TITLE
Fix qa evaluation data classification policy

### DIFF
--- a/examples/qa_evaluation.py
+++ b/examples/qa_evaluation.py
@@ -26,6 +26,7 @@ dataset = create_dataset(
     template="templates.qa.open",
     split="test",
     format="formats.chat_api",
+    data_classification_policy=["public"],
 )
 
 model = CrossProviderInferenceEngine(model="SmolLM2-1.7B-Instruct", provider="hf-local")

--- a/src/unitxt/inference.py
+++ b/src/unitxt/inference.py
@@ -728,9 +728,9 @@ class HFAutoModelInferenceEngine(HFInferenceEngineBase):
             args["quantization_config"] = quantization_config
         elif self.use_fp16:
             if self.device == torch.device("mps"):
-                args["torch_dtype"] = torch.float16
+                args["dtype"] = torch.float16
             else:
-                args["torch_dtype"] = torch.bfloat16
+                args["dtype"] = torch.bfloat16
 
         # We do this, because in some cases, using device:auto will offload some weights to the cpu
         # (even though the model might *just* fit to a single gpu), even if there is a gpu available, and this will
@@ -937,7 +937,7 @@ class HFLlavaInferenceEngine(HFInferenceEngineBase):
 
         self.model = LlavaForConditionalGeneration.from_pretrained(
             self.model_name,
-            torch_dtype=self._get_torch_dtype(),
+            dtype=self._get_torch_dtype(),
             low_cpu_mem_usage=self.low_cpu_mem_usage,
             device_map=self.device_map,
         )
@@ -1108,7 +1108,7 @@ class HFPeftInferenceEngine(HFAutoModelInferenceEngine):
             trust_remote_code=True,
             device_map=self.device_map,
             low_cpu_mem_usage=self.low_cpu_mem_usage,
-            torch_dtype=self._get_torch_dtype(),
+            dtype=self._get_torch_dtype(),
         )
         self.model = self.model.to(
             dtype=self._get_torch_dtype()
@@ -1197,9 +1197,9 @@ class HFPipelineBasedInferenceEngine(
             args["quantization_config"] = quantization_config
         elif self.use_fp16:
             if self.device == torch.device("mps"):
-                args["torch_dtype"] = torch.float16
+                args["dtype"] = torch.float16
             else:
-                args["torch_dtype"] = torch.bfloat16
+                args["dtype"] = torch.bfloat16
 
         # We do this, because in some cases, using device:auto will offload some weights to the cpu
         # (even though the model might *just* fit to a single gpu), even if there is a gpu available, and this will


### PR DESCRIPTION


* Fixed data classification policy warning (examples/qa_evaluation.py):

Added data_classification_policy=["public"] parameter to create_dataset()
Removes warning: "LoadFromDictionary sets 'data_classification_policy' to ['proprietary'] by default..."

* Fixed torch_dtype deprecation warning (src/unitxt/inference.py):

Replaced all torch_dtype parameters with dtype in model initialization calls
Updated in 4 locations across HFPipelineBasedInferenceEngine, LlavaInferenceEngine, and HFPeftInferenceEngine
Removes warning: "torch_dtype is deprecated! Use dtype instead!"
Verification:

Ran examples/qa_evaluation.py successfully with no warnings
All pre-commit checks passed (ruff, ruff-format, detect secrets, codespell, import enforcement)
Changes pushed to remote branch