### PR TITLE
fix: upgrade vulnerable dependencies in TORR benchmark requirements

### DIFF
--- a/prepare/benchmarks/torr/requirements.txt
+++ b/prepare/benchmarks/torr/requirements.txt
@@ -1,15 +1,15 @@
-torch==2.2.2
-transformers==4.44.2
+torch>=2.10.0
+transformers>=4.53.0,<5.0.0
 datasets==2.21.0
 scikit-learn==1.2.0
 scipy==1.15.2
 sentence-transformers==3.0.1
 evaluate==0.4.0
 safetensors==0.4.5
-nltk==3.8.1
-GitPython==3.1.37
+nltk>=3.9.4
+GitPython>=3.1.49
 seaborn==0.13.0
-protobuf==4.24.4
+protobuf>=5.29.6
 rouge-score==0.1.2
 sacrebleu[ko,ja]==2.3.1
 py7zr==0.20.6
@@ -18,7 +18,7 @@ einops==0.7.0
 accelerate==0.34.2
 retry==0.9.2
 ibm-watsonx-ai==1.3.0
-requests==2.32.2
+requests>=2.32.4
 ibm-cos-sdk==2.12.0
 peft==0.11.1
 numpy==1.26.4
@@ -30,7 +30,7 @@ duckdb==0.9.1
 pre-commit==3.5.0
 kubernetes
 click==8.1.7
-gradio==4.16.0
+gradio>=6.6.0
 pytrec-eval==0.5
 jwt
 func_timeout==4.3.5
@@ -40,4 +40,4 @@ packaging
 bitsandbytes
 setuptools
 openai==1.75.0
-bs4==4.13.2
+bs4


### PR DESCRIPTION
Resolves security alerts in prepare/benchmarks/torr/requirements.txt by upgrading vulnerable dependencies to patched versions and verifying the benchmark run: requests, protobuf, GitPython, nltk, transformers, gradio, torch, bs4