### PR TITLE
Fix TokenOverlap crash when references list is empty

### DIFF
--- a/src/unitxt/metrics.py
+++ b/src/unitxt/metrics.py
@@ -4408,6 +4408,8 @@ class TokenOverlap(InstanceMetric):
             self._compute_single_ref(str(reference), str(prediction))
             for reference in references
         ]
+        if not results:
+            return {"precision": 0, "recall": 0, "f1": 0}
         return {
             measure: max(r[i] for r in results)
             for i, measure in enumerate(["precision", "recall", "f1"])

--- a/tests/library/test_metrics.py
+++ b/tests/library/test_metrics.py
@@ -1190,6 +1190,17 @@ class TestMetrics(UnitxtTestCase):
         for target, value in global_targets.items():
             self.assertAlmostEqual(value, outputs[0]["score"]["global"][target])
 
+    def test_token_overlap_empty_references(self):
+        metric = TokenOverlap()
+        predictions = ["hello there"]
+        references = [[]]
+        outputs = apply_metric(
+            metric=metric, predictions=predictions, references=references
+        )
+        global_targets = {"f1": 0, "precision": 0, "recall": 0}
+        for target, value in global_targets.items():
+            self.assertAlmostEqual(value, outputs[0]["score"]["global"][target])
+
     def test_roc_auc(self):
         metric = RocAuc()
         predictions = [0.2, 0.8, 1.0]


### PR DESCRIPTION
Fix TokenOverlap crash when references list is empty

## Summary

`TokenOverlap.compute()` raises `ValueError: max()
iterable argument is empty` when `references` is an
empty list. This adds a guard that returns zero scores
instead of crashing.

## Problem

When `TokenOverlap` is used via a metric pipeline that
maps a potentially empty field to `references`, the list
comprehension produces an empty `results` list, and
`max(r[i] for r in results)` raises `ValueError`.

This occurs in practice with the `faithfulness` metric
(`metrics.rag.external_rag.faithfulness`), which copies
`contexts` to `references`. If a vector store query
returns zero chunks for a given question (e.g. due to
eventual consistency in the vector database, or a query
with no semantic match), `contexts` is an empty list,
and `TokenOverlap` crashes instead of returning a zero
score.

### Reproduction

```python
import pandas as pd
from unitxt.eval_utils import evaluate

data = [{
    "question": "Q1",
    "answer": "Some answer",
    "ground_truths": ["Ground truth"],
    "contexts": [],  # no chunks retrieved
    "context_ids": [],
    "question_id": "q1",
    "additional_data": None,
    "ground_truths_context_ids": ["doc1"],
}]
df = pd.DataFrame(data)
evaluate(
    df,
    metric_names=[
        "metrics.rag.external_rag.faithfulness"
    ],
    compute_conf_intervals=True,
)
# ValueError: max() iterable argument is empty
```

### Root cause in practice

This was encountered using the AutoRAG pipeline in
Red Hat OpenShift AI 3.4 with a Milvus vector store
configured with `consistency_level=Bounded`. With fast
GPU-based embedding, chunks are inserted and queried
within ~100ms. Bounded consistency does not guarantee
immediate visibility of inserted data, so some queries
return zero results. The faithfulness metric then
receives `contexts=[]`, which maps to `references=[]`,
triggering the crash.

While the operational fix is to use `Strong` consistency
in Milvus, `TokenOverlap` should handle empty references
gracefully regardless of the upstream cause.

## Fix

Add `if not results: return {"precision": 0, "recall": 0,
"f1": 0}` before the `max()` call, consistent with the
zero-score behavior already present in
`_compute_single_ref` when `num_same == 0`.

## Test

Added `test_token_overlap_empty_references` that verifies
the metric returns zero scores when references is empty,
instead of crashing.
---
*Developed with AI assistance (Claude). Code reviewed and empirically validated by the author.*