### PR TITLE
fix: support deferred class annotations on Python 3.14

### DIFF
--- a/src/unitxt/dataclass.py
+++ b/src/unitxt/dataclass.py
@@ -152,6 +152,15 @@ def is_possible_field(field_name, field_value):
     return True
 
 
+def _get_class_annotations(obj):
+    cls = obj if isinstance(obj, type) else type(obj)
+    if hasattr(inspect, "Format"):
+        return inspect.get_annotations(cls, format=inspect.Format.FORWARDREF)
+    if hasattr(inspect, "get_annotations"):
+        return inspect.get_annotations(cls)
+    return dict(vars(cls).get("__annotations__", {}))
+
+
 def get_fields(cls, attrs):
     """Get the fields for a class based on its attributes.
 
@@ -165,7 +174,7 @@ def get_fields(cls, attrs):
     fields = {}
     for base in cls.__bases__:
         fields = {**getattr(base, _FIELDS, {}), **fields}
-    annotations = {**attrs.get("__annotations__", {})}
+    annotations = _get_class_annotations(cls)
 
     for attr_name, attr_value in attrs.items():
         if attr_name not in annotations and is_possible_field(attr_name, attr_value):
@@ -593,7 +602,7 @@ class Dataclass(metaclass=DataclassMeta):
         else:
             attributes = []
             for cls in classes:
-                attributes += list(cls.__annotations__.keys())
+                attributes += list(_get_class_annotations(cls).keys())
             attributes_dict = {
                 attribute: getattr(self, attribute) for attribute in attributes
             }

--- a/tests/library/test_dataclass.py
+++ b/tests/library/test_dataclass.py
@@ -1,3 +1,5 @@
+import sys
+import unittest
 from dataclasses import field
 from typing import Callable
 
@@ -5,6 +7,7 @@ from unitxt.dataclass import (
     AbstractField,
     AbstractFieldError,
     Dataclass,
+    DataclassMeta,
     FinalField,
     FinalFieldError,
     MissingDefaultError,
@@ -25,6 +28,37 @@ from tests.utils import UnitxtTestCase
 
 
 class TestDataclass(UnitxtTestCase):
+    @unittest.skipUnless(sys.version_info >= (3, 14), "requires deferred annotations")
+    def test_self_referencing_annotation(self):
+        class SelfReferencingDataclass(Dataclass):
+            child: SelfReferencingDataclass | None = None  # noqa: F821
+
+        instance = SelfReferencingDataclass()
+
+        self.assertIsNone(instance.child)
+        self.assertListEqual(fields_names(SelfReferencingDataclass), ["child"])
+
+    def test_annotations_not_stored_in_class_namespace(self):
+        class DeferredAnnotationsMeta(DataclassMeta):
+            def __init__(self, name, bases, attrs):
+                attrs.pop("__annotations__", None)
+                super().__init__(name, bases, attrs)
+
+        class DeferredAnnotationsDataclass(
+            Dataclass, metaclass=DeferredAnnotationsMeta
+        ):
+            pass
+
+        class Dummy(DeferredAnnotationsDataclass):
+            name: str
+            count: int = 0
+
+        dummy = Dummy(name="example")
+
+        self.assertEqual(dummy.name, "example")
+        self.assertEqual(dummy.count, 0)
+        self.assertListEqual(fields_names(Dummy), ["name", "count"])
+
     def test_dataclass(self):
         class GrandParent(Dataclass):
             a: int


### PR DESCRIPTION
## Summary

- resolve dataclass annotations from the created class instead of the class-body namespace
- use `Format.FORWARDREF` on Python 3.14 to support unresolved and self-referencing annotations
- preserve compatibility with Python 3.8–3.13
- handle both classes and instances passed to `to_dict(classes=...)`

Closes #1974

## Testing

- Python 3.14.6: `import unitxt`
- Python 3.14.6: `python -m unittest tests.library.test_dataclass` — 21 passed
- Python 3.12.4: `python -m unittest tests.library.test_dataclass` — 20 passed, 1 skipped
- simulated Python 3.8/3.9 annotation-inspection path — 20 passed, 1 skipped
- `pre-commit run --files src/unitxt/dataclass.py tests/library/test_dataclass.py`
